### PR TITLE
Remove old file from cmakelist

### DIFF
--- a/MRI2CBCT/CMakeLists.txt
+++ b/MRI2CBCT/CMakeLists.txt
@@ -8,7 +8,6 @@ set(MODULE_PYTHON_SCRIPTS
   ${FOLDER_LIBRARY}/Approx_MRI2CBCT.py
   ${FOLDER_LIBRARY}/Method.py
   ${FOLDER_LIBRARY}/Preprocess_CBCT_MRI.py
-  ${FOLDER_LIBRARY}/Preprocess_CBCT.py
   ${FOLDER_LIBRARY}/Preprocess_MRI.py
   ${FOLDER_LIBRARY}/Reg_MRI2CBCT.py
   ${FOLDER_LIBRARY}/LR_crop.py


### PR DESCRIPTION
Preprocess_CBCT.py has been removed  in 
https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/commit/719f925331e09ef6a276fe30f1e5d91bd1551afc

but hasn't been removed in cmakelist