### PR TITLE
FIX: Build not recognizing testing directory

### DIFF
--- a/ALI/Testing/CMakeLists.txt
+++ b/ALI/Testing/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Python)

--- a/ALI/Testing/Python/CMakeLists.txt
+++ b/ALI/Testing/Python/CMakeLists.txt
@@ -1,0 +1,2 @@
+
+#slicer_add_python_unittest(SCRIPT ${MODULE_NAME}ModuleTest.py)


### PR DESCRIPTION
This PR adds the previously missing `Testing` folder to the `ALI` module. Its absence was causing a CMake error during extension build due to the `add_subdirectory(Testing)` call in `ALI/CMakeLists.txt`.

With this fix, the extension now builds correctly and is available for download via the Extension Manager.