### PR TITLE
BUG: Flybyprocess = autocrop3d_cli

### DIFF
--- a/AutoCrop3D/Crop_Volumes_UI/AutoCrop3D.py
+++ b/AutoCrop3D/Crop_Volumes_UI/AutoCrop3D.py
@@ -610,7 +610,7 @@ class AutoCrop3DLogic(ScriptedLoadableModuleLogic):
         parameters ["suffix"] = self.suffix
         parameters ["logPath"] = self.logPath
         
-        flybyProcess = slicer.modules.crop_volumes_cli
+        flybyProcess = slicer.modules.autocrop3d_cli
         self.cliNode = slicer.cli.run(flybyProcess,None, parameters)  
         
         return flybyProcess


### PR DESCRIPTION
Hello @allemangD 

One of our clinician tried to use AutoCrop3D but she got an error:

>Traceback (most recent call last):
  File "/Applications/Slicer.app/Contents/Extensions-31938/SlicerAutomatedDentalTools/lib/Slicer-5.4/qt-scripted-modules/AutoCrop3D.py", line 314, in onApplyButton
    self.logic.process()
  File "/Applications/Slicer.app/Contents/Extensions-31938/SlicerAutomatedDentalTools/lib/Slicer-5.4/qt-scripted-modules/AutoCrop3D.py", line 613, in process
    flybyProcess = slicer.modules.crop_volumes_cli
AttributeError: module 'modules' has no attribute 'crop_volumes_cli'
Traceback (most recent call last):
  File "/Applications/Slicer.app/Contents/Extensions-31938/SlicerAutomatedDentalTools/lib/Slicer-5.4/qt-scripted-modules/AutoCrop3D.py", line 314, in onApplyButton
    self.logic.process()
  File "/Applications/Slicer.app/Contents/Extensions-31938/SlicerAutomatedDentalTools/lib/Slicer-5.4/qt-scripted-modules/AutoCrop3D.py", line 613, in process
    flybyProcess = slicer.modules.crop_volumes_cli
AttributeError: module 'modules' has no attribute 'crop_volumes_cli' `


I changed the line 613 with "flybyProcess = slicer.modules.autocrop3d_cli" but I am not sure it is the thing to do.
Could you tell me if you have a hints?

Thank you!