### PR TITLE
FIX : error import

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXTENSION_ICONURL "https://raw.githubusercontent.com/DCBIA-OrthoLab/SlicerAu
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/main/ADT-exemple.png")
 set(EXTENSION_DEPENDS 
     SlicerDentalModelSeg
-    Conda)# Specified as a list or "NA" if no dependencies
+    SlicerConda)# Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------
 # Extension dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16.3...3.19.7 FATAL_ERROR)
 
-project(SlicerAutomatedDentalTools)
+project(AutomatedDentalTools)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information


### PR DESCRIPTION
Hi @allemangD !

In Slicer preview SlicerAutomatedDentalsTools cannot be built because the CondaSetUp import failed. I've tried to fix it, can you tell me if it will work and if so merge it ? 

Thank you !
Gaelle