### PR TITLE
FIX: Tools not working with Python 3.12

### DIFF
--- a/ALI_CBCT/ALI_CBCT_utils/environment.py
+++ b/ALI_CBCT/ALI_CBCT_utils/environment.py
@@ -1,9 +1,10 @@
 import os
+import sys
 import json
 import numpy as np
 import torch
 import SimpleITK as sitk
-from monai.transforms import Compose, AddChannel, BorderPad, ScaleIntensity, SpatialCrop
+from monai.transforms import Compose, BorderPad, ScaleIntensity, SpatialCrop
 
 from ALI_CBCT_utils.constants import LABELS, LABEL_GROUPS, SCALE_KEYS, DEVICE, bcolors
 from ALI_CBCT_utils.io import WriteJson, GenControlPoint
@@ -29,18 +30,25 @@ class Environment :
         self.device = device
         self.scale_keys = scale_keys if scale_keys is not None else SCALE_KEYS
         self.verbose = verbose
-        self.transform = Compose([AddChannel(),BorderPad(spatial_border=self.padding.tolist())])
-        # self.transform = Compose([AddChannel(),BorderPad(spatial_border=self.padding.tolist()),ScaleIntensity(minv = -1.0, maxv = 1.0, factor = None)])
-
+        self.transform = Compose([
+            self.get_channel_transform(),
+            BorderPad(spatial_border=self.padding.tolist())
+        ])
         self.scale_nbr = 0
 
-        # self.transform = Compose([AddChannel(),BorderPad(spatial_border=self.padding.tolist())])
         self.available_lm = []
 
         self.data = {}
 
         self.predicted_landmarks = {}
 
+    def get_channel_transform(self):
+        if sys.version_info >= (3, 10):
+            from monai.transforms import EnsureChannelFirst
+            return EnsureChannelFirst(channel_dim="no_channel")
+        else:
+            from monai.transforms import AddChannel
+            return AddChannel()
 
     def LoadImages(self,images_path):
 
@@ -50,7 +58,10 @@ class Environment :
             data = {"path":path}
             img = sitk.ReadImage(path)
             img_ar = sitk.GetArrayFromImage(img)
-            data["image"] = torch.from_numpy(self.transform(img_ar)).type(torch.int16)
+            if sys.version_info >= (3, 10):
+                data["image"] = self.transform(img_ar).to(dtype=torch.int16)
+            else:
+                data["image"] = torch.from_numpy(self.transform(img_ar)).type(torch.int16)
 
             data["spacing"] = np.array(img.GetSpacing())
             origin = img.GetOrigin()

--- a/ALI_IOS/ALI_IOS.py
+++ b/ALI_IOS/ALI_IOS.py
@@ -120,9 +120,9 @@ def main(args):
     for jaw_teeth in dic_teeth.values():
         total_landmarks += len(jaw_teeth)
     total_landmarks *= len(dic_patients)
-    
-    
-    for patient_id,patient_path in dic_patients.items():
+
+
+    for idx,(patient_id,patient_path) in enumerate(dic_patients.items()):
 
         print(f"prediction for patient {patient_id}")
         for models_type in models_to_use.keys():
@@ -233,17 +233,12 @@ def main(args):
 
                                 group_data[land_name] = {"x": final[0], "y": final[1], "z": final[2]}
 
-                    # print(f"""<filter-progress>{1}</filter-progress>""")
-                    # sys.stdout.flush()
-                    # time.sleep(0.5)
-                    # print(f"""<filter-progress>{0}</filter-progress>""")
-
                 if len(group_data.keys()) > 0:
                     lm_lst = GenControlPoint(group_data, landmarks_selected)
                     WriteJson(lm_lst,os.path.join(args.output_dir,f"{patient_id}_{jaw}_{models_type}_Pred.json"))
                     
-                    with open(args.log_path, "r+") as log_f:
-                        log_f.write(str(1))
+        with open(args.log_path, "w+") as log_f:
+            log_f.write(str(idx + 1))
 
 
 if __name__ == "__main__":

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import textwrap
 import pkg_resources
 import platform
+import signal
 import threading
 import subprocess
 import re
@@ -319,6 +320,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.all_installed = False
 
         self.nb_patient = 0  # number of scans in the input folder
