### PR TITLE
ENH: Call to Crop volume module for tilted images

### DIFF
--- a/AutoCrop3D/Crop_Volumes_CLI/AutoCrop3D_CLI.py
+++ b/AutoCrop3D/Crop_Volumes_CLI/AutoCrop3D_CLI.py
@@ -30,7 +30,7 @@ def main(args)-> None:
         # clear log file
         log_f.truncate(0)
     index =0
-    ScanList = Search(path_input, ".nii.gz",".nrrd.gz",".gipl.gz")
+    ScanList = Search(path_input, ".nii.gz",".nii",".nrrd.gz",".nrrd",".gipl.gz",".gipl")
 
     # Include case with a folder of ROI corresponding to a folder of scans
     ROIList = Search(ROI_Path,".mrk.json")
@@ -41,7 +41,7 @@ def main(args)-> None:
     for key,data in ScanList.items():
 
         for patient_path in data:
-            patient = os.path.basename(patient_path).split('_Scan')[0].split('_scan')[0].split('_Or')[0].split('_OR')[0].split('_MAND')[0].split('_MD')[0].split('_MAX')[0].split('_MX')[0].split('_CB')[0].split('_lm')[0].split('_T2')[0].split('_T1')[0].split('_Cl')[0].split('.')[0]
+            patient = os.path.basename(patient_path).split('_Scan')[0].split('_scan')[0].split('_Seg')[0].split('_seg')[0].split('_Or')[0].split('_OR')[0].split('_MAND')[0].split('_MD')[0].split('_MAX')[0].split('_MX')[0].split('_CB')[0].split('_lm')[0].split('_T2')[0].split('_T1')[0].split('_Cl')[0].split('.')[0]
 
             img = sitk.ReadImage(patient_path)
 

--- a/AutoCrop3D/Crop_Volumes_UI/Resources/UI/AutoCrop3D.ui
+++ b/AutoCrop3D/Crop_Volumes_UI/Resources/UI/AutoCrop3D.ui
@@ -111,6 +111,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="checkBoxCV">
+          <property name="text">
+           <string>Use module &quot;Crop Volume&quot; for tilted images</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_11"/>
         </item>
        </layout>


### PR DESCRIPTION
Hello @allemangD 

(Change in AutoCrop3D.)
We noticed that if the ROI box was tilted compared to the ROI of the image, Autocrop wasn't cropping correctly because we didn't think about this case while working on it but Crop Volume does. So I added a checkbox to choose if we want to use the module Crop Volume. this way we can use the module with folders of volume and gain time. 

I choose not to get rid of the code for Autocrop because Crop Volume doesn't handle Segmentation well (it was done just for Volume and not for labelVolume or Segmentation). Because of this compatibility issue, it mixes the 2 existing labels of the segmentation and add post processing for the clinicians. 

For non tilted images, Autocrop3D is still a good solution.

Thanks,
Jeanne