### PR TITLE
BUG : fix multiprocess by thread because windows error

### DIFF
--- a/AutoMatrix/AutoMatrix.py
+++ b/AutoMatrix/AutoMatrix.py
@@ -22,7 +22,7 @@ from Method.General_tools import search, GetPatients
 
 
 import time
-import multiprocessing
+import threading
 import io
 
 
@@ -510,7 +510,7 @@ class AutoMatrixWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                             original_stdin = sys.stdin
                             sys.stdin = DummyFile()
 
-                            process = multiprocessing.Process(target=self.saveOutput, args=(model,outpath.split(extension_scan)[0]+self.ui.LineEditSuffix.text+matrix_name+extension_scan))
+                            process =  threading.Thread(target=self.saveOutput, args=(model,outpath.split(extension_scan)[0]+self.ui.LineEditSuffix.text+matrix_name+extension_scan,))
                             process.start()
 
                             while process.is_alive():


### PR DESCRIPTION
Hi @allemangD !

Multiprocessing using the librairy multiprocess is not working on Windows. I changed it by the threading library :)

Can you tell me if it's ok and if so merge it ? 
Thank you !
Gaelle