+        self.time_log = 0  # time of the last log update
 
     def setup(self):
         """
@@ -1024,15 +1026,17 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def onPredictButton(self):
         if self.type == "CBCT":
+            monai_version = '==1.5.0' if sys.version_info >= (3, 10) else '==0.7.0'
             if platform.system() == "Windows":
-                list_libs_CBCT_windows = [('itk','<=5.4.rc1',None),('itk-elastix','==0.17.1',None),('dicom2nifti', '==2.3.0',None),('pydicom', '==2.2.2',None),('einops',None,None),('nibabel',None,None),('connected-components-3d','==3.9.1',None),
-                            ('pandas',None,None),('torch',None,"https://download.pytorch.org/whl/cu118"),('monai','==0.7.0',None)] #(lib_name, version, url)
+                list_libs_CBCT_windows = [('itk',None,None),('itk-elastix',None,None),('dicom2nifti', '==2.3.0',None),('pydicom', '==2.2.2',None),('einops',None,None),('nibabel',None,None),('torch',None,"https://download.pytorch.org/whl/cu118"),('nnunetv2',None,None),('pandas',None,None)] #(lib_name, version, url)
+                list_libs_CBCT_windows.append(('monai', monai_version, None))
 
                 is_installed = install_function(self,list_libs_CBCT_windows)
             else:
                 # libraries and versions compatibility to use AREG_CBCT
-                list_libs_CBCT = [('itk','<=5.4.rc1',None),('itk-elastix','==0.17.1',None),('dicom2nifti', '==2.3.0',None),('pydicom', '==2.2.2',None),('einops',None,None),('nibabel',None,None),('connected-components-3d','==3.9.1',None),
-                            ('pandas',None,None),('torch',None,None),('monai','==0.7.0',None)] #(lib_name, version, url)
+                list_libs_CBCT = [('itk',None,None),('itk-elastix',None,None),('dicom2nifti', '==2.3.0',None),('pydicom', '==2.2.2',None),('einops',None,None),('nibabel',None,None),('torch',None,"https://download.pytorch.org/whl/cu118"),('nnunetv2',None,None),
+                            ('pandas',None,None)] #(lib_name, version, url)
+                list_libs_CBCT.append(('monai', monai_version, None))
 
                 is_installed = install_function(self,list_libs_CBCT)
                 
@@ -1042,7 +1046,10 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             print("seg_env : ",check_env)
             
             if check_env:
-                list_libs_IOS = [("tqdm",None,None),('vtk',None,None),('pandas',None,None),('monai','==0.7.0',None)]
+                list_libs_IOS = [("tqdm",None,None),('vtk',None,None),('pandas',None,None)]
+                
+                monai_version = '==0.7.0' #'==1.5.0' if sys.version_info >= (3, 10) else '==0.7.0'
+                list_libs_IOS.append(('monai', monai_version, None))
 
                 is_installed = install_function(self,list_libs_IOS)
 
@@ -1106,18 +1113,18 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.nb_extension_launch = len(self.list_Processes_Parameters)
             self.onProcessStarted()
 
-            module = self.list_Processes_Parameters[0]["Module"]
+            self.module_name = self.list_Processes_Parameters[0]["Module"]
             # /!\ Launch of the first process /!\
-            print("module name : ", module)
+            print("module name : ", self.module_name)
             # if we are on windows, crownsegmentation and areg ios need to be run in wsl because of Pytorch3D
-            if module in ["CrownSegmentationcli T1", "AREG_IOS"]:
-                self.ui.ButtonCancel.setEnabled(False)
-                if "CrownSegmentationcli" in module:
+            if self.module_name in ["CrownSegmentationcli T1", "AREG_IOS"]:
+                if "CrownSegmentationcli" in self.module_name:
                     self.run_conda_tool("seg")
-                else :
+                else:
+                    self.nb_extension_did += 1
+                    print("module name : ", self.module_name)
                     self.run_conda_tool("areg")
               
-            self.ui.ButtonCancel.setEnabled(True)
             self.process = slicer.cli.run(
                 self.list_Processes_Parameters[0]["Process"],
                 None,
@@ -1140,7 +1147,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.ui.LabelProgressPatient.setText(f"Patient : 0 / {self.nb_patient}")
         self.ui.LabelProgressExtension.setText(
-            f"Extension : 0 / {self.nb_extension_launch}"
+            f"Extension : 1 / {self.nb_extension_launch}"
         )
         self.nb_extension_did = 0
 
@@ -1148,6 +1155,43 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.nb_change_bystep = 0
 
         self.RunningUI(True)
+        
+    def read_log_path(self):
+      with open(self.log_path, 'r') as f:
+          line = f.readline()
+          if line != '':
+              return line
+  
+    def onCondaProcessUpdate(self):
+        if os.path.isfile(self.log_path):
+            self.ui.LabelNameExtension.setText(self.module_name)
+            
+            self.ui.LabelProgressExtension.setText(
+                f"Extension : {self.nb_extension_did} / {self.nb_extension_launch}"
+            )
+
+            if self.module_name_before != self.module_name:
+                self.module_name_before = self.module_name
+                self.progress = 0
+                self.ui.LabelProgressPatient.setText(f"Patient : {self.progress}/{self.nb_patient}")
+                progress_bar_value = round((self.progress) / self.nb_patient * 100,2)
+                
+                self.ui.progressBar.setValue(progress_bar_value)
+                self.ui.progressBar.setFormat(f"{progress_bar_value:.2f}%")
+
+            time_progress = os.path.getmtime(self.log_path)
+            line = self.read_log_path()
+            if (time_progress != self.time_log) and line:
+                progress = line.strip()
+            
+                self.progress = int(progress)
+                self.ui.LabelProgressPatient.setText(f"Patient : {self.progress}/{self.nb_patient}")
+                
+                progress_bar_value = round((self.progress) / self.nb_patient * 100,2)
+                self.time_log = time_progress
+                
+                self.ui.progressBar.setValue(progress_bar_value)
+                self.ui.progressBar.setFormat(f"{progress_bar_value:.2f}%")
 
     def onProcessUpdate(self, caller, event):
         # timer = f"Time : {time.time()-self.startTime:.2f}s"
@@ -1165,7 +1209,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.LabelNameExtension.setText(self.module_name)
         # self.displayModule = self.displayModule_bis if self.displayModule_bis is not None else self.display[self.module_name.split(' ')[0]]
 
-        if self.module_name_before != self.module_name:
+        if (self.module_name_before != self.module_name) and (self.module_name != "AREG_IOS"):
             self.ui.LabelProgressPatient.setText(f"Patient : 0 / {self.nb_patient}")
             self.nb_extension_did += 1
             self.ui.LabelProgressExtension.setText(
@@ -1213,6 +1257,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 try:
                     print("name process : ",self.list_Processes_Parameters[0]["Process"])
                     if self.list_Processes_Parameters[0]["Module"]=="AREG_IOS":
+                        self.nb_extension_did += 1
                         self.run_conda_tool("areg")
                         
                     self.ui.ButtonCancel.setEnabled(True)
@@ -1233,7 +1278,6 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def OnEndProcess(self):
         self.ui.LabelProgressPatient.setText(f"Patient : 0 / {self.nb_patient}")
-        self.nb_extension_did += 1
         self.ui.LabelProgressExtension.setText(
             f"Extension : {self.nb_extension_did} / {self.nb_extension_launch}"
         )
@@ -1242,7 +1286,6 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # if self.nb_change_bystep == 0:
         #     print(f'Erreur this module didnt work {self.module_name_before}')
 
-        self.module_name_before = self.module_name
         self.nb_change_bystep = 0
         total_time = time.time() - self.startTime
         average_time = total_time / self.nb_patient
@@ -1287,7 +1330,11 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
           os.remove(csv_file)
 
     def onCancel(self):
-        self.process.Cancel()
+        try:
+            self.process.Cancel()
+        except Exception as e:
+            self.logic.cancel_process()
+            
         print("\n\n ========= PROCESS CANCELED ========= \n")
 
         self.RunningUI(False)
@@ -1329,7 +1376,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 return
             
             for i in range(2):
+                self.nb_extension_did += 1
                 args = self.list_Processes_Parameters[0]["Parameter"]
+                self.module_name = self.list_Processes_Parameters[0]["Module"]
                 print("args : ",args)
                 conda_exe = self.logic.conda.getCondaExecutable()
                 command = [conda_exe, "run", "-n", self.logic.name_env, "python" ,"-m", f"CrownSegmentationcli"]
@@ -1341,14 +1390,18 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     command.append(f"\"{value}\"")
                 print("*"*50)
                 print("command : ",command)
+                
+                self.ui.LabelNameExtension.setText(f"{self.module_name}")
 
                 # running in // to not block Slicer
-                self.process = threading.Thread(target=self.logic.conda.condaRunCommand, args=(command,))
+                self.process = threading.Thread(target=self.logic.condaRunCommand, args=(command,))
                 self.process.start()
                 self.ui.LabelTimer.setHidden(False)
                 self.ui.LabelTimer.setText(f"Time : 0.00s")
                 previous_time = self.startTime
                 while self.process.is_alive():
+                    self.ui.ButtonCancel.setVisible(True)
+                    self.onCondaProcessUpdate()
                     slicer.app.processEvents()
                     current_time = time.time()
                     gap=current_time-previous_time
@@ -1369,6 +1422,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         elif type=="areg":
             args = self.list_Processes_Parameters[0]["Parameter"]
             print("args : ", args)
+            self.module_name = self.list_Processes_Parameters[0]["Module"]
+            
             conda_exe = self.logic.conda.getCondaExecutable()
             command = [conda_exe, "run", "-n", self.logic.name_env, "python" ,"-m", f"AREG_IOS"]
             for key, value in args.items():
@@ -1379,12 +1434,14 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             print("command : ",command)
 
             # running in // to not block Slicer
-            self.process = threading.Thread(target=self.logic.conda.condaRunCommand, args=(command,))
+            self.process = threading.Thread(target=self.logic.condaRunCommand, args=(command,))
             self.process.start()
             self.ui.LabelTimer.setHidden(False)
             self.ui.LabelTimer.setText(f"time : 0.00s")
             previous_time = self.startTime
             while self.process.is_alive():
+                self.ui.ButtonCancel.setVisible(True)
+                self.onCondaProcessUpdate()
                 slicer.app.processEvents()
                 current_time = time.time()
                 gap=current_time-previous_time
@@ -1782,6 +1839,7 @@ class AREGLogic(ScriptedLoadableModuleLogic):
         self.conda = self.init_conda()
         self.name_env = "shapeaxi"
         self.cliNode = None
+        self.python_version = "3.9"
 
     def init_conda(self):
         # check if CondaSetUp exists
@@ -1804,7 +1862,7 @@ class AREGLogic(ScriptedLoadableModuleLogic):
         self.process.start()
         
     def install_shapeaxi(self):
-        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,"3.9",["shapeaxi==1.0.10"],)) #run in parallel to not block slicer
+        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["shapeaxi==1.0.10"],)) #run in parallel to not block slicer
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
@@ -1888,6 +1946,16 @@ class AREGLogic(ScriptedLoadableModuleLogic):
 
         return path
     
+    def cancel_process(self):
+        if platform.system() == 'Windows':
+            self.subpro.send_signal(signal.CTRL_BREAK_EVENT)
+        else:
+            os.killpg(os.getpgid(self.subpro.pid), signal.SIGTERM)
+        print("Cancellation requested. Terminating process...")
+
+        self.subpro.wait() ## important
+        self.cancel = True
+    
     def check_cli_script(self):
         if not self.check_pythonpath_windows("AREG_IOS"): 
             self.give_pythonpath_windows()
@@ -1919,9 +1987,9 @@ class AREGLogic(ScriptedLoadableModuleLogic):
             print("command_to_execute in condaRunCommand : ",command_to_execute)
 
             self.subpro = subprocess.Popen(command_to_execute, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, 
-                                    text=True, encoding='utf-8', errors='replace', env=slicer.util.startupEnvironment(),
-                                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP  # For Windows
-                                    )
+                              text=True, encoding='utf-8', errors='replace', env=slicer.util.startupEnvironment(),
+                              creationflags=subprocess.CREATE_NEW_PROCESS_GROUP  # For Windows
+                              )
         else:
             path_conda_exe = self.conda.getCondaExecutable()
             command_execute = f"{path_conda_exe} run -n {self.name_env}"

--- a/AREG/AREG_Method/CBCT.py
+++ b/AREG/AREG_Method/CBCT.py
@@ -113,10 +113,7 @@ class Semi_CBCT(Method):
 
     def getModelUrl(self):
         return {
-            "Segmentation": {
-                "Full Face Models": "https://github.com/lucanchling/AMASSS_CBCT/releases/download/v1.0.2/AMASSS_Models.zip",
-                "Mask Models": "https://github.com/lucanchling/AMASSS_CBCT/releases/download/v1.0.2/Masks_Models.zip",
-            }
+            "Segmentation": "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/releases/download/AMASSS_CBCT/AMASSS_Models.zip",
         }
 
     def getALIModelList(self):
@@ -287,6 +284,8 @@ class Semi_CBCT(Method):
             "temp_folder": "../",
             "DCMInput": kwargs["isDCMInput"],
         }
+        
+        print(f"PRE_ASO param: {parameter_pre_aso}\n")
 
         PreOrientProcess = slicer.modules.pre_aso_cbct
         list_process = [
@@ -322,12 +321,13 @@ class Semi_CBCT(Method):
                     "Display": DisplayAREGCBCT(nb_scan),
                 }
             )
+            print(f"AREG_CBCT param {full_reg_struct[i]}: {parameter_areg_cbct}\n")
 
         # AMASSS PROCESS - SEGMENTATION
         AMASSSProcess = slicer.modules.amasss_cli
         parameter_amasss_seg_t1 = {
             "inputVolume": kwargs["input_t1_folder"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -336,7 +336,7 @@ class Semi_CBCT(Method):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
@@ -345,7 +345,7 @@ class Semi_CBCT(Method):
         }
         parameter_amasss_seg_t2 = {
             "inputVolume": kwargs["folder_output"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -354,13 +354,15 @@ class Semi_CBCT(Method):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
             "SegmentInput": False,
             "DCMInput": False,
         }
+        print(f"AMASSS T1 Parameters: {parameter_amasss_seg_t1}\n")
+        print(f"AMASSS T2 Parameters: {parameter_amasss_seg_t2}\n")
         if len(full_seg_struct) > 0:
             list_process.append(
                 {
@@ -408,7 +410,7 @@ class Auto_CBCT(Semi_CBCT):
         # AMASSS PROCESS - MASK SEGMENTATIONS
         parameter_amasss_mask_t1 = {
             "inputVolume": kwargs["input_t1_folder"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": reg_struct,
             "merge": "SEPARATE",
@@ -417,7 +419,7 @@ class Auto_CBCT(Semi_CBCT):
             "output_folder": kwargs["input_t1_folder"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
@@ -436,8 +438,7 @@ class Auto_CBCT(Semi_CBCT):
             },
         ]
 
-        # print('AMASSS Mask Parameters:', parameter_amasss_mask_t1)
-        # print()
+        print(f'AMASSS Mask Parameters: {parameter_amasss_mask_t1}\n')
         centered_T2 = kwargs["input_t2_folder"] + "_Center"
         parameter_pre_aso = {
             "input": kwargs["input_t2_folder"],
@@ -499,7 +500,7 @@ class Auto_CBCT(Semi_CBCT):
         AMASSSProcess = slicer.modules.amasss_cli
         parameter_amasss_seg_t1 = {
             "inputVolume": kwargs["input_t1_folder"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -508,7 +509,7 @@ class Auto_CBCT(Semi_CBCT):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
@@ -517,7 +518,7 @@ class Auto_CBCT(Semi_CBCT):
         }
         parameter_amasss_seg_t2 = {
             "inputVolume": kwargs["folder_output"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -526,14 +527,16 @@ class Auto_CBCT(Semi_CBCT):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
             "SegmentInput": False,
             "DCMInput": False,
         }
-        
+        print(f"AMASSS T1 Parameters: {parameter_amasss_seg_t1}\n")
+        print(f"AMASSS T2 Parameters: {parameter_amasss_seg_t2}\n")
+
         if len(full_seg_struct) > 0:
             list_process.append(
                 {
@@ -562,10 +565,7 @@ class Auto_CBCT(Semi_CBCT):
 class Or_Auto_CBCT(Semi_CBCT):
     def getModelUrl(self):
         return {
-            "Segmentation": {
-                "Full Face Models": "https://github.com/lucanchling/AMASSS_CBCT/releases/download/v1.0.2/AMASSS_Models.zip",
-                "Mask Models": "https://github.com/lucanchling/AMASSS_CBCT/releases/download/v1.0.2/Masks_Models.zip",
-            },
+            "Segmentation": "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/releases/download/AMASSS_CBCT/AMASSS_Models.zip",
             "Orientation": {
                 "PreASO": "https://github.com/lucanchling/ASO_CBCT/releases/download/v01_preASOmodels/PreASOModels.zip",
                 "Occlusal and Midsagittal Plane": "https://github.com/lucanchling/ASO_CBCT/releases/download/v01_goldmodels/Occlusal_Midsagittal_Plane.zip",
@@ -690,8 +690,7 @@ class Or_Auto_CBCT(Semi_CBCT):
 
         list_lmrk_str, nb_landmark = self.ReferenceLandmarks(OrientationReference)
 
-        print("PRE_ASO param:", parameter_pre_aso)
-        print()
+        print(f"PRE_ASO param: {parameter_pre_aso}\n")
 
         # ALI CBCT
         parameter_ali = {
@@ -708,8 +707,8 @@ class Or_Auto_CBCT(Semi_CBCT):
         }
         ALIProcess = slicer.modules.ali_cbct
 
-        print("ALI param:", parameter_ali)
-        print()
+        print(f"ALI param: {parameter_ali}\n")
+        
         # SEMI ASO CBCT
         ASO_T1_Oriented = kwargs["input_t1_folder"] + "Or"
         parameter_semi_aso = {
@@ -721,7 +720,7 @@ class Or_Auto_CBCT(Semi_CBCT):
         }
         OrientProcess = slicer.modules.semi_aso_cbct
 
-        print("SEMI_ASO param:", parameter_semi_aso)
+        print(f"SEMI_ASO param: {parameter_semi_aso}\n")
 
         nb_scan = (
             self.NumberScan(kwargs["input_t1_folder"], kwargs["input_t2_folder"])
@@ -760,22 +759,23 @@ class Or_Auto_CBCT(Semi_CBCT):
         # AMASSS PROCESS - MASK SEGMENTATIONS
         parameter_amasss_mask_t1 = {
             "inputVolume": ASO_T1_Oriented,
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": reg_struct,
             "merge": "SEPARATE",
             "genVtk": False,
             "save_in_folder": False,
-            "output_folder": kwargs["input_t1_folder"],
+            "output_folder": ASO_T1_Oriented,
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
             "SegmentInput": False,
             "DCMInput": False,
         }
+        print(f"AMASSS Mask Parameters: {parameter_amasss_mask_t1}\n")
         AMASSSProcess = slicer.modules.amasss_cli
         list_process += [
             {
@@ -797,6 +797,7 @@ class Or_Auto_CBCT(Semi_CBCT):
             "temp_folder": "../",
             "DCMInput": kwargs["isDCMInput"],
         }
+        print(f"Centering T2 Parameters: {parameter_pre_aso}\n")
 
         PreOrientProcess = slicer.modules.pre_aso_cbct
         list_process.append(
@@ -835,6 +836,7 @@ class Or_Auto_CBCT(Semi_CBCT):
                     "Display": DisplayAREGCBCT(nb_scan),
                 }
             )
+            print(f"AREG CBCT Parameters {full_reg_struct[i]}: {parameter_areg_cbct}\n")
 
         full_seg_struct = list_struct["AMASSS Segmentation"]
         seg_struct = self.TranslateModels(full_seg_struct, False)
@@ -843,7 +845,7 @@ class Or_Auto_CBCT(Semi_CBCT):
         AMASSSProcess = slicer.modules.amasss_cli
         parameter_amasss_seg_t1 = {
             "inputVolume": ASO_T1_Oriented,
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -852,7 +854,7 @@ class Or_Auto_CBCT(Semi_CBCT):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
@@ -861,7 +863,7 @@ class Or_Auto_CBCT(Semi_CBCT):
         }
         parameter_amasss_seg_t2 = {
             "inputVolume": kwargs["folder_output"],
-            "modelDirectory": kwargs["model_folder_1"],
+            "modelDirectory": os.path.join(kwargs["model_folder_1"], "AMASSS_Models"),
             "highDefinition": False,
             "skullStructure": seg_struct,
             "merge": "MERGE" if kwargs["merge_seg"] else "SEPARATE",
@@ -870,13 +872,15 @@ class Or_Auto_CBCT(Semi_CBCT):
             "output_folder": kwargs["folder_output"],
             "precision": 50,
             "vtk_smooth": 5,
-            "prediction_ID": "Pred",
+            "prediction_ID": "seg",
             "gpu_usage": self.getGPUUsage(),
             "cpu_usage": 1,
             "temp_fold": self.tempAMASSS_folder,
             "SegmentInput": False,
             "DCMInput": False,
         }
+        print(f"AMASSS T1 Parameters: {parameter_amasss_seg_t1}\n")
+        print(f"AMASSS T2 Parameters: {parameter_amasss_seg_t2}\n")
         if len(full_seg_struct) > 0:
             list_process.append(
                 {

--- a/AREG_IOS/AREG_IOS.py
+++ b/AREG_IOS/AREG_IOS.py
@@ -129,8 +129,8 @@ def main(args):
 
         # pbar.update(1)
 
-        with open(args.log_path, "r+") as log_f:
-            log_f.write(str(1))
+        with open(args.log_path, "w+") as log_f:
+            log_f.write(str(idx + 1))
 
 
 if __name__ == "__main__":

--- a/ASO_IOS/ASO_IOS_utils/data_file.py
+++ b/ASO_IOS/ASO_IOS_utils/data_file.py
@@ -51,12 +51,14 @@ class Lower:
 
 @dataclass(init=True, repr=True)
 class Jaw:
-    upper: Upper = field(init=False, repr=False, default=Upper())
-    lower: Lower = field(init=False, repr=False, default=Lower())
+    upper: Upper = field(init=False, repr=False, default_factory=Upper)
+    lower: Lower = field(init=False, repr=False, default_factory=Lower)
     actual: Union[Upper, Lower]
 
     def __init__(self, actual) -> None:
         assert isinstance(actual, (Upper, Lower, str))
+        self.upper = Upper()
+        self.lower = Lower()
         if isinstance(actual, str):
             actual = Files.TypeOfJaw(actual)
         self.actual = actual

--- a/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
+++ b/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
@@ -211,8 +211,8 @@ def main(args):
                 args.add_inname[0],
             )
 
-        with open(args.log_path[0], "r+") as log_f:
-            log_f.write(str(index))
+        with open(args.log_path[0], "w+") as log_f:
+            log_f.write(str(index+1))
 
 
 if __name__ == "__main__":

--- a/ASO_IOS/SEMI_ASO_IOS/SEMI_ASO_IOS.py
+++ b/ASO_IOS/SEMI_ASO_IOS/SEMI_ASO_IOS.py
@@ -142,8 +142,8 @@ def main(args):
                     args.output_folder[0],
                 )
 
-        with open(args.log_path[0], "r+") as log_f:
-            log_f.write(str(index))
+        with open(args.log_path[0], "w+") as log_f:
+            log_f.write(str(index+1))
 
 
 if __name__ == "__main__":

--- a/MRI2CBCT/MRI2CBCT.py
+++ b/MRI2CBCT/MRI2CBCT.py
@@ -1,15 +1,16 @@
 import logging
 import os
+import sys
 from typing import Annotated, Optional
 from qt import QApplication, QWidget, QTableWidget, QDoubleSpinBox, QTableWidgetItem, QHeaderView,QSpinBox, QVBoxLayout, QLabel, QSizePolicy, QCheckBox, QFileDialog,QMessageBox, QApplication, QProgressDialog
 import qt
-from MRI2CBCT_utils.Preprocess_CBCT import Process_CBCT
 from MRI2CBCT_utils.Preprocess_MRI import Process_MRI
 from MRI2CBCT_utils.Preprocess_CBCT_MRI import Preprocess_CBCT_MRI
 from MRI2CBCT_utils.Reg_MRI2CBCT import Registration_MRI2CBCT
 from MRI2CBCT_utils.Approx_MRI2CBCT import Approximation_MRI2CBCT
 from MRI2CBCT_utils.LR_crop import LR_CROP_MRI2CBCT
 from MRI2CBCT_utils.TMJ_crop import TMJ_CROP_MRI2CBCT
+
 import time 
 
 
@@ -31,40 +32,93 @@ import zipfile
 import importlib.metadata
 from pathlib import Path
 
+from packaging.version import Version
+from packaging.specifiers import SpecifierSet
+
 from slicer import vtkMRMLScalarVolumeNode
 
 def check_lib_installed(lib_name, required_version=None):
     try:
-        installed_version = importlib.metadata.version(lib_name)
-        if required_version and installed_version != required_version:
-            return False
+        installed_version = Version(importlib.metadata.version(lib_name))
+        if required_version:
+            spec = SpecifierSet(required_version)
+            if installed_version not in spec:
+                print(f"{lib_name} version {installed_version} does not satisfy {required_version}")
+                return False
         return True
     except importlib.metadata.PackageNotFoundError:
+        print(f"{lib_name} not installed")
+        return False
+    except Exception as e:
+        print(f"Error checking {lib_name}: {e}")
         return False
 
-# import csv
-    
 def install_function():
-    libs = [('itk',None),('monai','0.7.0'),('einops',None),('dicom2nifti', '2.3.0'),('pydicom', '2.2.2'),('nibabel',None),('itk-elastix',None),('connected-components-3d','3.9.1'),("pandas",None),("scikit-learn",None),("torch",None),("torchreg",None),("SimpleITK",None)]
+    libs = [
+        ('itk', None),
+        ('einops', None),
+        ('dicom2nifti', '==2.3.0'),
+        ('pydicom', '==2.2.2'),
+        ('nibabel', None),
+        ('itk-elastix', None),
+        ('pandas', None),
+        ('scikit-learn', None),
+        ('torch', None),  # Special case
+        ('torchreg', None),
+        ('SimpleITK', None),
+        ('numpy', '==1.26.4'),
+        ('numexpr', '==2.9.0'),
+        ('psutil', None)
+    ]
+
     libs_to_install = []
-    for lib, version in libs:
-        if not check_lib_installed(lib, version):
-            libs_to_install.append((lib, version))
+    for lib, version_spec in libs:
+        if not check_lib_installed(lib, version_spec):
+            libs_to_install.append((lib, version_spec))
 
     if libs_to_install:
         message = "The following libraries are not installed or need updating:\n"
-        message += "\n".join([f"{lib}=={version}" if version else lib for lib, version in libs_to_install])
-        message += "\n\nDo you want to install/update these libraries?\n Doing it could break other modules"
+        message += "\n".join([
+            f"{lib}{version if version else ''}" for lib, version in libs_to_install
+        ])
+        message += "\n\nDo you want to install/update these libraries?\nDoing it could break other modules"
         user_choice = slicer.util.confirmYesNoDisplay(message)
 
         if user_choice:
-            for lib, version in libs_to_install:
-                lib_version = f'{lib}=={version}' if version else lib
-                pip_install(lib_version)
-        else :
-          return False
-    import vtk
-    import itk
+            for lib, version_spec in libs_to_install:
+                try:
+                    if lib == "torch":
+                        print("Installing torch from official PyTorch wheel (cu118)")
+                        pip_install("torch --index-url https://download.pytorch.org/whl/cu118")
+                    else:
+                        pip_target = f"{lib}{version_spec}" if version_spec else lib
+                        pip_install(pip_target)
+                except Exception as e:
+                    slicer.util.errorDisplay(f"Failed to install {lib}: {str(e)}")
+                    return False
+        else:
+            return False
+
+    from SlicerNNUNetLib import InstallLogic
+    # Version-aware nnUNet installation
+    install_logic = InstallLogic()
+    if sys.version_info >= (3, 10):
+        nnunet_version = "nnunetv2>=2.6.2"
+    else:
+        nnunet_version = "nnunetv2==2.5.2"
+
+    success = install_logic.setupPythonRequirements(nnunet_version)
+    if not success:
+        slicer.util.errorDisplay("nnUNet installation failed. Please check the logs.")
+        return False
+
+    try:
+        import vtk
+        import itk
+    except ImportError as e:
+        slicer.util.errorDisplay(f"Final import check failed: {e}")
+        return False
+
     return True
 #
 # MRI2CBCT
@@ -81,7 +135,7 @@ class MRI2CBCT(ScriptedLoadableModule):
         self.parent.title = _("MRI2CBCT")  # TODO: make this more human readable by adding spaces
         # TODO: set categories (folders where the module shows up in the module selector)
         self.parent.categories = ["Automated Dental Tools"]
-        self.parent.dependencies = []  # TODO: add here list of module names that this module requires
+        self.parent.dependencies = ["SlicerNNUNet"]  # TODO: add here list of module names that this module requires
         self.parent.contributors = ["John Doe (AnyWare Corp.)"]  # TODO: replace with "Firstname Lastname (Organization)"
         # TODO: update with short description of the module and a link to online module documentation
         # _() function marks text as translatable to other languages
@@ -224,7 +278,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             "MRI2CBCT",
             "MRI2CBCT_" + "CBCT",
         )
-        self.preprocess_cbct = Process_CBCT(self)
         self.preprocess_mri = Process_MRI(self)
         self.preprocess_mri_cbct = Preprocess_CBCT_MRI(self)
         self.registration_mri2cbct = Registration_MRI2CBCT(self)
@@ -317,15 +370,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         
         
-        ### CBCT Orientation ###
-        self.ui.SearchButtonCBCT.connect("clicked(bool)",partial(self.openFinder,"InputCBCT"))
-        self.ui.pushButtonTestFilePreCBCT.connect("clicked(bool)",partial(self.downloadModel,self.ui.LineEditCBCT, "MRI2CBCT", True))
-        self.ui.SearchOutputFolderOrientCBCT.connect("clicked(bool)",partial(self.openFinder,"OutputOrientCBCT"))
-        self.ui.pushButtonDownloadOrientCBCT.connect("clicked(bool)",partial(self.downloadModel,self.ui.lineEditOrientCBCT, "Orientation", True))
-        self.ui.pushButtonDownloadSegCBCT.connect("clicked(bool)",partial(self.downloadModel,self.ui.lineEditSegCBCT, "Segmentation", True))
-        self.ui.pushButtonOrientCBCT.connect("clicked(bool)",self.orientCBCT)
-        
-        
         
         ### Registration ###
         self.ui.SearchButtonOutput.connect("clicked(bool)",partial(self.openFinder,"OutputReg"))
@@ -345,8 +389,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Make sure parameter node is initialized (needed for module reload) 
         self.initializeParameterNode()
-        self.ui.ComboBoxCBCT.setCurrentIndex(1)
-        self.ui.ComboBoxCBCT.setEnabled(False)
         self.ui.ComboBoxMRI.setCurrentIndex(1)
         self.ui.ComboBoxMRI.setEnabled(False)
         
@@ -372,7 +414,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.label_info.setHidden(True)
         self.ui.progressBar.setHidden(True)
         
-        self.ui.ComboBoxCBCT.setHidden(True)
         self.ui.ComboBoxMRI.setHidden(True)
         self.ui.comboBoxRegMRI.setHidden(True)
         self.ui.comboBoxRegCBCT.setHidden(True)
@@ -980,13 +1021,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                   surface_folder = QFileDialog.getOpenFileName(self.parent,'Open a file',)
 
             self.ui.LineEditMRI.setText(surface_folder)
-
-        elif nom=="InputCBCT":
-            if self.ui.ComboBoxCBCT.currentIndex==1:
-                surface_folder = QFileDialog.getExistingDirectory(self.parent, "Select a scan folder")
-            else :
-                surface_folder = QFileDialog.getOpenFileName(self.parent,'Open a file',)
-            self.ui.LineEditCBCT.setText(surface_folder)
             
         elif nom=="InputRegCBCT":
             if self.ui.comboBoxRegCBCT.currentIndex==1:
@@ -1032,11 +1066,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         elif nom=="InputResampleT2Seg":
             surface_folder = QFileDialog.getExistingDirectory(self.parent, "Select a scan folder")
             self.ui.lineEditResampleT2Seg.setText(surface_folder)
- 
-
-        elif nom=="OutputOrientCBCT":
-            surface_folder = QFileDialog.getExistingDirectory(self.parent, "Select a scan folder")
-            self.ui.lineEditOutputOrientCBCT.setText(surface_folder)
             
         elif nom=="OutputOrientMRI":
             surface_folder = QFileDialog.getExistingDirectory(self.parent, "Select a scan folder")
@@ -1115,94 +1144,37 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if any errors occur.
         """
         install_function()
