### PR TITLE
FIX:  Pytorch installation code not recognized by CMake

### DIFF
--- a/ALI/CMakeLists.txt
+++ b/ALI/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   ALI_Method/__init__.py
   ALI_Method/CBCT.py
+  ALI_Method/install_pytorch.py
   ALI_Method/IOS.py
   ALI_Method/Method.py
   ALI_Method/Progress.py

--- a/AREG/CMakeLists.txt
+++ b/AREG/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   AREG_Method/__init__.py
   AREG_Method/CBCT.py
+  AREG_Method/install_pytorch.py
   AREG_Method/IOS.py
   AREG_Method/IOSCBCT.py
   AREG_Method/Method.py

--- a/ASO/CMakeLists.txt
+++ b/ASO/CMakeLists.txt
@@ -6,6 +6,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   ASO_Method/__init__.py
   ASO_Method/CBCT.py
+  ASO_Method/install_pytorch.py
   ASO_Method/IOS.py
   ASO_Method/IOS_utils/__init__.py
   ASO_Method/IOS_utils/Reader.py

--- a/FlexReg/CMakeLists.txt
+++ b/FlexReg/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_RESOURCES
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   FlexReg_utils/__init__.py
+  FlexReg_utils/install_pytorch.py
   FlexReg_utils/orientation.py
   FlexReg_utils/transform.py
   FlexReg_utils/util.py

--- a/MRI2CBCT/MRI2CBCT.py
+++ b/MRI2CBCT/MRI2CBCT.py
@@ -63,7 +63,6 @@ def install_function():
           return False
     import vtk
     import itk
-    import cc3d
     return True
 #
 # MRI2CBCT


### PR DESCRIPTION
This update restores the missing lines in the `CMakeLists.txt` that were preventing the PyTorch installation code from being located and executed properly.