+        url = "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/releases/download/test_files/TestFile.zip"
 
-        # To select the reference files (CBCT Orientation and Registration mode only)
-        if name=="Segmentation" or name=="Orientation" :
-            listmodel = self.preprocess_cbct.getModelUrl()
-            print("listmodel : ",listmodel)
+        documentsLocation = qt.QStandardPaths.DocumentsLocation
+        self.documents = qt.QStandardPaths.writableLocation(documentsLocation)
+        self.SlicerDownloadPath = os.path.join(
+            self.documents,
+            slicer.app.applicationName + "Downloads",
+        )
+        self.isDCMInput = False
+        if not os.path.exists(self.SlicerDownloadPath):
+            os.makedirs(self.SlicerDownloadPath)
 
-            urls = listmodel[name]
-            if isinstance(urls, str):
-                url = urls
-                _ = self.DownloadUnzip(
-                    url=url,
-                    directory=os.path.join(self.SlicerDownloadPath),
-                    folder_name=os.path.join("Models", name),
-                    num_downl=1,
-                    total_downloads=1,
-                )
-                model_folder = os.path.join(self.SlicerDownloadPath, "Models", name)
-
-            elif isinstance(urls, dict):
-                for i, (name_bis, url) in enumerate(urls.items()):
-                    _ = self.DownloadUnzip(
-                        url=url,
-                        directory=os.path.join(self.SlicerDownloadPath),
-                        folder_name=os.path.join("Models", name, name_bis),
-                        num_downl=i + 1,
-                        total_downloads=len(urls),
-                    )
-                model_folder = os.path.join(self.SlicerDownloadPath, "Models", name)
-
-            if not model_folder == "":
-                error = self.preprocess_cbct.TestModel(model_folder, lineEdit.name)
-
-                if isinstance(error, str):
-                    QMessageBox.warning(self.parent, "Warning", error)
-
-                else:
-                    lineEdit.setText(model_folder)
-                    
-        elif name == "MeanCBCT" or name == "ROI":
-            listmodel = self.approximate_mri2cbct.getModelUrl()
-            print("listmodel : ", listmodel)
-
-            urls = listmodel[name]
-            if isinstance(urls, str):
-                url = urls
-                _ = self.DownloadUnzip(
-                    url=url,
-                    directory=os.path.join(self.SlicerDownloadPath),
-                    folder_name=os.path.join("Models", name),
-                    num_downl=1,
-                    total_downloads=1,
-                )
-                model_folder = os.path.join(self.SlicerDownloadPath, "Models", name)
-               
-        else :
-            url = "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/releases/download/test_files/TestFile.zip"
-
-            documentsLocation = qt.QStandardPaths.DocumentsLocation
-            self.documents = qt.QStandardPaths.writableLocation(documentsLocation)
-            self.SlicerDownloadPath = os.path.join(
-                self.documents,
-                slicer.app.applicationName + "Downloads",
+        scan_folder = self.DownloadUnzip(
+                url=url,
+                directory=os.path.join(self.SlicerDownloadPath),
+                folder_name=os.path.join(name)
+                if not self.isDCMInput
+                else os.path.join(name),
             )
-            self.isDCMInput = False
-            if not os.path.exists(self.SlicerDownloadPath):
-                os.makedirs(self.SlicerDownloadPath)
-
-            scan_folder = self.DownloadUnzip(
-                    url=url,
-                    directory=os.path.join(self.SlicerDownloadPath),
-                    folder_name=os.path.join(name)
-                    if not self.isDCMInput
-                    else os.path.join(name),
-                )
-            
-            scan_folder = os.path.join(scan_folder,"TestFile")
-            print("scan folder : ",scan_folder)
-            print("name : ",name)
-            if lineEdit.objectName=="LineEditCBCT":
-                lineEdit.setText(os.path.join(scan_folder,"CBCT_ori"))
-            elif lineEdit.objectName=="LineEditMRI":
-                lineEdit.setText(os.path.join(scan_folder,"MRI_ori"))
-            elif lineEdit.objectName=="lineEditRegMRI":
-                lineEdit.setText(os.path.join(scan_folder,"REG","MRI"))
-            elif lineEdit.objectName=="lineEditRegCBCT":
-                lineEdit.setText(os.path.join(scan_folder,"REG","CBCT"))
-            elif lineEdit.objectName=="lineEditRegLabel":
-                lineEdit.setText(os.path.join(scan_folder,"REG","Seg"))
+        
+        scan_folder = os.path.join(scan_folder,"TestFile")
+        print("scan folder : ",scan_folder)
+        print("name : ",name)
+        if lineEdit.objectName=="LineEditMRI":
+            lineEdit.setText(os.path.join(scan_folder,"MRI_ori"))
+        elif lineEdit.objectName=="lineEditRegMRI":
+            lineEdit.setText(os.path.join(scan_folder,"REG","MRI"))
+        elif lineEdit.objectName=="lineEditRegCBCT":
+            lineEdit.setText(os.path.join(scan_folder,"REG","CBCT"))
+        elif lineEdit.objectName=="lineEditRegLabel":
+            lineEdit.setText(os.path.join(scan_folder,"REG","Seg"))
 
     def DownloadUnzip(
         self, url, directory, folder_name=None, num_downl=1, total_downloads=1
@@ -1400,54 +1372,6 @@ class MRI2CBCTWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.processObserver = self.process.AddObserver(
             "ModifiedEvent", self.onProcessUpdate
         )
-        del self.list_Processes_Parameters[0]
-
-    def orientCBCT(self)->None:
-        """
-        This function is called when the button "pushButtonOrientCBCT" is click.
-        Orient CBCT images using specified parameters and initiate the processing pipeline.
-
-        This function sets up the parameters for CBCT image orientation, tests the process and scan,
-        and starts the processing pipeline if all checks pass. It handles the initial setup,
-        parameter passing, and process initiation, including setting up observers for process updates.
-        """
-        install_function()
-        
-        param = {"input_t1_folder":self.ui.LineEditCBCT.text,
-                "folder_output":self.ui.lineEditOutputOrientCBCT.text,
-                "model_folder_1":self.ui.lineEditSegCBCT.text,
-                "merge_seg":False,
-                "isDCMInput":False,
-                "slicerDownload":self.SlicerDownloadPath}
-        
-        ok,mess = self.preprocess_cbct.TestProcess(**param) 
-        if not ok : 
-            self.showMessage(mess)
-            return
-        ok,mess = self.preprocess_cbct.TestScan(param["input_t1_folder"])
-        if not ok : 
-            self.showMessage(mess)
-            return
-        
-        self.list_Processes_Parameters = self.preprocess_cbct.Process(**param)
-        
-        self.onProcessStarted()
-        
-        # /!\ Launch of the first process /!\
-        print("module name : ",self.list_Processes_Parameters[0]["Module"])
-        print("Parameters : ",self.list_Processes_Parameters[0]["Parameter"])
-        
-        self.process = slicer.cli.run(
-                self.list_Processes_Parameters[0]["Process"],
-                None,
-                self.list_Processes_Parameters[0]["Parameter"],
-            )
-        
-        self.module_name = self.list_Processes_Parameters[0]["Module"]
-        self.processObserver = self.process.AddObserver(
-            "ModifiedEvent", self.onProcessUpdate
-        )
-
         del self.list_Processes_Parameters[0]
     
     def orientCenterMRI(self):

--- a/MRI2CBCT/Resources/UI/MRI2CBCT.ui
+++ b/MRI2CBCT/Resources/UI/MRI2CBCT.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>939</width>
-    <height>2459</height>
+    <height>2482</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -289,185 +289,6 @@
      </property>
      <layout class="QFormLayout" name="formLayout_2">
       <item row="6" column="1">
-       <spacer name="verticalSpacer_9">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>5</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="7" column="1">
-       <widget class="QLabel" name="label_6">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Orientation +  Segmentation of the CBCT</string>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="1">
-       <spacer name="verticalSpacer_5">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>5</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="9" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout_7">
-        <item>
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Input CBCT folder:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="LineEditCBCT"/>
-        </item>
-        <item>
-         <widget class="QComboBox" name="ComboBoxCBCT">
-          <item>
-           <property name="text">
-            <string>File</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Folder</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="SearchButtonCBCT">
-          <property name="text">
-           <string>Search</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButtonTestFilePreCBCT">
-          <property name="text">
-           <string>TestFile</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="10" column="1">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="lineEditOrientCBCT"/>
-        </item>
-        <item row="1" column="2">
-         <widget class="QPushButton" name="pushButtonDownloadOrientCBCT">
-          <property name="text">
-           <string>Download</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="lineEditSegCBCT"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_14">
-          <property name="text">
-           <string>Orientation Model: </string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="lineEditOutputOrientCBCT"/>
-        </item>
-        <item row="0" column="2">
-         <widget class="QPushButton" name="SearchOutputFolderOrientCBCT">
-          <property name="text">
-           <string>Search</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QPushButton" name="pushButtonDownloadSegCBCT">
-          <property name="text">
-           <string>Download</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="text">
-           <string>Segmentation Model: </string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>Output folder:</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="11" column="1">
-       <widget class="QPushButton" name="pushButtonOrientCBCT">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-        <property name="styleSheet">
-         <string notr="true"/>
-        </property>
-        <property name="text">
-         <string>Orient and Segment CBCT</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="1">
-       <widget class="QFrame" name="frame_3">
-        <property name="styleSheet">
-         <string notr="true">QFrame {
-    background-color: #D3D3D3;;
-}</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::HLine</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Plain</enum>
-        </property>
-        <property name="lineWidth">
-         <number>0</number>
-        </property>
-        <property name="midLineWidth">
-         <number>4</number>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="1">
        <spacer name="verticalSpacer_7">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -483,7 +304,7 @@
         </property>
        </spacer>
       </item>
-      <item row="14" column="1">
+      <item row="7" column="1">
        <widget class="QLabel" name="label_8">
         <property name="font">
          <font>
@@ -496,7 +317,7 @@
         </property>
        </widget>
       </item>
-      <item row="15" column="1">
+      <item row="8" column="1">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -512,14 +333,14 @@
         </property>
        </spacer>
       </item>
-      <item row="17" column="1">
+      <item row="10" column="1">
        <widget class="QCheckBox" name="checkBoxBilateralMRI">
         <property name="text">
          <string>Bilateral MRI</string>
         </property>
        </widget>
       </item>
-      <item row="19" column="1">
+      <item row="12" column="1">
        <widget class="QComboBox" name="comboBoxDICOMVolumes">
         <item>
          <property name="text">
@@ -528,14 +349,14 @@
         </item>
        </widget>
       </item>
-      <item row="20" column="1">
+      <item row="13" column="1">
        <widget class="QLabel" name="labelDICOMSpacing">
         <property name="text">
          <string>Acquisition spacing: None</string>
         </property>
        </widget>
       </item>
-      <item row="21" column="1">
+      <item row="14" column="1">
        <spacer name="verticalSpacer_10">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -551,7 +372,7 @@
         </property>
        </spacer>
       </item>
-      <item row="22" column="1">
+      <item row="15" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
          <spacer name="horizontalSpacer_3">
@@ -595,7 +416,7 @@
         </item>
        </layout>
       </item>
-      <item row="23" column="1">
+      <item row="16" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
          <widget class="QLabel" name="label_4">
@@ -637,14 +458,14 @@
         </item>
        </layout>
       </item>
-      <item row="24" column="1">
+      <item row="17" column="1">
        <widget class="QTableWidget" name="tableWidgetOrient">
         <property name="whatsThis">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="26" column="1">
+      <item row="19" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QPushButton" name="ButtonDefaultOrientMRI">
@@ -668,7 +489,7 @@
         </item>
        </layout>
       </item>
-      <item row="31" column="1">
+      <item row="24" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_13">
         <item>
          <widget class="QLabel" name="label_25">
@@ -689,7 +510,7 @@
         </item>
        </layout>
       </item>
-      <item row="32" column="1">
+      <item row="25" column="1">
        <widget class="QPushButton" name="pushButtonOrientMRI">
         <property name="styleSheet">
          <string notr="true"/>
@@ -699,7 +520,7 @@
         </property>
        </widget>
       </item>
-      <item row="33" column="1">
+      <item row="26" column="1">
        <widget class="QFrame" name="frame_2">
         <property name="styleSheet">
          <string notr="true">QFrame {
@@ -720,7 +541,7 @@
         </property>
        </widget>
       </item>
-      <item row="34" column="1">
+      <item row="27" column="1">
        <spacer name="verticalSpacer_8">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -736,7 +557,7 @@
         </property>
        </spacer>
       </item>
-      <item row="35" column="1">
+      <item row="28" column="1">
        <widget class="QLabel" name="label_23">
         <property name="font">
          <font>
@@ -749,7 +570,7 @@
         </property>
        </widget>
       </item>
-      <item row="36" column="1">
+      <item row="29" column="1">
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <layout class="QGridLayout" name="gridLayout_8">
@@ -825,7 +646,7 @@
         </item>
        </layout>
       </item>
-      <item row="37" column="1">
+      <item row="30" column="1">
        <spacer name="verticalSpacer_6">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -841,14 +662,14 @@
         </property>
        </spacer>
       </item>
-      <item row="38" column="1">
+      <item row="31" column="1">
        <widget class="QLabel" name="labelCropLR">
         <property name="text">
          <string>No separation selected</string>
         </property>
        </widget>
       </item>
-      <item row="39" column="1">
+      <item row="32" column="1">
        <widget class="QPushButton" name="pushButtonCropLR">
         <property name="styleSheet">
          <string notr="true"/>


### PR DESCRIPTION
## Update for Python 3.12 Compatibility and IOS Tool Enhancements

This PR introduces several major improvements across multiple modules to ensure compatibility with both **Python 3.9** (stable) and the new **Python 3.12** included in the latest 3D Slicer nightly builds. In addition, usability and performance enhancements have been made to the **IOS tool suite**.

## Summary of Changes
### 🔧 Compatibility Updates
- [ALI](https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/tree/main/ALI), [ASO](https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/tree/main/ASO), [AREG](https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/tree/main/AREG), and [MRI2CBCT](https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/tree/main/MRI2CBCT) modules have been updated to support both **Python 3.9** and **3.12** environments.
- Updated syntax and imports where necessary to support Slicer’s nightly **Python 3.12** runtime.

### 📊 UI & User Experience
- **Progress bars** are now integrated into all IOS tools, providing real-time visual feedback during processing.
- The **Cancel button** has been fixed and now properly interrupts IOS tool execution across platforms.

### 📦 AREG Model Update
- **AREG** has been updated to use the latest AMASSS models for the segmentation as introduced in PR #162.