### PR TITLE
WORK

### DIFF
--- a/ALI_IOS/ALI_IOS.py
+++ b/ALI_IOS/ALI_IOS.py
@@ -74,6 +74,60 @@ else :
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
+
+def EstimateMissingArchPositions(lst_teeth, RI, V):
+    """Centroid and arch tangent of the teeth missing from the segmentation.
+
+    The MG cameras are aimed with the centroid of each tooth and the local
+    direction of the arch, both read from the segmentation. When a tooth has
+    no label, both can still be estimated: the lower labels are consecutive
+    along the arch (19 to 31), so the centroids of the segmented teeth trace
+    the arch and a quadratic fit of each coordinate against the label index
+    fills the gaps.
+
+    Needs at least 4 segmented teeth spread over a span of at least 4 labels,
+    otherwise the extrapolation is not trustworthy and {} is returned, leaving
+    the caller to skip those teeth as before.
+
+    Returns {label: (position, tangent)} as float32 tensors in unit-sphere
+    space, for the missing labels only.
+    """
+    ids = RI.squeeze(0)
+    present, centroids = [], []
+    for label in lst_teeth:
+        idx = (ids == int(label)).nonzero(as_tuple=True)[0]
+        if len(idx) > 0:
+            present.append(int(label))
+            centroids.append(V[0][idx].mean(dim=0).cpu().numpy())
+    missing = [int(label) for label in lst_teeth if int(label) not in present]
+    if not missing:
+        return {}
+    if len(present) < 4 or (max(present) - min(present)) < 4:
+        span = max(present) - min(present) if present else 0
+        logger.warning(
+            f"Only {len(present)} teeth segmented over a span of {span} labels: "
+            f"not enough to estimate the position of teeth {missing}")
+        return {}
+
+    present_arr = np.array(present, dtype=float)
+    centroids = np.array(centroids)
+    fits = [np.polyfit(present_arr, centroids[:, axis], deg=2) for axis in range(3)]
+
+    def at(label_value):
+        return np.array([np.polyval(fit, label_value) for fit in fits])
+
+    estimated = {}
+    for label in missing:
+        estimated[label] = (
+            torch.tensor(at(label), dtype=torch.float32),
+            torch.tensor(at(label + 0.5) - at(label - 0.5), dtype=torch.float32),
+        )
+    logger.info(
+        f"Teeth {missing} are not in the segmentation: their positions were "
+        f"estimated from the arch traced by the {len(present)} segmented teeth")
+    return estimated
+
+
 def main(args):
     """Main function with comprehensive error handling."""
     logger.info(f"Starting ALI_IOS with args: {args}")
@@ -245,7 +299,18 @@ def main(args):
                         path_vtk = patient_path
                         model = models_to_use[models_type]['Lower'] if jaw == 'Lower' else models_to_use[models_type]['Upper']
                         camera_position = dic_cam[models_type]['L'] if jaw == 'Lower' else dic_cam[models_type]['U']
-                        
+
+                        # The MG cameras need a position per tooth. For the
+                        # teeth the segmentation does not know, estimate one
+                        # from the arch of the teeth it does know, instead of
+                        # skipping their landmark.
+                        mg_estimated = {}
+                        if models_type == "MG":
+                            surf_est = ReadSurf(path_vtk)
+                            unit_est, mean_est, scale_est = ScaleSurf(surf_est)
+                            (V_est, _f_est, _cn_est, RI_est) = GetSurfProp(unit_est, mean_est, scale_est)
+                            mg_estimated = EstimateMissingArchPositions(lst_teeth, RI_est, V_est)
+
                         for label in lst_teeth:
                             try:
                                 logger.debug(f"Loading model for patient {patient_id}, label {label}, jaw {jaw}")
@@ -266,8 +331,15 @@ def main(args):
                                 surf_unit, mean_arr, scale_factor = ScaleSurf(SURF)
                                 (V, F, CN, RI) = GetSurfProp(surf_unit, mean_arr, scale_factor)
 
-                                if int(label) in RI.squeeze(0):
-                                    agent.position_agent(RI, V, label)
+                                estimated = mg_estimated.get(int(label)) if models_type == "MG" else None
+                                if int(label) in RI.squeeze(0) or estimated is not None:
+                                    if estimated is None:
+                                        agent.position_agent(RI, V, label)
+                                    else:
+                                        agent.position_agent_estimated(V, estimated[0], estimated[1], label)
+                                        logger.info(
+                                            f"Label {label} is not in the segmentation of {patient_id}: "
+                                            "cameras aimed at its position estimated from the arch")
                                     textures = TexturesVertex(verts_features=CN)
                                     meshe = Meshes(verts=V, faces=F, textures=textures).to(DEVICE)
 
@@ -398,9 +470,14 @@ def main(args):
                                                     final = upscale_pos.detach().cpu().numpy()
 
                                                     entry = {"x": final[0], "y": final[1], "z": final[2]}
+                                                    # Flag degraded points in the json: they need a clinical review
+                                                    notes = []
+                                                    if estimated is not None:
+                                                        notes.append("cameras aimed from an arch fit, tooth not segmented")
                                                     if forced_conf is not None:
-                                                        # Flag it in the json: a forced point needs a clinical review
-                                                        entry["desc"] = f"forced (confidence {forced_conf:.3f})"
+                                                        notes.append(f"forced (confidence {forced_conf:.3f})")
+                                                    if notes:
+                                                        entry["desc"] = "; ".join(notes)
                                                     group_data[land_name] = entry
                                                 elif models_type == "MG" and args.force_landmarks:
                                                     # Last resort: not one predicted pixel landed on the mesh.
@@ -424,12 +501,28 @@ def main(args):
                                         logger.error(f"Error during neural network inference for label {label}: {e}")
                                         continue
                                 else:
-                                    logger.debug(f"Label {label} not found in surface")
+                                    logger.warning(
+                                        f"Label {label} is not in the segmentation of {patient_id} "
+                                        f"and too few teeth are segmented to estimate it: the "
+                                        f"landmark(s) {LABEL[str(label)]} cannot be placed")
                                     
                             except Exception as e:
                                 logger.error(f"Error processing label {label} for patient {patient_id}: {e}")
                                 continue
                         
+                        if models_type == "MG":
+                            # A skipped tooth is easy to miss in the log stream:
+                            # say in one line how much of the line is missing.
+                            requested = [LABEL[str(label)][MODELS_DICT['MG']['MG']] for label in lst_teeth]
+                            missing = [name for name in requested if name not in group_data]
+                            if missing:
+                                logger.warning(
+                                    f"{patient_id}: only {len(requested) - len(missing)} of the "
+                                    f"{len(requested)} requested MG landmarks were placed. Missing: "
+                                    f"{', '.join(missing)} — their teeth are not in the segmentation "
+                                    "(Universal_ID / PredictedID) and too few teeth were segmented "
+                                    "to estimate their position along the arch")
+
                         if len(group_data.keys()) > 0:
                             try:
                                 lm_lst = GenControlPoint(group_data, landmarks_selected)

--- a/ALI_IOS/ALI_IOS_utils/agent.py
+++ b/ALI_IOS/ALI_IOS_utils/agent.py
@@ -101,6 +101,23 @@ class Agent:
             logger.error(f"Error in position_agent: {e}")
             raise
 
+    def position_agent_estimated(self, vert, position, tangent, label):
+        """Position the MG agent on a tooth absent from the segmentation.
+
+        `position` and `tangent` come from a fit of the arch through the
+        segmented teeth. The camera geometry is then built exactly as in
+        position_agent: only the source of the tooth centre and of the arch
+        direction changes.
+        """
+        self.positions = position.view(1, 3).to(DEVICE)
+        tangent = tangent.clone().to(DEVICE)
+        tangent[2] = 0.0                      # keep it horizontal
+        norm = torch.norm(tangent)
+        self.arch_tangents = (tangent / norm if norm > 1e-6 else tangent).view(1, 3)
+        if self.lm_type == 'MG':
+            self.buccal_normals, self.aim_points = self._local_frame(vert, self.positions, label)
+        return self.positions
+
     def _arch_tangents(self, text, vert, label):
         """Direction of the dental arch at `label`, one row per mesh, horizontal, unit norm.
 

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -2213,8 +2213,8 @@ qMRMLNodeComboBox:focus {
                         timer = f"Time : {int(currentTime/60)}min and {int(currentTime%60)}s"
                     else:
                         timer = f"Time : {int(currentTime/3600)}h, {int(currentTime%3600/60)}min and {int(currentTime%60)}s"
-                    
-                self.ui.LabelTimer.setText(timer)
+
+                    self.ui.LabelTimer.setText(timer)
 
             del self.list_Processes_Parameters[0]
             

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -30,6 +30,10 @@ logger.addHandler(console_handler)
 # Height of the MGL patch on each side of the mucogingival line, in mm. Below
 # 1 mm the band holds too few vertices for the ICP, above 20 mm it runs past the
 # scanned mucosa.
+# Row of the models folder field inside gridLayout_2 of AREG.ui, where the
+# Browse button is added beside its Download button.
+MODEL3_GRID_ROW = 8
+
 MGL_DEFAULT_RADIUS = 5.0
 MGL_MIN_RADIUS = 1.0
 MGL_MAX_RADIUS = 20.0
@@ -677,8 +681,38 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         grid.addWidget(self.lineEditMGLLandmarks, row + 2, 1)
         grid.addWidget(self.ButtonSearchMGLLandmarks, row + 2, 2)
 
+        # The model field only ever had a Download button, so a folder already on
+        # the disk could not be selected.
+        self.ButtonBrowseModel3 = QPushButton("Browse")
+        self.ButtonBrowseModel3.setToolTip("Select a models folder already on this computer")
+        self.ButtonBrowseModel3.clicked.connect(self.BrowseModelFolder)
+        # Column 3 sits right of the Download button, on the row of the field it
+        # belongs to (the models row of the .ui grid).
+        grid.addWidget(self.ButtonBrowseModel3, MODEL3_GRID_ROW, 3)
+
         self.CbRegReference.currentIndexChanged.connect(self.SwitchRegReference)
         self.SwitchRegReference(0)
+
+    def BrowseModelFolder(self):
+        """Pick the models folder from the disk rather than downloading it."""
+        folder = qt.QFileDialog.getExistingDirectory(self.parent, "Select the models folder")
+        if not folder:
+            return
+
+        if self.isMGLRegistration():
+            error = self.ActualMeth.TestMGLModel(
+                model_folder_3=folder,
+                mgl_landmarks=self.lineEditMGLLandmarks.text.strip(),
+            ) or None
+        else:
+            error = self.ActualMeth.TestModel(folder, self.ui.lineEditModel3.name)
+
+        if isinstance(error, str):
+            qt.QMessageBox.warning(self.parent, "Warning", error)
+            return
+
+        self.ui.lineEditModel3.setText(folder)
+        self.enableCheckbox()
 
     def MGLRadius(self):
         """Patch height as typed, kept inside the range the patch is usable in."""
@@ -718,6 +752,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 "ALI Models Folder (MGL)" if is_mgl else "Registration Model Folder"
             )
 
+
         # MGL takes its pose from the landmarks, so the ASO orientation reference
         # and its segmentation model play no part: hide them rather than leave
         # the user guessing what to fill in. Outside MGL they come back only in
@@ -731,6 +766,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """Hide the whole choice outside IOS, where only one reference exists."""
         for widget in (self.label_reg_reference, self.CbRegReference):
             widget.setVisible(visible)
+        # Browsing for the models folder is offered wherever that folder is asked
+        # for, which in this module is the IOS modes.
+        self.ButtonBrowseModel3.setVisible(visible)
         if visible:
             self.SwitchRegReference(self.CbRegReference.currentIndex)
         else:

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1218,7 +1218,15 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             model_folder = os.path.join(self.SlicerDownloadPath, "Models", name)
 
         if not model_folder == "":
-            error = self.ActualMeth.TestModel(model_folder, lineEdit.name)
+            if self.isMGLRegistration() and lineEdit.name == "lineEditModel3":
+                # That field holds the ALI models in MGL, so the palatal
+                # checkpoint check does not apply to it
+                error = self.ActualMeth.TestMGLModel(
+                    model_folder_3=model_folder,
+                    mgl_landmarks=self.lineEditMGLLandmarks.text.strip(),
+                ) or None
+            else:
+                error = self.ActualMeth.TestModel(model_folder, lineEdit.name)
 
             if isinstance(error, str):
                 qt.QMessageBox.warning(self.parent, "Warning", error)
@@ -1411,6 +1419,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             dic_checkbox=self.dicchckbox,
             isDCMInput=self.isDCMInput,
             OrientReference=self.CBCTOrientRef,
+            reg_type="MGL" if self.isMGLRegistration() else "Butterfly",
+            mgl_landmarks=self.lineEditMGLLandmarks.text.strip(),
         )
 
         if isinstance(error, str):

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -7,7 +7,6 @@ from qt import (
     QTabWidget,
     QGridLayout,
     QComboBox,
-    QDoubleSpinBox,
     QLabel,
     QLineEdit,
     QPushButton,
@@ -27,6 +26,13 @@ console_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno)d) - %(message)s')
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
+
+# Height of the MGL patch on each side of the mucogingival line, in mm. Below
+# 1 mm the band holds too few vertices for the ICP, above 20 mm it runs past the
+# scanned mucosa.
+MGL_DEFAULT_RADIUS = 5.0
+MGL_MIN_RADIUS = 1.0
+MGL_MAX_RADIUS = 20.0
 
 from AREG_Method.IOS import Auto_IOS, Semi_IOS
 from AREG_Method.CBCT import Semi_CBCT, Auto_CBCT, Or_Auto_CBCT
@@ -644,21 +650,18 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         grid.addWidget(self.label_reg_reference, row, 0)
         grid.addWidget(self.CbRegReference, row, 1)
 
+        # A plain line edit rather than a spin box: the module stylesheet pads
+        # every QLineEdit by 6px, and a spin box wears that padding on its inner
+        # editor, which clips the digits out of view.
         self.label_mgl_radius = QLabel("MGL Patch Height (mm)")
-        self.SpinMGLRadius = QDoubleSpinBox()
-        self.SpinMGLRadius.setRange(1.0, 20.0)
-        self.SpinMGLRadius.setSingleStep(0.5)
-        self.SpinMGLRadius.setDecimals(1)
-        self.SpinMGLRadius.setSuffix(" mm")
-        self.SpinMGLRadius.setMinimumWidth(90)
-        self.SpinMGLRadius.setValue(5.0)
-        self.SpinMGLRadius.setToolTip(
-            "How far the patch spreads on each side of the mucogingival line, "
-            "along the surface. Vertices belonging to the crowns are always left "
-            "out, whatever the value."
+        self.lineEditMGLRadius = QLineEdit(str(MGL_DEFAULT_RADIUS))
+        self.lineEditMGLRadius.setToolTip(
+            f"How far the patch spreads on each side of the mucogingival line, "
+            f"along the surface, in mm (between {MGL_MIN_RADIUS} and {MGL_MAX_RADIUS}). "
+            "Vertices belonging to the crowns are always left out, whatever the value."
         )
         grid.addWidget(self.label_mgl_radius, row + 1, 0)
-        grid.addWidget(self.SpinMGLRadius, row + 1, 1)
+        grid.addWidget(self.lineEditMGLRadius, row + 1, 1)
 
         self.label_mgl_lm = QLabel("MGL Landmarks Folder")
         self.lineEditMGLLandmarks = QLineEdit()
@@ -677,6 +680,20 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.CbRegReference.currentIndexChanged.connect(self.SwitchRegReference)
         self.SwitchRegReference(0)
 
+    def MGLRadius(self):
+        """Patch height as typed, kept inside the range the patch is usable in."""
+        try:
+            radius = float(self.lineEditMGLRadius.text.replace(",", ".").strip())
+        except ValueError:
+            logger.warning(f"Unreadable MGL patch height, falling back to {MGL_DEFAULT_RADIUS} mm")
+            return str(MGL_DEFAULT_RADIUS)
+
+        clamped = min(max(radius, MGL_MIN_RADIUS), MGL_MAX_RADIUS)
+        if clamped != radius:
+            logger.warning(f"MGL patch height {radius} mm is out of range, using {clamped} mm")
+            self.lineEditMGLRadius.setText(str(clamped))
+        return str(clamped)
+
     def SearchMGLLandmarks(self):
         folder = qt.QFileDialog.getExistingDirectory(self.parent, "Select the MGL landmarks folder")
         if folder:
@@ -691,7 +708,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def SwitchRegReference(self, index):
         """Show the fields that belong to the selected reference."""
         is_mgl = index == 1
-        for widget in (self.label_mgl_radius, self.SpinMGLRadius, self.label_mgl_lm,
+        for widget in (self.label_mgl_radius, self.lineEditMGLRadius, self.label_mgl_lm,
                        self.lineEditMGLLandmarks, self.ButtonSearchMGLLandmarks):
             widget.setVisible(is_mgl)
 
@@ -717,7 +734,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if visible:
             self.SwitchRegReference(self.CbRegReference.currentIndex)
         else:
-            for widget in (self.label_mgl_radius, self.SpinMGLRadius, self.label_mgl_lm,
+            for widget in (self.label_mgl_radius, self.lineEditMGLRadius, self.label_mgl_lm,
                            self.lineEditMGLLandmarks, self.ButtonSearchMGLLandmarks):
                 widget.setVisible(False)
 
@@ -1429,7 +1446,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 ),
                 ApproxStep=self.ui.ApproxcheckBox.isChecked(),
                 reg_type="MGL" if self.isMGLRegistration() else "Butterfly",
-                patch_radius=str(self.SpinMGLRadius.value),
+                patch_radius=self.MGLRadius(),
                 mgl_landmarks=self.lineEditMGLLandmarks.text.strip(),
             )
 

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1473,6 +1473,13 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 )
             else:
                 merge_seg = None
+
+            if self.isMGLRegistration():
+                # MGL registers the mandibles, which NumberScan does not count
+                self.nb_patient = self.ActualMeth.NumberScanLower(
+                    self.ui.lineEditScanT1LmPath.text, self.ui.lineEditScanT2LmPath.text
+                )
+
             self.list_Processes_Parameters = self.ActualMeth.Process(
                 input_t1_folder=self.ui.lineEditScanT1LmPath.text,
                 input_t2_folder=self.ui.lineEditScanT2LmPath.text,
@@ -1635,7 +1642,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.module_name_before = self.module_name
                 self.progress = 0
                 self.ui.LabelProgressPatient.setText(f"Patient : {self.progress}/{self.nb_patient}")
-                progress_bar_value = round((self.progress) / self.nb_patient * 100,2)
+                progress_bar_value = round(self.progress / self.nb_patient * 100, 2) if self.nb_patient else 0
                 
                 self.ui.progressBar.setValue(progress_bar_value)
                 self.ui.progressBar.setFormat(f"{progress_bar_value:.2f}%")
@@ -1724,7 +1731,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.nb_change_bystep = 0
         total_time = time.time() - self.startTime
-        average_time = total_time / self.nb_patient
+        average_time = total_time / self.nb_patient if self.nb_patient else total_time
         logger.info("PROCESS DONE.")
         logger.info(
             "Done in {} min and {} sec".format(

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -27,15 +27,15 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-# Height of the MGL patch on each side of the mucogingival line, in mm. Below
-# 1 mm the band holds too few vertices for the ICP, above 20 mm it runs past the
-# scanned mucosa.
+# Height of the MGL patch on each side of the mucogingival line, in mm. At 0
+# the band degenerates into the snapped curve itself and the registration runs
+# on the line only; above 20 mm it runs past the scanned mucosa.
 # Row of the models folder field inside gridLayout_2 of AREG.ui, where the
 # Browse button is added beside its Download button.
 MODEL3_GRID_ROW = 8
 
 MGL_DEFAULT_RADIUS = 5.0
-MGL_MIN_RADIUS = 1.0
+MGL_MIN_RADIUS = 0.0
 MGL_MAX_RADIUS = 20.0
 
 from AREG_Method.IOS import Auto_IOS, Semi_IOS
@@ -662,7 +662,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.lineEditMGLRadius.setToolTip(
             f"How far the patch spreads on each side of the mucogingival line, "
             f"along the surface, in mm (between {MGL_MIN_RADIUS} and {MGL_MAX_RADIUS}). "
-            "Vertices belonging to the crowns are always left out, whatever the value."
+            "At 0 the patch is the line itself : the registration runs on the "
+            "curve through the landmarks only. Vertices belonging to the crowns "
+            "are always left out, whatever the value."
         )
         grid.addWidget(self.label_mgl_radius, row + 1, 0)
         grid.addWidget(self.lineEditMGLRadius, row + 1, 1)

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -6,6 +6,11 @@ from qt import (
     QScrollArea,
     QTabWidget,
     QGridLayout,
+    QComboBox,
+    QDoubleSpinBox,
+    QLabel,
+    QLineEdit,
+    QPushButton,
 )
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin, pip_install
@@ -458,6 +463,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.tohideCBCT_3,
         )
 
+        self.initRegistrationReference()
         self.HideComputeItems()
         self.SwitchType()
         
@@ -545,6 +551,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.isDCMInput = True
 
     def SwitchModeCBCT(self, index):
+        self.ShowRegistrationReference(False)
         """Function to change the UI depending on the mode selected (Semi or Fully Automated)"""
         self.ui.CbCBCTInputType.setVisible(True)
         self.ui.label_CBCTInputType.setVisible(True)
@@ -615,7 +622,95 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.label_CBCTInputType.setVisible(False)
             self.isDCMInput = False
 
+    def initRegistrationReference(self):
+        """Build the IOS choice of registration reference, below the input fields.
+
+        Two stable regions are available and they do not describe the same arch:
+        the palate carries the upper registration, the band along the
+        mucogingival line carries the lower one.
+        """
+        grid = self.ui.gridLayout_2
+        row = grid.rowCount()
+
+        self.label_reg_reference = QLabel("Registration Reference")
+        self.CbRegReference = QComboBox()
+        self.CbRegReference.addItem("Palate (Butterfly) - upper arch")
+        self.CbRegReference.addItem("Mucogingival line (MGL) - lower arch")
+        self.CbRegReference.setToolTip(
+            "Surface the registration is computed on. The palate is painted by a "
+            "neural network on the upper arch; the mucogingival band is built from "
+            "the MGL landmarks on the lower arch."
+        )
+        grid.addWidget(self.label_reg_reference, row, 0)
+        grid.addWidget(self.CbRegReference, row, 1)
+
+        self.label_mgl_radius = QLabel("MGL Patch Height (mm)")
+        self.SpinMGLRadius = QDoubleSpinBox()
+        self.SpinMGLRadius.setRange(1.0, 20.0)
+        self.SpinMGLRadius.setSingleStep(0.5)
+        self.SpinMGLRadius.setValue(5.0)
+        self.SpinMGLRadius.setToolTip(
+            "How far the patch spreads on each side of the mucogingival line, "
+            "along the surface. Vertices belonging to the crowns are always left "
+            "out, whatever the value."
+        )
+        grid.addWidget(self.label_mgl_radius, row + 1, 0)
+        grid.addWidget(self.SpinMGLRadius, row + 1, 1)
+
+        self.label_mgl_lm = QLabel("MGL Landmarks Folder")
+        self.lineEditMGLLandmarks = QLineEdit()
+        self.lineEditMGLLandmarks.setPlaceholderText("optional, computed by ALI when left empty")
+        self.lineEditMGLLandmarks.setToolTip(
+            "Folder of MG landmark json files, T1 and T2 together: they are matched "
+            "to their scan by name. Leave it empty to have ALI predict them from the "
+            "models folder."
+        )
+        self.ButtonSearchMGLLandmarks = QPushButton("Browse")
+        self.ButtonSearchMGLLandmarks.clicked.connect(self.SearchMGLLandmarks)
+        grid.addWidget(self.label_mgl_lm, row + 2, 0)
+        grid.addWidget(self.lineEditMGLLandmarks, row + 2, 1)
+        grid.addWidget(self.ButtonSearchMGLLandmarks, row + 2, 2)
+
+        self.CbRegReference.currentIndexChanged.connect(self.SwitchRegReference)
+        self.SwitchRegReference(0)
+
+    def SearchMGLLandmarks(self):
+        folder = qt.QFileDialog.getExistingDirectory(self.parent, "Select the MGL landmarks folder")
+        if folder:
+            self.lineEditMGLLandmarks.setText(folder)
+
+    def isMGLRegistration(self):
+        """True when the lower arch is registered on the mucogingival band."""
+        return (self.type == "IOS"
+                and getattr(self, "CbRegReference", None) is not None
+                and self.CbRegReference.currentIndex == 1)
+
+    def SwitchRegReference(self, index):
+        """Show the fields that belong to the selected reference."""
+        is_mgl = index == 1
+        for widget in (self.label_mgl_radius, self.SpinMGLRadius, self.label_mgl_lm,
+                       self.lineEditMGLLandmarks, self.ButtonSearchMGLLandmarks):
+            widget.setVisible(is_mgl)
+
+        # The palatal patch is the only one that needs its own trained model.
+        if hasattr(self.ui, "label_4"):
+            self.ui.label_4.setText(
+                "ALI Models Folder (MGL)" if is_mgl else "Registration Model Folder"
+            )
+
+    def ShowRegistrationReference(self, visible):
+        """Hide the whole choice outside IOS, where only one reference exists."""
+        for widget in (self.label_reg_reference, self.CbRegReference):
+            widget.setVisible(visible)
+        if visible:
+            self.SwitchRegReference(self.CbRegReference.currentIndex)
+        else:
+            for widget in (self.label_mgl_radius, self.SpinMGLRadius, self.label_mgl_lm,
+                           self.lineEditMGLLandmarks, self.ButtonSearchMGLLandmarks):
+                widget.setVisible(False)
+
     def SwitchModeIOS(self, index):
+        self.ShowRegistrationReference(True)
         self.ui.CbCBCTInputType.setVisible(False)
         self.ui.label_CBCTInputType.setVisible(False)
         self.ui.advancedCollapsibleButton.collapsed = True
@@ -667,6 +762,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
 
     def SwitchModeIOSCBCT(self, index):
+        self.ShowRegistrationReference(False)
         self.ui.CbCBCTInputType.setVisible(False)
         self.ui.label_CBCTInputType.setVisible(False)
         self.ui.advancedCollapsibleButton.collapsed = True
@@ -1319,6 +1415,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     self.SegmentationLabels[self.ui.LabelSelectcomboBox.currentIndex]
                 ),
                 ApproxStep=self.ui.ApproxcheckBox.isChecked(),
+                reg_type="MGL" if self.isMGLRegistration() else "Butterfly",
+                patch_radius=str(self.SpinMGLRadius.value),
+                mgl_landmarks=self.lineEditMGLLandmarks.text.strip(),
             )
 
             # Guard: if Process() returned an empty list, log and return to avoid IndexError

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1492,6 +1492,27 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 del self.list_Processes_Parameters[0]
 
             elif self.type == "IOS":
+                if self.isMGLRegistration():
+                    # Every step of the MGL pipeline is a conda tool, unlike the
+                    # palatal flow where the orientation is a Slicer CLI, so they
+                    # are simply run one after the other.
+                    while self.list_Processes_Parameters:
+                        module = self.list_Processes_Parameters[0]["Module"]
+                        self.displayModule = self.list_Processes_Parameters[0]["Display"]
+                        if module.startswith("CrownSegmentationcli"):
+                            self.run_conda_tool("seg")    # counts its own runs
+                        elif module.startswith("ALI_IOS"):
+                            self.nb_extension_did += 1
+                            self.run_conda_tool("ali")
+                        else:
+                            self.nb_extension_did += 1
+                            self.run_conda_tool("areg")
+                    try:
+                        self.OnEndProcess()
+                    except Exception:
+                        logger.exception("OnEndProcess failed after the MGL pipeline")
+                    return
+
                 if self.module_name in ["CrownSegmentationcli T1", "AREG_IOS"]:
                     if "CrownSegmentationcli" in self.module_name:
                         self.run_conda_tool("seg")

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -648,6 +648,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.SpinMGLRadius = QDoubleSpinBox()
         self.SpinMGLRadius.setRange(1.0, 20.0)
         self.SpinMGLRadius.setSingleStep(0.5)
+        self.SpinMGLRadius.setDecimals(1)
+        self.SpinMGLRadius.setSuffix(" mm")
+        self.SpinMGLRadius.setMinimumWidth(90)
         self.SpinMGLRadius.setValue(5.0)
         self.SpinMGLRadius.setToolTip(
             "How far the patch spreads on each side of the mucogingival line, "
@@ -698,6 +701,15 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 "ALI Models Folder (MGL)" if is_mgl else "Registration Model Folder"
             )
 
+        # MGL takes its pose from the landmarks, so the ASO orientation reference
+        # and its segmentation model play no part: hide them rather than leave
+        # the user guessing what to fill in. Outside MGL they come back only in
+        # the mode that orients, which is index 0.
+        orientation_used = not is_mgl and self.ui.CbModeType.currentIndex == 0
+        for widget in (self.ui.label_7, self.ui.lineEditModel1, self.ui.ButtonSearchModel1,
+                       self.ui.label_6, self.ui.lineEditModel2, self.ui.ButtonSearchModel2):
+            widget.setVisible(orientation_used)
+
     def ShowRegistrationReference(self, visible):
         """Hide the whole choice outside IOS, where only one reference exists."""
         for widget in (self.label_reg_reference, self.CbRegReference):
@@ -710,7 +722,6 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 widget.setVisible(False)
 
     def SwitchModeIOS(self, index):
-        self.ShowRegistrationReference(True)
         self.ui.CbCBCTInputType.setVisible(False)
         self.ui.label_CBCTInputType.setVisible(False)
         self.ui.advancedCollapsibleButton.collapsed = True
@@ -760,6 +771,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.lineEditModel3.setVisible(True)
             self.ui.ButtonSearchModel3.setVisible(True)
 
+        # Last, so the selected reference decides which model fields survive
+        self.ShowRegistrationReference(True)
 
     def SwitchModeIOSCBCT(self, index):
         self.ShowRegistrationReference(False)

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -279,31 +279,34 @@ class Auto_IOS(Method):
         if isinstance(scan, str):
             out = out + f"{scan}\n"
 
-        reference = self.TestReference(kwargs["model_folder_2"])
-        if isinstance(reference, str):
-            out = out + f"{reference}\n"
-
         if kwargs["folder_output"] == "":
             out = out + "Please select output folder\n"
 
-        if kwargs["model_folder_1"] == "":
-            out = out + "Please select folder for the registration model\n"
-
+        # MGL builds its patch from the landmarks, so it needs neither the
+        # palatal orientation reference nor a registration checkpoint.
         if kwargs.get("reg_type") == "MGL":
             out = out + self.TestMGLModel(**kwargs)
 
-        elif len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
-            out = (
-                out + "Please select folder with only one model for the registration\n"
-            )
+        else:
+            reference = self.TestReference(kwargs["model_folder_2"])
+            if isinstance(reference, str):
+                out = out + f"{reference}\n"
 
-        if kwargs["model_folder_3"] == "":
-            out = out + "Please select folder for the segmentation model\n"
+            if kwargs["model_folder_1"] == "":
+                out = out + "Please select folder for the registration model\n"
 
-        if len(self.search(kwargs["model_folder_1"], ".pth")[".pth"]) != 1:
-            out = (
-                out + "Please select folder with only one model for the segmentation\n"
-            )
+            if len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
+                out = (
+                    out + "Please select folder with only one model for the registration\n"
+                )
+
+            if kwargs["model_folder_3"] == "":
+                out = out + "Please select folder for the segmentation model\n"
+
+            if len(self.search(kwargs["model_folder_1"], ".pth")[".pth"]) != 1:
+                out = (
+                    out + "Please select folder with only one model for the segmentation\n"
+                )
 
         if out != "":
             out = out[:-1]
@@ -442,6 +445,36 @@ class Auto_IOS(Method):
         }
         
 
+        numberscan = self.NumberScan(
+            kwargs["input_t1_folder"], kwargs["input_t2_folder"]
+        )
+
+        if kwargs.get("reg_type") == "MGL":
+            # The mucogingival band needs the teeth segmentation, not the palatal
+            # orientation: the landmarks carry the pose the patch is built on.
+            mgl_kwargs = dict(kwargs)
+            mgl_kwargs["input_t1_folder"] = path_seg_T1
+            mgl_kwargs["input_t2_folder"] = path_seg_T2
+            SegProcess = slicer.modules.crownsegmentationcli
+            return [
+                {
+                    "Process": SegProcess,
+                    "Parameter": parameter_segteeth_T1,
+                    "Module": "CrownSegmentationcli T1",
+                    "Display": DisplayCrownSeg(
+                        number_scan_toseg_T1, kwargs["logPath"], "T1 Scan"
+                    ),
+                },
+                {
+                    "Process": SegProcess,
+                    "Parameter": parameter_segteeth_T2,
+                    "Module": "CrownSegmentationcli T2",
+                    "Display": DisplayCrownSeg(
+                        number_scan_toseg_T2, kwargs["logPath"], "T2 Scan"
+                    ),
+                },
+            ] + MGLProcess(self, numberscan, "Auto_IOS", **mgl_kwargs)
+
         parameter_pre_aso_T1 = {
             "input": path_seg_T1,
             "gold_folder": kwargs["model_folder_2"],
@@ -484,35 +517,6 @@ class Auto_IOS(Method):
         PreOrientProcess = slicer.modules.pre_aso_ios
         SegProcess = slicer.modules.crownsegmentationcli
         RegProcess = slicer.modules.areg_ios
-
-        numberscan = self.NumberScan(
-            kwargs["input_t1_folder"], kwargs["input_t2_folder"]
-        )
-
-        if kwargs.get("reg_type") == "MGL":
-            # The mucogingival band needs the teeth segmentation, not the palatal
-            # orientation: the landmarks carry the pose the patch is built on.
-            mgl_kwargs = dict(kwargs)
-            mgl_kwargs["input_t1_folder"] = path_seg_T1
-            mgl_kwargs["input_t2_folder"] = path_seg_T2
-            return [
-                {
-                    "Process": SegProcess,
-                    "Parameter": parameter_segteeth_T1,
-                    "Module": "CrownSegmentationcli T1",
-                    "Display": DisplayCrownSeg(
-                        number_scan_toseg_T1, kwargs["logPath"], "T1 Scan"
-                    ),
-                },
-                {
-                    "Process": SegProcess,
-                    "Parameter": parameter_segteeth_T2,
-                    "Module": "CrownSegmentationcli T2",
-                    "Display": DisplayCrownSeg(
-                        number_scan_toseg_T2, kwargs["logPath"], "T2 Scan"
-                    ),
-                },
-            ] + MGLProcess(self, numberscan, "Auto_IOS", **mgl_kwargs)
 
         list_process = [
             {

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -245,6 +245,8 @@ class Auto_IOS(Method):
             "Registration": "https://github.com/HUTIN1/AREG/releases/download/v1.0.0/AREG_model.zip",
             "Reference": "https://github.com/HUTIN1/ASO/releases/download/v1.0.0/Gold_file.zip",
             "Segmentation": "https://github.com/HUTIN1/ASO/releases/download/v1.0.0/segmentation_model.zip",
+            # MGL reads its landmarks from the ALI models, not from a palatal checkpoint
+            "ALI": "https://github.com/DCBIA-OrthoLab/SlicerAutomatedDentalTools/releases/download/ALI_IOS_models/Models.zip",
         }
 
     def getReferenceList(self):

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -1,5 +1,5 @@
 from AREG_Method.Method import Method
-from AREG_Method.Progress import DisplayAREGIOS, DisplayCrownSeg, DisplayASOIOS
+from AREG_Method.Progress import DisplayAREGIOS, DisplayCrownSeg, DisplayASOIOS, DisplayALIIOS
 import slicer
 import webbrowser
 import glob
@@ -22,6 +22,76 @@ console_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno)d) - %(message)s')
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
+
+
+# The 13 MG landmarks, in arch order. Must match MG_OUTPUT_NAME in
+# ALI_IOS/ALI_IOS_utils/model.py, which is what the CLI translates back.
+MGL_TEETH = ("LL6MG LL5MG LL4MG LL3MG LL2MG LL1MG L0MG "
+             "LR1MG LR2MG LR3MG LR4MG LR5MG LR6MG")
+
+
+def MGLProcess(method, numberscan, areg_mode, **kwargs):
+    """Processes registering the lower arches on the mucogingival band.
+
+    ALI predicts the landmarks for both timepoints unless the user points at a
+    folder that already holds them, which also lets a run be repeated without
+    paying for the prediction again.
+    """
+    landmarks_folder = kwargs.get("mgl_landmarks", "").strip()
+    predict = not landmarks_folder
+
+    if predict:
+        landmarks_folder = os.path.join(slicer.util.tempDirectory(), "MGL_landmarks")
+        os.makedirs(landmarks_folder, exist_ok=True)
+
+    list_process = []
+
+    if predict:
+        # Key order matters: the values are passed positionally to the ALI_IOS CLI
+        for time in ("T1", "T2"):
+            parameter_ali = {
+                "input": kwargs[f"input_{time.lower()}_folder"],
+                "dir_models": kwargs["model_folder_3"],
+                "lm_type": "None",
+                "teeth": "None",
+                "teeth_mg": MGL_TEETH,
+                "output_dir": landmarks_folder,
+                "image_size": "224",
+                "blur_radius": "0",
+                "faces_per_pixel": "1",
+                "log_path": kwargs["logPath"],
+            }
+            logger.info(f"Parameter ALI_IOS {time}: {parameter_ali}")
+            list_process.append({
+                "Process": slicer.modules.ali_ios,
+                "Parameter": parameter_ali,
+                "Module": f"ALI_IOS {time}",
+                "Display": DisplayALIIOS(13, numberscan),
+            })
+
+    # Key order matters: the values are passed positionally to the AREG_IOS CLI
+    parameter_reg = {
+        "T1": kwargs["input_t1_folder"],
+        "T2": kwargs["input_t2_folder"],
+        "output": kwargs["folder_output"],
+        "model": "None",                       # the palatal model is not used
+        "suffix": kwargs["add_in_namefile"],
+        "log_path": kwargs["logPath"],
+        "areg_mode": areg_mode,
+        "reg_type": "MGL",
+        "patch_radius": kwargs.get("patch_radius", "5.0"),
+        "lm_T1": landmarks_folder,
+        "lm_T2": landmarks_folder,
+    }
+    logger.info(f"Parameter AREG_IOS (MGL): {parameter_reg}")
+    list_process.append({
+        "Process": slicer.modules.areg_ios,
+        "Parameter": parameter_reg,
+        "Module": "AREG_IOS",
+        "Display": DisplayAREGIOS(numberscan, kwargs["logPath"]),
+    })
+
+    return list_process
 
 
 class Auto_IOS(Method):
@@ -185,6 +255,23 @@ class Auto_IOS(Method):
     def getALIModelList(self):
         return super().getALIModelList()
 
+
+    def TestMGLModel(self, **kwargs) -> str:
+        """Validate what MGL needs instead of the palatal checkpoint."""
+        if kwargs.get("mgl_landmarks", "").strip():
+            folder = kwargs["mgl_landmarks"].strip()
+            if len(self.search(folder, ".json")[".json"]) == 0:
+                return "The MGL landmarks folder holds no json file\n"
+            return ""
+
+        if kwargs["model_folder_3"] == "":
+            return "Please select the ALI models folder holding the MGL model\n"
+        if not [f for f in self.search(kwargs["model_folder_3"], ".pth")[".pth"]
+                if os.path.basename(f).split("_")[1:2] == ["MG"]]:
+            return ('No MGL model found in the models folder, a file named '
+                    '"Lower_MG_*.pth" is expected\n')
+        return ""
+
     def TestProcess(self, **kwargs) -> str:
         out = ""
 
@@ -202,7 +289,10 @@ class Auto_IOS(Method):
         if kwargs["model_folder_1"] == "":
             out = out + "Please select folder for the registration model\n"
 
-        if len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
+        if kwargs.get("reg_type") == "MGL":
+            out = out + self.TestMGLModel(**kwargs)
+
+        elif len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
             out = (
                 out + "Please select folder with only one model for the registration\n"
             )
@@ -398,6 +488,32 @@ class Auto_IOS(Method):
         numberscan = self.NumberScan(
             kwargs["input_t1_folder"], kwargs["input_t2_folder"]
         )
+
+        if kwargs.get("reg_type") == "MGL":
+            # The mucogingival band needs the teeth segmentation, not the palatal
+            # orientation: the landmarks carry the pose the patch is built on.
+            mgl_kwargs = dict(kwargs)
+            mgl_kwargs["input_t1_folder"] = path_seg_T1
+            mgl_kwargs["input_t2_folder"] = path_seg_T2
+            return [
+                {
+                    "Process": SegProcess,
+                    "Parameter": parameter_segteeth_T1,
+                    "Module": "CrownSegmentationcli T1",
+                    "Display": DisplayCrownSeg(
+                        number_scan_toseg_T1, kwargs["logPath"], "T1 Scan"
+                    ),
+                },
+                {
+                    "Process": SegProcess,
+                    "Parameter": parameter_segteeth_T2,
+                    "Module": "CrownSegmentationcli T2",
+                    "Display": DisplayCrownSeg(
+                        number_scan_toseg_T2, kwargs["logPath"], "T2 Scan"
+                    ),
+                },
+            ] + MGLProcess(self, numberscan, "Auto_IOS", **mgl_kwargs)
+
         list_process = [
             {
                 "Process": SegProcess,
@@ -456,13 +572,17 @@ class Semi_IOS(Auto_IOS):
         if kwargs["folder_output"] == "":
             out = out + "Please select output folder\n"
 
-        if kwargs["model_folder_3"] == "":
-            out = out + "Please select folder for the registration model\n"
+        if kwargs.get("reg_type") == "MGL":
+            out = out + self.TestMGLModel(**kwargs)
 
-        if len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
-            out = (
-                out + "Please select folder with only one model for the registration\n"
-            )
+        else:
+            if kwargs["model_folder_3"] == "":
+                out = out + "Please select folder for the registration model\n"
+
+            if len(self.search(kwargs["model_folder_3"], ".ckpt")[".ckpt"]) != 1:
+                out = (
+                    out + "Please select folder with only one model for the registration\n"
+                )
 
         if out != "":
             out = out[:-1]
@@ -472,6 +592,13 @@ class Semi_IOS(Auto_IOS):
         return out
 
     def Process(self, **kwargs):
+
+        numberscan = self.NumberScan(
+            kwargs["input_t1_folder"], kwargs["input_t2_folder"]
+        )
+
+        if kwargs.get("reg_type") == "MGL":
+            return MGLProcess(self, numberscan, "Semi_IOS", **kwargs)
 
         parameter_reg = {
             "T1": kwargs["input_t1_folder"],
@@ -485,9 +612,6 @@ class Semi_IOS(Auto_IOS):
 
         logger.info(f"Parameter AREG_IOS: {parameter_reg}")
         RegProcess = slicer.modules.areg_ios
-        numberscan = self.NumberScan(
-            kwargs["input_t1_folder"], kwargs["input_t2_folder"]
-        )
         processus = [
             {
                 "Process": RegProcess,

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -40,6 +40,10 @@ def MGLProcess(method, numberscan, areg_mode, **kwargs):
     landmarks_folder = kwargs.get("mgl_landmarks", "").strip()
     predict = not landmarks_folder
 
+    # MGL works on the mandibles, so the progress must count those, not the
+    # maxillae numberscan reports.
+    numberscan = method.NumberScanLower(kwargs["input_t1_folder"], kwargs["input_t2_folder"])
+
     if predict:
         landmarks_folder = os.path.join(slicer.util.tempDirectory(), "MGL_landmarks")
         os.makedirs(landmarks_folder, exist_ok=True)
@@ -109,6 +113,16 @@ class Auto_IOS(Method):
                 count += 1
 
         return len(all_files) - count
+
+    def NumberScanLower(self, scan_folder_t1: str, scan_folder_t2: str):
+        """Count the lower scans, which are the ones MGL registers.
+
+        NumberScan counts the upper arches, since the palatal registration works
+        on the maxilla. A folder holding only mandibles would count zero there.
+        """
+        files = self.search(scan_folder_t1, ".vtk", ".stl")
+        all_files = files[".vtk"] + files[".stl"]
+        return sum(1 for f in all_files if self.IsLower([f]))
 
     def IsLower(self, folder_path_or_file_list):
         words_lower = ["lower", "_l", "l_", "mandibule", "md"]

--- a/AREG/AREG_Method/IOSCBCT.py
+++ b/AREG/AREG_Method/IOSCBCT.py
@@ -315,11 +315,13 @@ class Semi_IOSCBCT(IOSCBCT):
         ios_landmarks_folder_path = os.path.join(kwargs["folder_output"],"IOS Landmarks")
         os.makedirs(ios_landmarks_folder_path, exist_ok=True)
 
+        # Key order matters: the values are passed positionally to the ALI_IOS CLI
         parameter_ali_ios = {
             "input": seg_ios_folder_path,
             "dir_models": kwargs["model_folder_3"],
             "lm_type": "'O'",
             "teeth": "LL1 LL3 LL6 LR1 LR3 LR6 UL1 UL3 UL6 UR1 UR3 UR6'",
+            "teeth_mg": "None",
             "output_dir": ios_landmarks_folder_path,
             "image_size": "224",
             "blur_radius": "0",
@@ -775,11 +777,13 @@ class Auto_IOSCBCT(IOSCBCT):
         ios_landmarks_folder_path = os.path.join(kwargs["folder_output"],"IOS Landmarks")
         os.makedirs(ios_landmarks_folder_path, exist_ok=True)
 
+        # Key order matters: the values are passed positionally to the ALI_IOS CLI
         parameter_ali_ios = {
             "input": pre_aso_ios_folder_path,
             "dir_models": kwargs["model_folder_3"],
             "lm_type": "'O'",
             "teeth": "LL1 LL3 LL6 LR1 LR3 LR6 UL1 UL3 UL6 UR1 UR3 UR6'",
+            "teeth_mg": "None",
             "output_dir": ios_landmarks_folder_path,
             "image_size": "224",
             "blur_radius": "0",

--- a/AREG_IOS/AREG_IOS.py
+++ b/AREG_IOS/AREG_IOS.py
@@ -62,7 +62,7 @@ if check_platform()=="WSL":
     from AREG_IOS_utils.utils import WriteSurf, ReadSurf, LoadJsonLandmarks
     from AREG_IOS_utils.transformation import TransformSurf
     from AREG_IOS.AREG_IOS_utils.transformation import saveMatrixAsTfm
-    from AREG_IOS_utils.mgl_patch import MGLPatch, DEFAULT_RADIUS
+    from AREG_IOS_utils.mgl_patch import MGLPatch, DEFAULT_RADIUS, MGL_ARRAY_NAME
 
 else :
     from AREG_IOS_utils import (
@@ -79,6 +79,7 @@ else :
         saveMatrixAsTfm,
         MGLPatch,
         DEFAULT_RADIUS,
+        MGL_ARRAY_NAME,
     )
 
 
@@ -183,9 +184,12 @@ def main(args):
         # ===== MGL MODE =====
         # The lower patch comes from the landmarks, so neither the palatal model
         # nor the upper arches are involved, and the dataset of upper pairs is
-        # not built at all: the input may hold lower scans only.
+        # not built at all: the input may hold lower scans only. Its patch lives
+        # in its own array, so the ICP is pointed at that one.
         if args.reg_type == "MGL":
-            RunMGL(args, icp)
+            mgl_icp = ICP([vtkICP()],
+                          option=vtkMeshTeeth(list_teeth=[1], property=MGL_ARRAY_NAME))
+            RunMGL(args, mgl_icp)
             return
 
         # ===== DATASET INITIALIZATION =====

--- a/AREG_IOS/AREG_IOS.py
+++ b/AREG_IOS/AREG_IOS.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import glob
 import shutil
 import argparse
 import platform
@@ -53,26 +54,100 @@ def check_platform():
         return "Unknown"
 
 if check_platform()=="WSL":
-    from AREG_IOS_utils.dataset import DatasetPatch
+    from AREG_IOS_utils.dataset import DatasetPatch, SortLower
     from AREG_IOS_utils.PredPatch import PredPatch
     from AREG_IOS_utils.vtkSegTeeth import vtkMeshTeeth
     from AREG_IOS_utils.ICP import vtkICP
     from AREG_IOS_utils.ICP import ICP
-    from AREG_IOS_utils.utils import WriteSurf
+    from AREG_IOS_utils.utils import WriteSurf, ReadSurf, LoadJsonLandmarks
     from AREG_IOS_utils.transformation import TransformSurf
     from AREG_IOS.AREG_IOS_utils.transformation import saveMatrixAsTfm
+    from AREG_IOS_utils.mgl_patch import MGLPatch, DEFAULT_RADIUS
 
-else : 
+else :
     from AREG_IOS_utils import (
         DatasetPatch,
+        SortLower,
         PredPatch,
         vtkMeshTeeth,
         vtkICP,
         ICP,
         WriteSurf,
+        ReadSurf,
+        LoadJsonLandmarks,
         TransformSurf,
         saveMatrixAsTfm,
+        MGLPatch,
+        DEFAULT_RADIUS,
     )
+
+
+def FindLandmarkFile(folder, surf_path):
+    """Locate the MG landmark json that goes with `surf_path`.
+
+    ALI_IOS names its output '<scan>_Lower_MG_Pred.json', which is tried first;
+    a folder produced by hand is then searched for any json carrying the scan
+    name, so users are not forced into that convention.
+    """
+    stem = os.path.splitext(os.path.basename(surf_path))[0]
+
+    expected = os.path.join(folder, f"{stem}_Lower_MG_Pred.json")
+    if os.path.isfile(expected):
+        return expected
+
+    candidates = sorted(f for f in glob.glob(os.path.join(folder, "*.json"))
+                        if stem in os.path.basename(f))
+    if candidates:
+        if len(candidates) > 1:
+            logger.warning(f"Several landmark files match {stem}, using {os.path.basename(candidates[0])}")
+        return candidates[0]
+
+    raise FileNotFoundError(f"No MG landmark json found for {stem} in {folder}")
+
+
+def RunMGL(args, icp):
+    """Register the lower arches on the band around the mucogingival line.
+
+    Mirrors the palatal flow: a stable region is painted on both timepoints,
+    the ICP runs on that region only, and T2 is written transformed. The upper
+    arches are left untouched, the MG model covering the mandible only.
+    """
+    pairs = SortLower(args.T1, args.T2)
+    if not pairs:
+        raise ValueError("MGL registration needs lower arches, none were paired between the input folders")
+
+    logger.info(f"MGL registration on {len(pairs)} lower pair(s), patch radius {args.patch_radius} mm")
+
+    processed, failed = 0, []
+    for idx, pair in enumerate(pairs):
+        context = f"sample {idx + 1}/{len(pairs)}"
+        try:
+            surfaces = {}
+            for time in ("T1", "T2"):
+                surf = ReadSurf(pair[time])
+                folder = args.lm_T1 if time == "T1" else args.lm_T2
+                landmarks = LoadJsonLandmarks(FindLandmarkFile(folder, pair[time]))
+                surfaces[time] = MGLPatch(surf, landmarks, radius=args.patch_radius)
+
+            output_icp = icp.run(surfaces["T2"], surfaces["T1"])
+
+            WriteSurf(surfaces["T1"], args.output, os.path.basename(pair["T1"]), args.suffix)
+            WriteSurf(output_icp["source_Or"], args.output,
+                      os.path.basename(pair["T2"]), args.suffix)
+
+            with open(args.log_path, "w") as log_f:
+                log_f.write(str(idx + 1))
+
+            processed += 1
+            logger.info(f"Successfully processed {context}")
+        except Exception as e:
+            logger.error(f"Failed to process {context}: {e}")
+            failed.append((idx, str(e)))
+            continue
+
+    logger.info(f"MGL registration completed: {processed}/{len(pairs)} pair(s) processed successfully")
+    for idx, error in failed:
+        logger.warning(f"  Pair {idx}: {error}")
 
 
 def main(args):
@@ -94,6 +169,25 @@ def main(args):
             logger.error(f"Error setting up log file: {e}")
             raise
 
+        # ===== REGISTRATION SETUP =====
+        try:
+            logger.debug("Initializing registration method (vtkICP)")
+            Method = [vtkICP()]
+            option = vtkMeshTeeth(list_teeth=[1], property="Butterfly")
+            icp = ICP(Method, option=option)
+            logger.debug("Registration method initialized")
+        except Exception as e:
+            logger.error(f"Error initializing registration method: {e}")
+            raise
+
+        # ===== MGL MODE =====
+        # The lower patch comes from the landmarks, so neither the palatal model
+        # nor the upper arches are involved, and the dataset of upper pairs is
+        # not built at all: the input may hold lower scans only.
+        if args.reg_type == "MGL":
+            RunMGL(args, icp)
+            return
+
         # ===== DATASET INITIALIZATION =====
         try:
             logger.debug(f"Loading dataset from T1: {args.T1}, T2: {args.T2}")
@@ -112,17 +206,6 @@ def main(args):
             logger.debug("Prediction model loaded")
         except Exception as e:
             logger.error(f"Error loading prediction model: {e}")
-            raise
-
-        # ===== REGISTRATION SETUP =====
-        try:
-            logger.debug("Initializing registration method (vtkICP)")
-            Method = [vtkICP()]
-            option = vtkMeshTeeth(list_teeth=[1], property="Butterfly")
-            icp = ICP(Method, option=option)
-            logger.debug("Registration method initialized")
-        except Exception as e:
-            logger.error(f"Error initializing registration method: {e}")
             raise
 
         # ===== CHECK DENTITION TYPE =====
@@ -312,6 +395,17 @@ if __name__ == "__main__":
             parser.add_argument("suffix", type=str)
             parser.add_argument("log_path", type=str)
             parser.add_argument("areg_mode", type=str)
+            # Appended after the historical arguments so the positional order
+            # the GUI relies on stays valid.
+            parser.add_argument("reg_type", type=str, nargs="?", default="Butterfly",
+                                help="'Butterfly' (palatal patch, upper arch) or "
+                                     "'MGL' (band along the mucogingival line, lower arch)")
+            parser.add_argument("patch_radius", type=float, nargs="?", default=DEFAULT_RADIUS,
+                                help="MGL only: half-height of the band around the curve, in mm")
+            parser.add_argument("lm_T1", type=str, nargs="?", default="None",
+                                help="MGL only: folder holding the T1 MG landmark json files")
+            parser.add_argument("lm_T2", type=str, nargs="?", default="None",
+                                help="MGL only: folder holding the T2 MG landmark json files")
 
             args = parser.parse_args()
             logger.debug(f"Arguments parsed successfully: T1={args.T1}, T2={args.T2}")

--- a/AREG_IOS/AREG_IOS_utils/__init__.py
+++ b/AREG_IOS/AREG_IOS_utils/__init__.py
@@ -5,4 +5,4 @@ from .vtkSegTeeth import vtkMeshTeeth
 from .ICP import ICP, vtkICP
 from .utils import WriteSurf, ReadSurf, LoadJsonLandmarks
 from .transformation import TransformSurf, saveMatrixAsTfm
-from .mgl_patch import MGLPatch, DEFAULT_RADIUS
+from .mgl_patch import MGLPatch, DEFAULT_RADIUS, MGL_ARRAY_NAME

--- a/AREG_IOS/AREG_IOS_utils/__init__.py
+++ b/AREG_IOS/AREG_IOS_utils/__init__.py
@@ -1,7 +1,8 @@
-from .dataset import DatasetPatch
+from .dataset import DatasetPatch, SortLower
 from .net import MonaiUNetHRes
 from .PredPatch import PredPatch
 from .vtkSegTeeth import vtkMeshTeeth
 from .ICP import ICP, vtkICP
-from .utils import WriteSurf
+from .utils import WriteSurf, ReadSurf, LoadJsonLandmarks
 from .transformation import TransformSurf, saveMatrixAsTfm
+from .mgl_patch import MGLPatch, DEFAULT_RADIUS

--- a/AREG_IOS/AREG_IOS_utils/dataset.py
+++ b/AREG_IOS/AREG_IOS_utils/dataset.py
@@ -170,6 +170,27 @@ def Sort(T1: str, T2: str) -> tuple[list, list]:
     return list_reg_Upper, list_reg_Lower
 
 
+def SortLower(T1: str, T2: str) -> list:
+    """Pair the lower scans of two folders, whether or not upper scans are there.
+
+    Sort() only keeps a lower pair when the matching upper pair exists, since
+    the palatal registration always starts from the maxilla. The MGL
+    registration works on the mandible alone, so it pairs the lower files on
+    their own.
+
+    Returns:
+        list[dict]: [{'T1': 'path/P1_LowerT1.vtk', 'T2': 'path/P1_LowerT2.vtk'}, ...]
+    """
+    surface_extensions = ('.vtk', '.vtp', '.stl', '.obj')
+
+    def lower_files(folder):
+        files = [f for f in glob.glob(os.path.join(folder, "*"))
+                 if f.lower().endswith(surface_extensions)]
+        return [f for f in files if not isLowerUpper(f, choice="Upper")]
+
+    return sort(lower_files(T1), lower_files(T2))
+
+
 def insideLower(list_files: list) -> bool:
     """Check if there are lower archer in list of file
 

--- a/AREG_IOS/AREG_IOS_utils/mgl_patch.py
+++ b/AREG_IOS/AREG_IOS_utils/mgl_patch.py
@@ -1,0 +1,212 @@
+# Build the registration patch of the lower arch from the mucogingival (MGL)
+# landmarks predicted by ALI_IOS.
+#
+# The upper arch uses a patch painted by a neural network on the palate. The
+# mandible has no such stable plateau, but it has the mucogingival line: the
+# 13 MG landmarks run along the arch and can be joined into a smooth curve. The
+# band of surface around that curve plays the same role as the palatal patch,
+# and is written into the very same "Butterfly" point array so the registration
+# code downstream does not change.
+#
+# Two properties matter for the result to be usable:
+#   - every sample of the curve is snapped onto the mesh, because a curve
+#     interpolated between landmarks floats off the surface in the concavities
+#     between teeth;
+#   - the band grows along the surface (geodesic), never through it, so a
+#     buccal patch cannot leak onto the lingual side where the ridge is thin.
+import heapq
+import logging
+import sys
+
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
+
+# --- LOGGING CONFIGURATION ---
+logger = logging.getLogger("AREG_IOS_MGL")
+logger.setLevel(logging.INFO)
+logger.propagate = False
+if logger.handlers:
+    logger.handlers.clear()
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno)d) - %(message)s')
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
+
+# Landmark names of the MG model, in arch order. L0MG is the midline (tooth 25),
+# so the right side is shifted by one against the tooth numbers.
+MGL_ORDER = ['LL6MG', 'LL5MG', 'LL4MG', 'LL3MG', 'LL2MG', 'LL1MG', 'L0MG',
+             'LR1MG', 'LR2MG', 'LR3MG', 'LR4MG', 'LR5MG', 'LR6MG']
+
+# Names written by predictions made before the MG suffix was added.
+MGL_ORDER_LEGACY = [name[:-2] for name in MGL_ORDER]
+
+DEFAULT_RADIUS = 5.0        # mm, half-height of the band around the curve
+DEFAULT_SAMPLES = 300       # samples along the spline
+
+# Universal_ID labels of the lower teeth. The gingiva carries its own label, so
+# the patch can be kept off the crowns, which are the structures that move
+# between the two timepoints and must not drive the registration.
+LOWER_TOOTH_LABELS = range(18, 32)
+
+
+def OrderedMGLandmarks(landmarks):
+    """Return the MG landmark positions in arch order, as an (N, 3) array.
+
+    Accepts both the current names (LL6MG...) and the older suffix-less ones,
+    and tolerates missing teeth: a scan where ALI could not place every point
+    still yields a usable curve, as long as three points remain.
+    """
+    for order in (MGL_ORDER, MGL_ORDER_LEGACY):
+        points = [np.asarray(landmarks[name], dtype=float)
+                  for name in order if name in landmarks]
+        if len(points) >= 3:
+            missing = [name for name in order if name not in landmarks]
+            if missing:
+                logger.warning(f"MG landmarks missing from the prediction: {missing}")
+            return np.array(points)
+
+    raise ValueError(
+        "Fewer than 3 MG landmarks found. Expected names such as "
+        f"{MGL_ORDER[:3]}, got {sorted(landmarks)}"
+    )
+
+
+def SplineThroughLandmarks(points, n_samples=DEFAULT_SAMPLES):
+    """Sample a B-spline passing through `points`, as an (n_samples, 3) array.
+
+    The landmarks are sparse (one per tooth), so the curve between them is an
+    interpolation, not a measurement: it is only used to place the band.
+    """
+    vtk_points = vtk.vtkPoints()
+    for point in points:
+        vtk_points.InsertNextPoint(*point)
+
+    spline = vtk.vtkParametricSpline()
+    spline.SetPoints(vtk_points)
+    spline.ClosedOff()
+
+    source = vtk.vtkParametricFunctionSource()
+    source.SetParametricFunction(spline)
+    source.SetUResolution(n_samples)
+    source.Update()
+
+    return vtk_to_numpy(source.GetOutput().GetPoints().GetData())
+
+
+def SnapToSurface(surf, samples):
+    """Return, for each sample, the id of the closest vertex of `surf`.
+
+    A spline drawn through landmarks that sit on the surface still leaves it
+    between them, so the samples are snapped back before growing the band.
+    Duplicate ids are removed: consecutive samples often land on one vertex.
+    """
+    locator = vtk.vtkPointLocator()
+    locator.SetDataSet(surf)
+    locator.BuildLocator()
+
+    seeds = []
+    for sample in samples:
+        seeds.append(locator.FindClosestPoint(sample))
+    return sorted(set(seeds))
+
+
+def _adjacency(surf):
+    """Neighbour ids of every vertex, from the mesh edges."""
+    surf.BuildLinks()
+    n_points = surf.GetNumberOfPoints()
+    neighbours = [set() for _ in range(n_points)]
+
+    cell_points = vtk.vtkIdList()
+    for cell_id in range(surf.GetNumberOfCells()):
+        surf.GetCellPoints(cell_id, cell_points)
+        ids = [cell_points.GetId(i) for i in range(cell_points.GetNumberOfIds())]
+        for a in ids:
+            for b in ids:
+                if a != b:
+                    neighbours[a].add(b)
+    return neighbours
+
+
+def GrowBand(surf, seeds, radius):
+    """Vertices within `radius` mm of a seed, measured along the surface.
+
+    Growing along the mesh rather than through space is what keeps the band on
+    the buccal side: a straight-line radius of a few millimetres would reach the
+    lingual surface wherever the ridge is thinner than that.
+    """
+    points = vtk_to_numpy(surf.GetPoints().GetData())
+    neighbours = _adjacency(surf)
+
+    distance = np.full(surf.GetNumberOfPoints(), np.inf)
+    queue = []
+    for seed in seeds:
+        distance[seed] = 0.0
+        heapq.heappush(queue, (0.0, seed))
+
+    while queue:
+        dist, point_id = heapq.heappop(queue)
+        if dist > distance[point_id]:
+            continue
+        for neighbour in neighbours[point_id]:
+            step = float(np.linalg.norm(points[neighbour] - points[point_id]))
+            new_dist = dist + step
+            if new_dist < distance[neighbour] and new_dist <= radius:
+                distance[neighbour] = new_dist
+                heapq.heappush(queue, (new_dist, neighbour))
+
+    return distance <= radius
+
+
+def _tooth_mask(surf):
+    """True where a vertex belongs to a tooth crown, False on the gingiva.
+
+    All-False when the mesh carries no segmentation, so the caller keeps the
+    whole band rather than losing the patch.
+    """
+    scalars = None
+    for name in ("Universal_ID", "PredictedID", "UniversalID"):
+        scalars = surf.GetPointData().GetScalars(name) or surf.GetPointData().GetArray(name)
+        if scalars is not None:
+            break
+
+    if scalars is None:
+        logger.warning("No teeth segmentation on the mesh, the patch is not kept off the crowns")
+        return np.zeros(surf.GetNumberOfPoints(), dtype=bool)
+
+    labels = vtk_to_numpy(scalars)
+    return np.isin(labels, list(LOWER_TOOTH_LABELS))
+
+
+def MGLPatch(surf, landmarks, radius=DEFAULT_RADIUS, n_samples=DEFAULT_SAMPLES,
+             array_name="Butterfly", exclude_teeth=True):
+    """Paint the band around the mucogingival line into `array_name`.
+
+    Writes the same 0/1 point array the palatal patch uses, so the registration
+    reads it without knowing which arch produced it. Returns the surface.
+    """
+    points = OrderedMGLandmarks(landmarks)
+    logger.info(f"Building the MGL patch from {len(points)} landmark(s), radius {radius} mm")
+
+    samples = SplineThroughLandmarks(points, n_samples)
+    seeds = SnapToSurface(surf, samples)
+    logger.debug(f"{len(samples)} spline sample(s) snapped onto {len(seeds)} vertex(es)")
+
+    inside = GrowBand(surf, seeds, radius)
+
+    if exclude_teeth:
+        on_teeth = _tooth_mask(surf) & inside
+        if on_teeth.any():
+            logger.info(f"Dropping {int(on_teeth.sum())} vertex(es) of the band that reached the crowns")
+            inside = inside & ~on_teeth
+
+    n_inside = int(inside.sum())
+    if n_inside == 0:
+        raise ValueError("The MGL patch is empty, the landmarks may not belong to this scan")
+    logger.info(f"MGL patch: {n_inside} vertex(es) out of {surf.GetNumberOfPoints()}")
+
+    array = numpy_to_vtk(inside.astype(np.int64))
+    array.SetName(array_name)
+    surf.GetPointData().AddArray(array)
+    return surf

--- a/AREG_IOS/AREG_IOS_utils/mgl_patch.py
+++ b/AREG_IOS/AREG_IOS_utils/mgl_patch.py
@@ -193,6 +193,9 @@ def MGLPatch(surf, landmarks, radius=DEFAULT_RADIUS, n_samples=DEFAULT_SAMPLES,
     """
     points = OrderedMGLandmarks(landmarks)
     logger.info(f"Building the MGL patch from {len(points)} landmark(s), radius {radius} mm")
+    if radius == 0:
+        logger.info("Radius 0: the patch is the snapped curve itself, the "
+                    "registration will run on the mucogingival line only")
 
     samples = SplineThroughLandmarks(points, n_samples)
     seeds = SnapToSurface(surf, samples)

--- a/AREG_IOS/AREG_IOS_utils/mgl_patch.py
+++ b/AREG_IOS/AREG_IOS_utils/mgl_patch.py
@@ -5,8 +5,8 @@
 # mandible has no such stable plateau, but it has the mucogingival line: the
 # 13 MG landmarks run along the arch and can be joined into a smooth curve. The
 # band of surface around that curve plays the same role as the palatal patch,
-# and is written into the very same "Butterfly" point array so the registration
-# code downstream does not change.
+# and is written as a 0/1 point array of the same shape, under its own name so
+# a mandible is never labelled after the palate.
 #
 # Two properties matter for the result to be usable:
 #   - every sample of the curve is snapped onto the mesh, because a curve
@@ -41,6 +41,11 @@ MGL_ORDER = ['LL6MG', 'LL5MG', 'LL4MG', 'LL3MG', 'LL2MG', 'LL1MG', 'L0MG',
 
 # Names written by predictions made before the MG suffix was added.
 MGL_ORDER_LEGACY = [name[:-2] for name in MGL_ORDER]
+
+# Name of the point array the patch is written to. The palatal patch is called
+# "Butterfly" after its shape; the band along the mucogingival line is neither
+# butterfly-shaped nor on the same arch, so it carries its own name.
+MGL_ARRAY_NAME = "Bottom_MGL"
 
 DEFAULT_RADIUS = 5.0        # mm, half-height of the band around the curve
 DEFAULT_SAMPLES = 300       # samples along the spline
@@ -180,11 +185,11 @@ def _tooth_mask(surf):
 
 
 def MGLPatch(surf, landmarks, radius=DEFAULT_RADIUS, n_samples=DEFAULT_SAMPLES,
-             array_name="Butterfly", exclude_teeth=True):
+             array_name=MGL_ARRAY_NAME, exclude_teeth=True):
     """Paint the band around the mucogingival line into `array_name`.
 
-    Writes the same 0/1 point array the palatal patch uses, so the registration
-    reads it without knowing which arch produced it. Returns the surface.
+    Writes a 0/1 point array shaped like the palatal one, so the registration
+    reads it the same way, under a name that says what it is. Returns the surface.
     """
     points = OrderedMGLandmarks(landmarks)
     logger.info(f"Building the MGL patch from {len(points)} landmark(s), radius {radius} mm")

--- a/AREG_IOS/CMakeLists.txt
+++ b/AREG_IOS/CMakeLists.txt
@@ -9,6 +9,7 @@ set(FOLDER_LIBRARY AREG_IOS_utils)
 
 set(MODULE_PYTHON_SCRIPTS
   ${FOLDER_LIBRARY}/__init__.py
+  ${FOLDER_LIBRARY}/check_deps.py
   ${FOLDER_LIBRARY}/dataset.py
   ${FOLDER_LIBRARY}/ICP.py
   ${FOLDER_LIBRARY}/mgl_patch.py

--- a/AREG_IOS/CMakeLists.txt
+++ b/AREG_IOS/CMakeLists.txt
@@ -11,6 +11,7 @@ set(MODULE_PYTHON_SCRIPTS
   ${FOLDER_LIBRARY}/__init__.py
   ${FOLDER_LIBRARY}/dataset.py
   ${FOLDER_LIBRARY}/ICP.py
+  ${FOLDER_LIBRARY}/mgl_patch.py
   ${FOLDER_LIBRARY}/net.py
   ${FOLDER_LIBRARY}/orientation.py
   ${FOLDER_LIBRARY}/post_process.py

--- a/FlexReg/CMakeLists.txt
+++ b/FlexReg/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_RESOURCES
 set(MODULE_PYTHON_SCRIPTS
   ${MODULE_NAME}.py
   FlexReg_utils/__init__.py
+  FlexReg_utils/butterfly_preview.py
   FlexReg_utils/install_pytorch.py
   FlexReg_utils/orientation.py
   FlexReg_utils/transform.py

--- a/FlexReg/CMakeLists.txt
+++ b/FlexReg/CMakeLists.txt
@@ -15,6 +15,7 @@ set(MODULE_PYTHON_SCRIPTS
   FlexReg_utils/__init__.py
   FlexReg_utils/butterfly_preview.py
   FlexReg_utils/install_pytorch.py
+  FlexReg_utils/mgl_patch.py
   FlexReg_utils/orientation.py
   FlexReg_utils/transform.py
   FlexReg_utils/util.py

--- a/FlexReg/FlexReg.py
+++ b/FlexReg/FlexReg.py
@@ -15,6 +15,7 @@ from qt import (
     QStackedWidget,
     QComboBox,
     QPushButton,
+    QSlider,
     QFileDialog,
     QSpinBox,
     QWidget,
@@ -67,7 +68,7 @@ from FlexReg_utils.orientation import orientation_f
 from FlexReg_utils.butterfly_preview import ButterflyPreview, ADJUST_SIGN
 from FlexReg_utils.mgl_patch import (
     MGLPatchBuilder, MGL_ARRAY_NAME, MGL_PREVIEW_ARRAY_NAME, MGL_ORDER,
-    DEFAULT_HEIGHT, MIN_HEIGHT, MAX_HEIGHT, ReadLandmarks,
+    DEFAULT_HEIGHT, MIN_HEIGHT, MAX_HEIGHT, ReadLandmarks, WriteLandmarks,
 )
 
 # Travel of the joystick pads along the antero-posterior axis, in mm. Typing a
@@ -315,6 +316,15 @@ class FlexRegWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         self.initializeParameterNode()
 
+        # One arch for the whole registration : both scans are the same jaw,
+        # so the choice is made once here instead of once per scan.
+        row_arch = QHBoxLayout()
+        row_arch.addWidget(QLabel('Arch :'))
+        self.combobox_arch = QComboBox()
+        self.combobox_arch.addItems(['Upper arch (palate)', 'Lower arch (MGL)'])
+        self.combobox_arch.activated.connect(self.onArchChanged)
+        row_arch.addWidget(self.combobox_arch)
+        self.ui.verticalLayout_2.insertLayout(0, row_arch)
 
         self.number_widget_scan = 0
         self.list_widget_scan = []
@@ -396,9 +406,14 @@ class FlexRegWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.number_widget_scan -= 1
 
         self.reg.setT1T2(self.list_widget_scan[0],self.list_widget_scan[1])
-        
-        
-        
+
+    def isLowerArch(self):
+        return self.combobox_arch.currentIndex == 1
+
+    def onArchChanged(self, _index=None):
+        '''The arch selector at the top drives every scan panel at once.'''
+        for widget in self.list_widget_scan:
+            widget.setArch(self.isLowerArch())
 
 
     def removeWidgetScan(self):
@@ -417,6 +432,7 @@ class FlexRegWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         '''
         self.list_widget_scan.append(
             WidgetParameter(self.ui.verticalLayout_2,self.parent,title,self.list_widget_scan))
+        self.list_widget_scan[-1].setArch(self.isLowerArch())
 
     def openFinder(self,nom : str,_) -> None : 
         """
@@ -958,8 +974,8 @@ class FlexRegLogic(ScriptedLoadableModuleLogic):
         
     def setup_cli_command(self):
         args = self.find_cli_parameters()
-        conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-m", f"FlexReg_CLI"]
+        # condaRunCommand already wraps everything in `conda run -n <env>`
+        command = ["python", "-m", "FlexReg_CLI"]
         for arg in args :
             command.append("\""+arg+"\"")
 
@@ -1039,8 +1055,8 @@ class FlexRegLogic(ScriptedLoadableModuleLogic):
         if not self.check_pythonpath_windows("ALI_IOS"):
             self.give_pythonpath_windows()
 
-        conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python", "-m", "ALI_IOS"]
+        # condaRunCommand already wraps everything in `conda run -n <env>`
+        command = ["python", "-m", "ALI_IOS"]
         for argument in arguments:
             value = argument
             if isinstance(value, str) and ("\\" in value or (len(value) > 1 and value[1] == ":")):
@@ -1293,7 +1309,9 @@ class Reg:
 
         # Launch pop up with time
         if not hasattr(self, "timerDialog"):
-            self.timerDialog = TimerDialog()
+            # Parented to the main window so it stays on top of Slicer and is
+            # repainted with it, instead of floating as a separate window.
+            self.timerDialog = TimerDialog(slicer.util.mainWindow())
             self.timerDialog.show()
             self.timerDialog.startTimer()
 
@@ -1475,8 +1493,13 @@ class JoystickPad(QWidget):
     FINE = 0.2       # sensitivity multiplier while Ctrl is held
 
     def __init__(self, outward_right=True, adjust_range=5.0, size=None, adjust_sign=1.0,
-                 ratio_range=(0.0, 1.0), side_labels=None, parent=None):
+                 ratio_range=(0.0, 1.0), side_labels=None, spring_back=False, parent=None):
         QWidget.__init__(self, parent)
+        # A spring_back pad is relative : each drag deals out a displacement
+        # and the knob returns to the centre on release, so repeated pushes
+        # never saturate against the ends of the travel.
+        self.spring_back = bool(spring_back)
+        self.onReleased = None
         self.outward_right = outward_right
         self.adjust_range = adjust_range
         self.adjust_sign = float(adjust_sign)
@@ -1580,8 +1603,8 @@ class JoystickPad(QWidget):
         self._dragging = True
         self._anchor = None
         x, y = _eventPosition(event)
-        if self._isFine():
-            # Fine drag : hold the knob where it is and scale the motion down,
+        if self.spring_back or self._isFine():
+            # Relative drag : hold the knob where it is and move from there,
             # rather than jumping it under the cursor.
             self._anchor = ((x, y), self._knobPosition())
             return
@@ -1591,20 +1614,28 @@ class JoystickPad(QWidget):
         if not self._dragging:
             return
         x, y = _eventPosition(event)
-        if self._isFine():
+        if self.spring_back or self._isFine():
             if self._anchor is None:
                 # Ctrl pressed mid-drag : rebase so the knob does not jump.
                 self._anchor = ((x, y), self._knobPosition())
-            (anchor_x, anchor_y), (knob_x, knob_y) = self._anchor
-            x = knob_x + (x - anchor_x) * self.FINE
-            y = knob_y + (y - anchor_y) * self.FINE
         else:
             self._anchor = None
+        if self._anchor is not None:
+            (anchor_x, anchor_y), (knob_x, knob_y) = self._anchor
+            scale = self.FINE if self._isFine() else 1.0
+            x = knob_x + (x - anchor_x) * scale
+            y = knob_y + (y - anchor_y) * scale
         self.setValues(*self._valuesAt(x, y), notify=True)
 
     def mouseReleaseEvent(self, event):
         self._dragging = False
         self._anchor = None
+        if self.spring_back:
+            # The displacement has been dealt out : back to the centre,
+            # silently, ready for the next push.
+            self.setValues(self.default_ratio, self.default_adjust)
+            if self.onReleased:
+                self.onReleased(self)
 
     def setDefaults(self, ratio, adjust):
         '''Where a double-click sends the knob back to.'''
@@ -1646,6 +1677,11 @@ class JoystickPad(QWidget):
             self.setValues(self.ratio, self.adjust + 0.1 * self.adjust_sign, notify=True)
         elif key == Qt.Key_Down:
             self.setValues(self.ratio, self.adjust - 0.1 * self.adjust_sign, notify=True)
+        if self.spring_back:
+            # each key press is one nudge, dealt out then sprung back
+            self.setValues(self.default_ratio, self.default_adjust)
+            if self.onReleased:
+                self.onReleased(self)
 
     # ---- painting -------------------------------------------------------
 
@@ -1736,6 +1772,8 @@ class WidgetParameter:
         self.matrix = None
         self.title=title
         self.camera = True
+        # Which arch is registered; set from the module-level arch selector.
+        self.lower_arch = False
         # The live list of scan widgets, shared by all of them, so the Copy
         # button can read the values of the one above. It is still being filled
         # while this one is built, hence the lookup at click time.
@@ -1748,6 +1786,10 @@ class WidgetParameter:
         self.fields = {}
         self.preview = ButterflyPreview()
         self.preview_node = None
+        # Touched by handleStackedWidgetChange, which fires as soon as the
+        # first page is inserted -- before setupMGL has run.
+        self.mgl_markups_node = None
+        self.mgl_names = []
         self.preview_dirty = False
         self._syncing = False
         self.preview_timer = QTimer()
@@ -1782,14 +1824,23 @@ class WidgetParameter:
         self.lineedit = QLineEdit()
         self.button_select_scan = QPushButton('Select')
         self.button_select_scan.pressed.connect(self.selectFile)
-        
+
+        self.button_scene = QPushButton('Scene')
+        self.button_scene.setToolTip(
+            'Use a model already loaded in the scene instead of browsing for '
+            'its file. Its own file is used when it has one; otherwise a .vtk '
+            'copy is written. The original model is hidden while FlexReg '
+            'shows its own centered copy of it.')
+        self.button_scene.pressed.connect(self.selectSceneModel)
+
         self.button_test_file = QPushButton('TestFile')
         self.button_test_file.pressed.connect(self.testFile)
-        
+
 
         self.layout_file.addWidget(self.label_1)
         self.layout_file.addWidget(self.lineedit)
         self.layout_file.addWidget(self.button_select_scan)
+        self.layout_file.addWidget(self.button_scene)
         self.layout_file.addWidget(self.button_test_file)
 
         widgetView = QWidget()
@@ -1799,13 +1850,6 @@ class WidgetParameter:
         self.layoutView.addWidget(self.button_view)
         layout.addWidget(widgetView)
         
-
-        # Which arch is registered, and therefore which stable region is drawn:
-        # the palate above, the band along the mucogingival line below.
-        self.combobox_arch = QComboBox()
-        self.combobox_arch.addItems(['Upper arch (palate)', 'Lower arch (MGL)'])
-        self.combobox_arch.activated.connect(self.changeArch)
-        layout.addWidget(self.combobox_arch)
 
         self.combobox_choice_method = QComboBox()
         self.combobox_choice_method.addItems(['Parameter','Landmark'])
@@ -1972,11 +2016,15 @@ class WidgetParameter:
         self.mgl_builder = MGLPatchBuilder()
         self.mgl_landmarks = None
         self.mgl_names = []
-        self.mgl_buccal = np.zeros(len(MGL_ORDER))
+        # Horizontal pad axis : slide along the mucogingival line (towards
+        # LL6 or LR6). Vertical : towards the crown or the vestibule.
+        self.mgl_tangent = np.zeros(len(MGL_ORDER))
         self.mgl_apical = np.zeros(len(MGL_ORDER))
-        self.mgl_heights = np.full(len(MGL_ORDER), DEFAULT_HEIGHT)
+        self.mgl_heights_up = np.full(len(MGL_ORDER), DEFAULT_HEIGHT)
+        self.mgl_heights_down = np.full(len(MGL_ORDER), DEFAULT_HEIGHT)
         self.mgl_checkboxes = {}
         self.mgl_preview_node = None
+        self.mgl_markups_node = None
         self._mgl_pad_origin = (0.0, 0.0)
 
         # --- landmarks ---
@@ -1998,46 +2046,86 @@ class WidgetParameter:
         row_select = QHBoxLayout()
         row_select.addWidget(QLabel('Selection :'))
         for text, action in (('All', self.selectAllMGL), ('None', self.selectNoMGL),
-                             ('Left', self.selectLeftMGL), ('Right', self.selectRightMGL)):
+                             ('R side', self.selectRightMGL), ('L side', self.selectLeftMGL)):
             button = QPushButton(text)
             button.pressed.connect(action)
             row_select.addWidget(button)
         layout.addLayout(row_select)
 
-        grid_checkboxes = QGridLayout()
-        for index, name in enumerate(MGL_ORDER):
-            checkbox = QCheckBox(name.replace('MG', ''))
-            checkbox.setToolTip(f'{name} : include in what the joystick moves')
-            checkbox.stateChanged.connect(self.onMGLSelectionChanged)
-            self.mgl_checkboxes[name] = checkbox
-            grid_checkboxes.addWidget(checkbox, index // 5, index % 5)
-        layout.addLayout(grid_checkboxes)
+        # Toggle buttons over three rows : the R side, the midline point on
+        # its own, then the L side -- distal to mesial reading left to right.
+        point_rows = (
+            [name for name in reversed(MGL_ORDER) if name.startswith('LR')],
+            ['L0MG'],
+            list(reversed([name for name in MGL_ORDER if name.startswith('LL')])),
+        )
+        for row_names in point_rows:
+            row_points = QHBoxLayout()
+            row_points.setSpacing(8)
+            row_points.addStretch()
+            for name in row_names:
+                button = QPushButton(self.shortMGLName(name))
+                button.setCheckable(True)
+                button.setChecked(True)
+                button.setToolTip(f'{name} : include in what the joystick moves')
+                button.setFixedWidth(34)
+                # An explicit checked state : the module stylesheet leaves
+                # checked and unchecked buttons looking the same.
+                button.setStyleSheet(
+                    'QPushButton { background-color: #555555; color: #dddddd; '
+                    'border: 1px solid #777777; border-radius: 4px; padding: 3px 0px; }'
+                    'QPushButton:checked { background-color: #2e7dd1; color: white; '
+                    'border: 1px solid #5dade2; font-weight: bold; }'
+                    'QPushButton:disabled { background-color: #3a3a3a; color: #666666; }'
+                )
+                button.toggled.connect(self.onMGLSelectionChanged)
+                self.mgl_checkboxes[name] = button
+                row_points.addWidget(button)
+            row_points.addStretch()
+            layout.addLayout(row_points)
 
         # --- the joystick and the height it carries ---
         row_pad = QHBoxLayout()
+        # The clinician faces the patient : dragging left pushes towards the
+        # patient's right (LR), and dragging up pushes towards the crowns.
+        # adjust_sign flips the vertical axis accordingly; the horizontal one
+        # is flipped where the delta is applied, in onMGLPadMoved.
         self.mgl_pad = JoystickPad(
             outward_right=True,
             adjust_range=MGL_OFFSET_RANGE,
+            adjust_sign=-1.0,
             ratio_range=(-MGL_OFFSET_RANGE, MGL_OFFSET_RANGE),
-            side_labels=('LING', 'BUCC'),
+            side_labels=('LR', 'LL'),
+            spring_back=True,
+            # Twice the default pad : the whole travel is only 12 mm, so
+            # every extra pixel is precision under the finger.
+            size=2 * PAD_SIZE,
         )
         self.mgl_pad.setValues(0.0, 0.0)
         self.mgl_pad.setDefaults(0.0, 0.0)
         self.mgl_pad.onChanged = self.onMGLPadMoved
+        self.mgl_pad.onReleased = self.onMGLPadReleased
         self.mgl_pad.onWheel = self.onMGLPadWheel
         self.mgl_pad.setToolTip(
-            'Drag to move the checked landmarks : sideways towards the cheek or '
-            'the tongue, up and down towards the crown or the vestibule. '
-            'The wheel changes their height.'
+            'Drag to push the checked landmarks ALONG the mucogingival line : '
+            'left towards the LR6 end, right towards the LL6 end, exactly as '
+            'the arch faces you. Up pushes towards the crowns, down towards '
+            'the vestibule. The knob springs back to the centre : each drag '
+            'is one push, they add up. The wheel changes the heights.'
         )
         row_pad.addWidget(self.mgl_pad)
 
         column_values = QVBoxLayout()
-        column_values.addWidget(QLabel('Height (mm)'))
-        self.lineedit_mgl_height = QLineEdit(f'{DEFAULT_HEIGHT:.1f}')
-        self.lineedit_mgl_height.setMaximumWidth(80)
-        self.lineedit_mgl_height.textEdited.connect(self.onMGLHeightEdited)
-        column_values.addWidget(self.lineedit_mgl_height)
+        # Slider to rough out the height, field to type it exactly : both
+        # drive the checked landmarks and mirror each other, 0.1 mm per step.
+        self.slider_mgl_height_up, self.lineedit_mgl_height_up = self.mglHeightControls(
+            column_values, 'up', 'Upper extension (mm)',
+            'How far the band climbs from the line towards the teeth, '
+            'for the checked landmarks')
+        self.slider_mgl_height_down, self.lineedit_mgl_height_down = self.mglHeightControls(
+            column_values, 'down', 'Lower extension (mm)',
+            'How far the band descends from the line towards the vestibule, '
+            'for the checked landmarks')
         self.label_mgl_state = QLabel('')
         column_values.addWidget(self.label_mgl_state)
         column_values.addStretch()
@@ -2045,6 +2133,13 @@ class WidgetParameter:
         layout.addLayout(row_pad)
 
         row_buttons = QHBoxLayout()
+        self.button_mgl_copy = QPushButton('Copy the patch of the fix scan')
+        self.button_mgl_copy.setToolTip('Apply the offsets and heights of the scan above to this '
+                                        'one. The landmarks are not copied : each scan keeps its own.')
+        self.button_mgl_copy.pressed.connect(self.copyMGLParameters)
+        # The fix scan is the one being copied from, so it has nothing to copy.
+        self.button_mgl_copy.setVisible(self.title != 1)
+        row_buttons.addWidget(self.button_mgl_copy)
         self.button_mgl_reset = QPushButton('Reset')
         self.button_mgl_reset.setToolTip('Put the checked landmarks back where ALI placed them')
         self.button_mgl_reset.pressed.connect(self.resetMGL)
@@ -2058,10 +2153,28 @@ class WidgetParameter:
 
     # --- selection ---
 
+    @staticmethod
+    def shortMGLName(name):
+        '''R6..R1, 0, L1..L6 : what fits on a one-row button.'''
+        base = name.replace('MG', '')
+        if base == 'L0':
+            return '0'
+        return base.replace('LL', 'L').replace('LR', 'R')
+
     def selectedMGL(self):
         '''Indices, in MGL_ORDER, of the landmarks the pad acts on.'''
         return [index for index, name in enumerate(MGL_ORDER)
                 if self.mgl_checkboxes[name].isChecked()]
+
+    def mglIndices(self):
+        '''Row, in the MGL_ORDER-indexed arrays, of each loaded landmark.
+
+        The builder compacts the loaded landmarks while the offset and height
+        arrays keep one row per possible name : indexing by name is what keeps
+        the L0 checkbox driving the L0 point when a tooth is missing in the
+        middle of the arch.
+        '''
+        return [MGL_ORDER.index(name) for name in self.mgl_names]
 
     def setMGLSelection(self, names):
         self._syncing = True
@@ -2095,11 +2208,15 @@ class WidgetParameter:
         self._syncing = True
         try:
             if selected:
-                buccal = float(np.mean(self.mgl_buccal[selected]))
-                apical = float(np.mean(self.mgl_apical[selected]))
-                self.mgl_pad.setValues(buccal, apical)
-                self._mgl_pad_origin = (buccal, apical)
-                self.lineedit_mgl_height.setText(f'{np.mean(self.mgl_heights[selected]):.1f}')
+                for side in ('up', 'down'):
+                    heights, slider, lineedit = self.mglHeightWidgets(side)
+                    mean = float(np.mean(heights[selected]))
+                    lineedit.setText(f'{mean:.1f}')
+                    slider.setValue(int(round(mean * 10)))
+            # The pad is relative and rests at the centre : only the origin
+            # follows it, the knob is never parked at a mean that could
+            # saturate the travel.
+            self._mgl_pad_origin = (self.mgl_pad.ratio, self.mgl_pad.adjust)
             self.label_mgl_state.setText(f'{len(selected)} / {len(MGL_ORDER)} selected')
         finally:
             self._syncing = False
@@ -2115,37 +2232,100 @@ class WidgetParameter:
             return
         selected = self.selectedMGL()
         if not selected:
+            # Say why nothing moves instead of silently doing nothing.
+            self.label_mgl_state.setText('0 selected : check a point below to move it')
             return
-        delta_buccal = pad.ratio - self._mgl_pad_origin[0]
+        delta_tangent = pad.ratio - self._mgl_pad_origin[0]
         delta_apical = pad.adjust - self._mgl_pad_origin[1]
         self._mgl_pad_origin = (pad.ratio, pad.adjust)
-        self.mgl_buccal[selected] += delta_buccal
+        # Dragging left must push towards the patient's right, i.e. towards
+        # LR6, which is the POSITIVE end of the tangent axis : flip the sign.
+        self.mgl_tangent[selected] -= delta_tangent
         self.mgl_apical[selected] += delta_apical
         self.markPreviewDirty()
 
-    def onMGLPadWheel(self, _pad, steps):
-        '''The wheel raises or lowers the height of the checked landmarks.'''
+    def onMGLPadReleased(self, pad):
+        '''The knob sprang back to the centre : follow it, without a delta.'''
+        self._mgl_pad_origin = (pad.ratio, pad.adjust)
+
+    def mglHeightControls(self, layout, side, title, tooltip):
+        '''One height : a label, a slider and a field mirroring each other.'''
+        layout.addWidget(QLabel(title))
+        row = QHBoxLayout()
+        slider = QSlider(Qt.Horizontal)
+        slider.setRange(int(MIN_HEIGHT * 10), int(MAX_HEIGHT * 10))
+        slider.setValue(int(DEFAULT_HEIGHT * 10))
+        slider.setToolTip(tooltip)
+        slider.valueChanged.connect(partial(self.onMGLHeightSlid, side))
+        row.addWidget(slider)
+        lineedit = QLineEdit(f'{DEFAULT_HEIGHT:.1f}')
+        lineedit.setMaximumWidth(56)
+        lineedit.setToolTip(tooltip)
+        lineedit.textEdited.connect(partial(self.onMGLHeightEdited, side))
+        row.addWidget(lineedit)
+        layout.addLayout(row)
+        return slider, lineedit
+
+    def mglHeightWidgets(self, side):
+        '''The array, slider and field of one side of the band.'''
+        if side == 'up':
+            return self.mgl_heights_up, self.slider_mgl_height_up, self.lineedit_mgl_height_up
+        return self.mgl_heights_down, self.slider_mgl_height_down, self.lineedit_mgl_height_down
+
+    def onMGLHeightSlid(self, side, value):
+        '''A height slider moved : a tenth of a millimetre per step.'''
+        if self._syncing:
+            return
         selected = self.selectedMGL()
         if not selected:
             return
-        self.mgl_heights[selected] = np.clip(
-            self.mgl_heights[selected] + 0.5 * steps, MIN_HEIGHT, MAX_HEIGHT)
+        heights, _slider, lineedit = self.mglHeightWidgets(side)
+        height = value / 10.0
+        heights[selected] = height
         self._syncing = True
         try:
-            self.lineedit_mgl_height.setText(f'{np.mean(self.mgl_heights[selected]):.1f}')
+            lineedit.setText(f'{height:.1f}')
         finally:
             self._syncing = False
         self.markPreviewDirty()
 
-    def onMGLHeightEdited(self, _text=None):
-        '''A height typed in applies to every checked landmark.'''
+    def onMGLPadWheel(self, _pad, steps):
+        '''The wheel raises or lowers both heights of the checked landmarks;
+        the two fields are there for setting each side on its own.'''
+        selected = self.selectedMGL()
+        if not selected:
+            return
+        for heights in (self.mgl_heights_up, self.mgl_heights_down):
+            heights[selected] = np.clip(
+                heights[selected] + 0.5 * steps, MIN_HEIGHT, MAX_HEIGHT)
+        self._syncing = True
+        try:
+            for side in ('up', 'down'):
+                heights, slider, lineedit = self.mglHeightWidgets(side)
+                mean = float(np.mean(heights[selected]))
+                lineedit.setText(f'{mean:.1f}')
+                slider.setValue(int(round(mean * 10)))
+        finally:
+            self._syncing = False
+        self.markPreviewDirty()
+
+    def onMGLHeightEdited(self, side, _text=None):
+        '''A height typed in applies to every checked landmark, on one side of
+        the line only : towards the crown or towards the vestibule.'''
         if self._syncing:
             return
         selected = self.selectedMGL()
-        height = self.readFloat(self.lineedit_mgl_height)
+        heights, slider, lineedit = self.mglHeightWidgets(side)
+        height = self.readFloat(lineedit)
         if height is None or not selected:
             return  # half-typed number, wait for the rest
-        self.mgl_heights[selected] = min(max(height, MIN_HEIGHT), MAX_HEIGHT)
+        clamped = min(max(height, MIN_HEIGHT), MAX_HEIGHT)
+        heights[selected] = clamped
+        self._syncing = True
+        try:
+            slider.setValue(int(round(clamped * 10)))
+        finally:
+            self._syncing = False
         self.markPreviewDirty()
 
     def resetMGL(self):
@@ -2153,16 +2333,17 @@ class WidgetParameter:
         selected = self.selectedMGL()
         if not selected:
             return
-        self.mgl_buccal[selected] = 0.0
+        self.mgl_tangent[selected] = 0.0
         self.mgl_apical[selected] = 0.0
-        self.mgl_heights[selected] = DEFAULT_HEIGHT
+        self.mgl_heights_up[selected] = DEFAULT_HEIGHT
+        self.mgl_heights_down[selected] = DEFAULT_HEIGHT
         self.onMGLSelectionChanged()
         self.markPreviewDirty()
 
     # --- landmarks ---
 
     def selectMGLLandmarks(self):
-        path = QFileDialog.getOpenFileName(None, 'Open the MG landmarks', '', 'Markups (*.json *.mrk.json)')
+        path = QFileDialog.getOpenFileName(slicer.util.mainWindow(), 'Open the MG landmarks', '', 'Markups (*.json *.mrk.json)')
         if path:
             self.lineedit_mgl_landmarks.setText(path)
             self.loadMGLLandmarks()
@@ -2184,6 +2365,25 @@ class WidgetParameter:
             self.warning(f'This landmark file cannot be read.\n{error}')
             return False
 
+        # The displayed mesh is in RAS : Slicer converts model files on load
+        # (a .vtk with no metadata is assumed LPS), while ReadLandmarks reads
+        # the raw positions of the json. Flip LPS landmarks the way Slicer's
+        # own markups loader would, or the curve is a mirror of the arch.
+        import json
+        with open(path) as handle:
+            system = json.load(handle)['markups'][0].get('coordinateSystem', 'LPS')
+        if system.upper() == 'LPS':
+            for name, position in self.mgl_landmarks.items():
+                self.mgl_landmarks[name] = position * np.array([-1.0, -1.0, 1.0])
+
+        # The mesh was then centered by viewScan (the matrix is kept) : bring
+        # the landmarks along, or the curve is built beside the scan.
+        matrix = self.getMatrix()
+        if matrix is not None and self.camera:
+            for name, position in self.mgl_landmarks.items():
+                moved = matrix.MultiplyPoint((*position, 1.0))
+                self.mgl_landmarks[name] = np.array(moved[:3])
+
         if not self.mgl_builder.prepare(self.surf.GetPolyData(), self.mgl_landmarks):
             self.warning(self.mgl_builder.error or 'The MG landmarks do not fit this scan.')
             return False
@@ -2193,8 +2393,57 @@ class WidgetParameter:
             checkbox.setEnabled(name in self.mgl_names)
             if name not in self.mgl_names:
                 checkbox.setChecked(False)
+        self.showMGLLandmarks()
         self.markPreviewDirty()
         return True
+
+    def showMGLLandmarks(self):
+        '''Show the MG points on the scan, at their joystick-moved positions.
+
+        They are displayed as soon as the landmarks are loaded, follow the
+        offsets the user dials in, and are locked : the joystick is what moves
+        them, a mouse drag would be invisible to the patch engine.
+
+        The positions shown are the moved points snapped back onto the mesh —
+        the raw offsets leave the surface, and a point floating in the air or
+        buried in the scan says nothing about where the band will be.
+        '''
+        if not self.mgl_builder.ready:
+            return
+        rows = self.mglIndices()
+        positions = self.mgl_builder.snappedLandmarks(
+            np.zeros(len(rows)), self.mgl_apical[rows],
+            tangent_offsets=self.mgl_tangent[rows])
+
+        node = self.mgl_markups_node
+        if node is None or node.GetScene() is None:
+            node = slicer.mrmlScene.AddNewNodeByClass(
+                'vtkMRMLMarkupsFiducialNode', f'MG landmarks {self.title}')
+            node.SetSaveWithScene(False)
+            node.SetLocked(True)
+            node.CreateDefaultDisplayNodes()
+            display = node.GetDisplayNode()
+            display.SetTextScale(2.5)
+            display.SetGlyphScale(1.5)
+            display.SetSelectedColor(1.0, 0.85, 0.0)
+            display.SetPointLabelsVisibility(True)
+            # A point on the far side of the arch stays faintly visible
+            # instead of vanishing behind the scan.
+            display.SetOccludedVisibility(True)
+            display.SetOccludedOpacity(0.4)
+            view = self.previewViewNode()
+            if view:
+                display.SetViewNodeIDs([view.GetID()])
+            self.mgl_markups_node = node
+
+        if node.GetNumberOfControlPoints() == len(positions):
+            for index, position in enumerate(positions):
+                node.SetNthControlPointPosition(index, *position)
+        else:
+            node.RemoveAllControlPoints()
+            for name, position in zip(self.mgl_names, positions):
+                node.AddControlPoint(vtk.vtkVector3d(*position), name.replace('MG', ''))
+        node.SetDisplayVisibility(1)
 
     def computeMGLLandmarks(self):
         '''Predict the MG landmarks of this scan with ALI, in the conda env.'''
@@ -2212,14 +2461,22 @@ class WidgetParameter:
         arguments = [path, models, 'None', 'None', ' '.join(MGL_ORDER), output,
                      '224', '0', '1', os.path.join(output, 'process.log')]
 
-        progress = QProgressDialog('Predicting the MG landmarks with ALI...', None, 0, 0, None)
+        progress = QProgressDialog('Predicting the MG landmarks with ALI...', None, 0, 0,
+                                   slicer.util.mainWindow())
         progress.setWindowTitle('ALI_IOS')
         progress.setWindowModality(Qt.WindowModal)
         progress.show()
-        slicer.app.processEvents()
+        # The prediction runs in a thread while this loop keeps pumping events:
+        # a window shown while the event loop is blocked is never painted and
+        # sits on the screen as a transparent ghost.
+        thread = threading.Thread(target=self.logic.runALI, args=(arguments,))
+        thread.start()
         try:
-            self.logic.runALI(arguments)
+            while thread.is_alive():
+                slicer.app.processEvents()
+                time.sleep(0.05)
         finally:
+            thread.join()
             progress.close()
 
         produced = sorted(f for f in os.listdir(output) if f.endswith('.json'))
@@ -2228,7 +2485,16 @@ class WidgetParameter:
             return
 
         self.lineedit_mgl_landmarks.setText(os.path.join(output, produced[0]))
-        self.loadMGLLandmarks()
+        if self.loadMGLLandmarks() and len(self.mgl_names) < len(MGL_ORDER):
+            missing = [name for name in MGL_ORDER if name not in self.mgl_names]
+            self.warning(
+                f'ALI only placed {len(self.mgl_names)} of the {len(MGL_ORDER)} MG landmarks.\n'
+                f'Missing : {", ".join(missing)}.\n\n'
+                'A landmark is only placed when its tooth has a label in the '
+                'segmentation of the scan (Universal_ID / PredictedID). Check '
+                'that the scan is segmented tooth by tooth with universal '
+                'numbering, and see the ALI log for details.'
+            )
 
     def mglModelsFolder(self):
         '''Folder holding Lower_MG_*.pth, downloading it once if need be.'''
@@ -2236,7 +2502,7 @@ class WidgetParameter:
         if self.hasMGLModel(folder):
             return folder
 
-        chosen = QFileDialog.getExistingDirectory(None, 'Select the ALI models folder')
+        chosen = QFileDialog.getExistingDirectory(slicer.util.mainWindow(), 'Select the ALI models folder')
         if chosen and self.hasMGLModel(chosen):
             return chosen
         if chosen:
@@ -2259,12 +2525,14 @@ class WidgetParameter:
         '''Repaint the band for the current offsets and heights.'''
         if not self.mgl_builder.ready:
             return
+        rows = self.mglIndices()
         labels, _samples = self.mgl_builder.compute(
-            self.mgl_buccal[:len(self.mgl_names)],
-            self.mgl_apical[:len(self.mgl_names)],
-            self.mgl_heights[:len(self.mgl_names)],
+            np.zeros(len(rows)), self.mgl_apical[rows],
+            self.mgl_heights_up[rows], self.mgl_heights_down[rows],
+            tangent_offsets=self.mgl_tangent[rows],
         )
         self.showMGLPreview(labels)
+        self.showMGLLandmarks()
 
     def showMGLPreview(self, labels):
         polydata = self.surf.GetPolyData()
@@ -2278,6 +2546,9 @@ class WidgetParameter:
         polydata.Modified()
 
     def clearMGLPreview(self):
+        if (self.mgl_markups_node is not None
+                and self.mgl_markups_node.GetScene() is not None):
+            self.mgl_markups_node.SetDisplayVisibility(0)
         if self.surf is None:
             return
         polydata = self.surf.GetPolyData()
@@ -2297,10 +2568,11 @@ class WidgetParameter:
             self.warning('Load or compute the MG landmarks first.')
             return
 
+        rows = self.mglIndices()
         labels, _samples = self.mgl_builder.compute(
-            self.mgl_buccal[:len(self.mgl_names)],
-            self.mgl_apical[:len(self.mgl_names)],
-            self.mgl_heights[:len(self.mgl_names)],
+            np.zeros(len(rows)), self.mgl_apical[rows],
+            self.mgl_heights_up[rows], self.mgl_heights_down[rows],
+            tangent_offsets=self.mgl_tangent[rows],
         )
         if labels.sum() == 0:
             self.warning('The patch is empty, raise the height.')
@@ -2317,10 +2589,36 @@ class WidgetParameter:
             return
 
         polydata.GetPointData().AddArray(self.mgl_builder.toArray(labels, MGL_ARRAY_NAME))
+
+        # For a future training set : keep the refined line itself, not only
+        # its band. Vertex ids are coordinate-free, so everything is stored
+        # against the file's own geometry, inside the file.
+        ids = self.mgl_builder.snappedLandmarkIds(
+            np.zeros(len(rows)), self.mgl_apical[rows],
+            tangent_offsets=self.mgl_tangent[rows])
+        field = polydata.GetFieldData()
+        for name, values, dtype in (
+                ('MGL_landmark_ids', ids, np.int64),
+                ('MGL_landmark_slots', rows, np.int64),
+                ('MGL_offsets_tangent', self.mgl_tangent[rows], np.float64),
+                ('MGL_offsets_apical', self.mgl_apical[rows], np.float64),
+                ('MGL_heights_crown', self.mgl_heights_up[rows], np.float64),
+                ('MGL_heights_vestibule', self.mgl_heights_down[rows], np.float64)):
+            array = numpy_to_vtk(np.asarray(values, dtype=dtype), deep=True)
+            array.SetName(name)
+            field.AddArray(array)
+
         writer = vtk.vtkPolyDataWriter()
         writer.SetFileName(path)
         writer.SetInputData(polydata)
         writer.Write()
+
+        # The same points as a markups file, in the naming and coordinates of
+        # the training annotations : ready to join the corpus.
+        markups_path = path.rsplit('.vtk', 1)[0] + '_MG_edited.mrk.json'
+        WriteLandmarks(markups_path, self.mgl_names,
+                       [polydata.GetPoint(point_id) for point_id in ids])
+        logger.info(f"Refined MGL line saved for training : {markups_path}")
 
         # The scene node carries it too: that is what the registration reads to
         # know the patch exists, and what the user is left looking at.
@@ -2338,7 +2636,7 @@ class WidgetParameter:
         logger.info(f"Wrote the {MGL_ARRAY_NAME} patch of {int(labels.sum())} points to {path}")
 
     def warning(self, text):
-        qt.QMessageBox.warning(None, 'Warning', text)
+        qt.QMessageBox.warning(slicer.util.mainWindow(), 'Warning', text)
 
     def handleStackedWidgetChange(self, index):
         # When stackedWidget change of page, this is called.
@@ -2381,7 +2679,7 @@ class WidgetParameter:
         self.stackedWidget.setCurrentIndex(index)
 
     def isLowerArch(self):
-        return self.combobox_arch.currentIndex == 1
+        return self.lower_arch
 
     def scanIsLower(self):
         '''Which arch the loaded scan actually is, read from its segmentation.
@@ -2417,16 +2715,17 @@ class WidgetParameter:
 
         scan_arch = "lower" if is_lower else "upper"
         chosen = "lower" if self.isLowerArch() else "upper"
-        self.warning(f'This scan is a {scan_arch} arch but the panel is set to the '
-                     f'{chosen} arch.\nSwitch the arch selector before going on.')
+        self.warning(f'This scan is a {scan_arch} arch but the module is set to the '
+                     f'{chosen} arch.\nSwitch the arch selector at the top before going on.')
         return False
 
-    def changeArch(self, index):
+    def setArch(self, lower):
         '''
+        Applied from the module-level arch selector, to every scan at once.
         Upper keeps the two ways of drawing the palatal patch; lower has a
         single one, built from the landmarks, so the method selector goes away.
         '''
-        lower = index == 1
+        self.lower_arch = lower
         self.combobox_choice_method.setVisible(not lower)
         if self.surf is not None:
             self.checkArchMatchesScan()
@@ -2801,6 +3100,25 @@ class WidgetParameter:
             return
         self.setParameterValues(source.parameterValues())
 
+    def mglParameterValues(self):
+        '''The hand-set part of the mucogingival patch : offsets and heights.'''
+        return (self.mgl_tangent.copy(), self.mgl_apical.copy(),
+                self.mgl_heights_up.copy(), self.mgl_heights_down.copy())
+
+    def copyMGLParameters(self):
+        '''
+        Take the offsets and heights of the fix scan and apply them here. The
+        landmarks themselves are not copied : each scan keeps its own, so the
+        same adjustments land on this scan's mucogingival line.
+        '''
+        source = self.sourceWidget()
+        if source is None:
+            return
+        (self.mgl_tangent, self.mgl_apical,
+         self.mgl_heights_up, self.mgl_heights_down) = source.mglParameterValues()
+        self.onMGLSelectionChanged()
+        self.markPreviewDirty()
+
     def readFloat(self, lineedit):
         try:
             return float(lineedit.text)
@@ -2965,6 +3283,87 @@ class WidgetParameter:
 
         self.lineedit.setText(path_file)
 
+    def sceneModels(self):
+        '''Models of the scene this scan could use.
+
+        FlexReg's own working copies and previews are pinned to one of its
+        views, so a model restricted to specific views is one of ours and is
+        left out; a user's model shows everywhere and has no such restriction.
+        '''
+        models = []
+        for node in slicer.util.getNodesByClass('vtkMRMLModelNode'):
+            if node.GetHideFromEditors() or node.GetPolyData() is None:
+                continue
+            display = node.GetDisplayNode()
+            if display is not None and display.GetViewNodeIDs():
+                continue
+            models.append(node)
+        return models
+
+    def selectSceneModel(self):
+        '''Offer the models already loaded in the scene as this scan.'''
+        models = self.sceneModels()
+        if not models:
+            self.warning('No model is loaded in the scene.')
+            return
+
+        menu = qt.QMenu(self.button_scene)
+        for node in models:
+            storage = node.GetStorageNode()
+            path = storage.GetFullNameFromFileName() if storage else None
+            if path and os.path.isfile(path) and path.endswith('.vtk'):
+                hint = path
+            else:
+                hint = 'no .vtk file, a copy will be written'
+            action = menu.addAction(f'{node.GetName()}   ({hint})')
+            action.triggered.connect(partial(self.useSceneModel, node.GetID()))
+        menu.exec_(qt.QCursor.pos())
+
+    def useSceneModel(self, node_id, _checked=False):
+        '''
+        Use a model already loaded in the scene as this scan. The whole
+        pipeline works on files, so the node's own file is used when it is a
+        readable .vtk; otherwise a .vtk snapshot of the node is written first.
+        '''
+        node = slicer.mrmlScene.GetNodeByID(node_id)
+        if node is None or node.GetPolyData() is None:
+            return
+
+        storage = node.GetStorageNode()
+        path = storage.GetFullNameFromFileName() if storage else None
+        if not path or not os.path.isfile(path) or not path.endswith('.vtk'):
+            path = self.exportNodeToVtk(node)
+            logger.info(f"Scene model '{node.GetName()}' written to {path}")
+
+        # FlexReg displays its own centered copy: the original stays in the
+        # scene but is hidden so the scan is not shown twice.
+        node.SetDisplayVisibility(0)
+        self.lineedit.setText(path)
+        self.viewScan()
+
+    def exportNodeToVtk(self, node):
+        '''A .vtk snapshot of a scene model, as displayed (world coordinates).'''
+        polydata = node.GetPolyData()
+        if node.GetParentTransformNode() is not None:
+            to_world = vtk.vtkGeneralTransform()
+            slicer.vtkMRMLTransformNode.GetTransformBetweenNodes(
+                node.GetParentTransformNode(), None, to_world)
+            transformer = vtk.vtkTransformPolyDataFilter()
+            transformer.SetTransform(to_world)
+            transformer.SetInputData(polydata)
+            transformer.Update()
+            polydata = transformer.GetOutput()
+
+        folder = os.path.join(slicer.app.temporaryPath, 'FlexReg_scene_models')
+        os.makedirs(folder, exist_ok=True)
+        name = re.sub(r'[^\w-]+', '_', node.GetName()).strip('_') or 'model'
+        path = os.path.join(folder, f'{name}.vtk')
+        writer = vtk.vtkPolyDataWriter()
+        writer.SetFileName(path)
+        writer.SetInputData(polydata)
+        writer.Write()
+        return path
+
     def checkLineEdit(self)->bool:
         '''
         check if input path is a vtk file
@@ -2983,25 +3382,20 @@ class WidgetParameter:
             check_env = self.onCheckRequirements()
             is_installed = False
             if check_env:
-                if platform.system() == "Windows":
-                    list_libs_windows = [('numpy',"<2.0.0",None),('itk',None,None),('torch','==2.2.0',None),('monai','==1.3.2',None)] #(lib_name, version, url)
-                    is_installed = install_function(self,list_libs_windows)
-                    
-                else:
-                    list_libs_linux = [('numpy',"<2.0.0",None),('itk',None,None),('torch','==2.2.0',None),('monai','==1.3.2',None)] #(lib_name, version, url)
-                    is_installed = install_function(self,list_libs_linux)
-                    
+                # Only torch is missing from a stock Slicer: vtk, numpy, scipy
+                # and SimpleITK all ship with it. numpy in particular must be
+                # left exactly as Slicer installed it: its scipy is built for
+                # that numpy, and swapping numpy on disk under a running
+                # session leaves the next scipy import reading a mix of the
+                # two ("No module named 'numpy.strings'"), which is what used
+                # to kill the MGL patch preview.
+                list_libs = [('torch', None, None)]  # (lib_name, version, url)
+                is_installed = install_function(self, list_libs)
+
             if not is_installed:
                 qt.QMessageBox.warning(self.parent, 'Warning', 'The module will not work properly without the required libraries.\nPlease install them and try again.')
                 return
-            
-            import numpy as np
-            from packaging.version import Version
 
-            numpy_version = Version(np.__version__)
-            if numpy_version > Version("2.0"):
-                pip_install("numpy<2.0.0")
-            
             FlexRegBootManager.booted = True
             self.label_time.setHidden(True)
         

--- a/FlexReg/FlexReg.py
+++ b/FlexReg/FlexReg.py
@@ -1214,7 +1214,9 @@ class Reg:
         result then no longer leaves a .vtk and a .tfm behind every time.
         '''
         if self.T1.getSurf()!=None and  self.T2.getSurf()!=None :
-            if self.isButterflyPatchAvailable(self.T1.getSurf()) and self.isButterflyPatchAvailable(self.T2.getSurf()) :
+            array_name = self.patchArrayName()
+            if (self.isButterflyPatchAvailable(self.T1.getSurf(), array_name)
+                    and self.isButterflyPatchAvailable(self.T2.getSurf(), array_name)):
                 self.preview = preview
                 self.temp_folder = None
                 if preview:
@@ -1243,7 +1245,7 @@ class Reg:
                             float(0),
                             "None",
                             "None",
-                            "icp",
+                            "icp_mgl" if self.isLowerArch() else "icp",
                             self.T1.getPath(),
                             output_folder,
                             suffix,
@@ -1256,19 +1258,28 @@ class Reg:
                 self.timer.start(500)
 
             else:
-                slicer.util.infoDisplay("Create patch on T1 and T2 before registration")
+                slicer.util.infoDisplay(
+                    f"Create the {array_name} patch on T1 and T2 before registration")
         else :
             slicer.util.infoDisplay(f"Load a vtk file in window number : 1 and 2 \nTo do this, enter the path to a vtk file and click on view.")
 
-    def isButterflyPatchAvailable(self, model_node)->bool:
+    def isButterflyPatchAvailable(self, model_node, array_name="Butterfly")->bool:
         """
-        Check if the Butterfly patch is available for the provided model node.
+        Check if the patch of the current arch is available for the model node.
         """
         polyData = model_node.GetPolyData()
         if polyData:
-            scalars = polyData.GetPointData().GetScalars("Butterfly")
+            scalars = (polyData.GetPointData().GetScalars(array_name)
+                       or polyData.GetPointData().GetArray(array_name))
             return scalars is not None
         return False
+
+    def isLowerArch(self)->bool:
+        """True when both scans are set to the lower arch."""
+        return self.T1.isLowerArch() and self.T2.isLowerArch()
+
+    def patchArrayName(self)->str:
+        return MGL_ARRAY_NAME if self.isLowerArch() else "Butterfly"
 
 
     def onProcessUpdateICP(self)->None:
@@ -2280,6 +2291,8 @@ class WidgetParameter:
         the CLI: it needs no GPU, so what the user sees is exactly what is
         written.
         '''
+        if not self.checkArchMatchesScan():
+            return
         if not self.mgl_builder.ready:
             self.warning('Load or compute the MG landmarks first.')
             return
@@ -2308,6 +2321,17 @@ class WidgetParameter:
         writer.SetFileName(path)
         writer.SetInputData(polydata)
         writer.Write()
+
+        # The scene node carries it too: that is what the registration reads to
+        # know the patch exists, and what the user is left looking at.
+        displayed = self.surf.GetPolyData()
+        displayed.GetPointData().AddArray(self.mgl_builder.toArray(labels, MGL_ARRAY_NAME))
+        displayed.GetPointData().SetActiveScalars(MGL_ARRAY_NAME)
+        display = self.surf.GetDisplayNode()
+        if display is not None:
+            display.SetActiveScalarName(MGL_ARRAY_NAME)
+            display.SetScalarVisibility(True)
+        displayed.Modified()
 
         self.preview_dirty = False
         self.button_mgl_update.setText('Update')
@@ -2359,6 +2383,44 @@ class WidgetParameter:
     def isLowerArch(self):
         return self.combobox_arch.currentIndex == 1
 
+    def scanIsLower(self):
+        '''Which arch the loaded scan actually is, read from its segmentation.
+
+        The lower teeth carry Universal_ID 18 to 31 and the upper ones 2 to 15,
+        so the labels say it without trusting the file name.
+        '''
+        if self.surf is None:
+            return None
+        point_data = self.surf.GetPolyData().GetPointData()
+        for name in ("Universal_ID", "PredictedID", "UniversalID"):
+            scalars = point_data.GetScalars(name) or point_data.GetArray(name)
+            if scalars is not None:
+                labels = vtk_to_numpy(scalars)
+                lower = int(np.isin(labels, range(18, 32)).sum())
+                upper = int(np.isin(labels, range(2, 16)).sum())
+                if lower == upper:
+                    return None
+                return lower > upper
+        return None
+
+    def checkArchMatchesScan(self):
+        '''Warn when the scan is not the arch the panel is set to.
+
+        The two patches are not interchangeable: the palate does not exist on a
+        mandible, and the mucogingival model was only trained on one.
+        '''
+        is_lower = self.scanIsLower()
+        if is_lower is None:
+            return True
+        if is_lower == self.isLowerArch():
+            return True
+
+        scan_arch = "lower" if is_lower else "upper"
+        chosen = "lower" if self.isLowerArch() else "upper"
+        self.warning(f'This scan is a {scan_arch} arch but the panel is set to the '
+                     f'{chosen} arch.\nSwitch the arch selector before going on.')
+        return False
+
     def changeArch(self, index):
         '''
         Upper keeps the two ways of drawing the palatal patch; lower has a
@@ -2366,6 +2428,8 @@ class WidgetParameter:
         '''
         lower = index == 1
         self.combobox_choice_method.setVisible(not lower)
+        if self.surf is not None:
+            self.checkArchMatchesScan()
         self.stackedWidget.setCurrentIndex(2 if lower else self.combobox_choice_method.currentIndex)
         for widget in (self.label_patch, self.combobox_patch,
                        self.add_patch, self.label_addpatch, self.delete_patch):

--- a/FlexReg/FlexReg.py
+++ b/FlexReg/FlexReg.py
@@ -33,6 +33,7 @@ import slicer
 from slicer.ScriptedLoadableModule import *
 from slicer.util import VTKObservationMixin, pip_install
 
+import numpy as np
 import vtk
 from vtk.util.numpy_support import vtk_to_numpy, numpy_to_vtk
 
@@ -64,6 +65,10 @@ def _get_installed_version(lib_name):
 from FlexReg_utils.util import ToothNoExist, NoSegmentationSurf
 from FlexReg_utils.orientation import orientation_f
 from FlexReg_utils.butterfly_preview import ButterflyPreview, ADJUST_SIGN
+from FlexReg_utils.mgl_patch import (
+    MGLPatchBuilder, MGL_ARRAY_NAME, MGL_PREVIEW_ARRAY_NAME, MGL_ORDER,
+    DEFAULT_HEIGHT, MIN_HEIGHT, MAX_HEIGHT, ReadLandmarks,
+)
 
 # Travel of the joystick pads along the antero-posterior axis, in mm. Typing a
 # larger value in the line edit still works, the knob just saturates.
@@ -72,6 +77,11 @@ ADJUST_RANGE = 5.0
 # Travel of the translation pad, in mm, on both axes. It moves the four
 # centroids together, so it is a rigid shift of the whole patch.
 SHIFT_RANGE = 15.0
+
+# Travel of the MGL joystick, in mm on both axes. It moves the checked
+# landmarks off the line ALI drew, sideways towards the cheek or the tongue and
+# up or down towards the crown or the vestibule.
+MGL_OFFSET_RANGE = 6.0
 
 # Side of the joystick pads, in pixels. The whole 0-1 ratio range is spread
 # across the pad, so this is what sets how much a single pixel of mouse travel
@@ -1021,6 +1031,25 @@ class FlexRegLogic(ScriptedLoadableModuleLogic):
             self.give_pythonpath_windows()
             results = self.check_pythonpath_windows("CrownSegmentationcli")
             
+    def runALI(self, arguments):
+        '''
+        Predict the MG landmarks of one scan, in the conda environment where
+        ALI_IOS has its dependencies. Blocks until the prediction is over.
+        '''
+        if not self.check_pythonpath_windows("ALI_IOS"):
+            self.give_pythonpath_windows()
+
+        conda_exe = self.conda.getCondaExecutable()
+        command = [conda_exe, "run", "-n", self.name_env, "python", "-m", "ALI_IOS"]
+        for argument in arguments:
+            value = argument
+            if isinstance(value, str) and ("\\" in value or (len(value) > 1 and value[1] == ":")):
+                value = self.windows_to_linux_path(value)
+            command.append(f'"{value}"')
+
+        logger.info(f"Running ALI_IOS: {' '.join(command)}")
+        self.condaRunCommand(command)
+
     def condaRunCommand(self, command: list[str]):
         '''
         Runs a command in a specified Conda environment, handling different operating systems.
@@ -1452,6 +1481,7 @@ class JoystickPad(QWidget):
         self.adjust = 0.0
         self.default_ratio = 0.0
         self.default_adjust = 0.0
+        self.onWheel = None
         self.onChanged = None
         self.enabled_preview = True
         self._dragging = False
@@ -1580,6 +1610,11 @@ class JoystickPad(QWidget):
         the other axis, where up means outwards.
         '''
         steps = _wheelSteps(event)
+        if self.onWheel is not None:
+            # Both axes drive the movement in MGL, so the wheel is free for
+            # whatever the caller wants to put on it.
+            self.onWheel(self, steps)
+            return
         if slicer.app.keyboardModifiers() & Qt.ShiftModifier:
             # scrolling up walks the point outwards, which is the ratio going up
             self.setValues(self.ratio + self.ratio_step * steps, self.adjust, notify=True)
@@ -1754,6 +1789,13 @@ class WidgetParameter:
         layout.addWidget(widgetView)
         
 
+        # Which arch is registered, and therefore which stable region is drawn:
+        # the palate above, the band along the mucogingival line below.
+        self.combobox_arch = QComboBox()
+        self.combobox_arch.addItems(['Upper arch (palate)', 'Lower arch (MGL)'])
+        self.combobox_arch.activated.connect(self.changeArch)
+        layout.addWidget(self.combobox_arch)
+
         self.combobox_choice_method = QComboBox()
         self.combobox_choice_method.addItems(['Parameter','Landmark'])
         self.combobox_choice_method.activated.connect(self.changeMode)
@@ -1854,6 +1896,11 @@ class WidgetParameter:
 
         
 
+        # page 2 : the mucogingival patch of the lower arch
+        widget_mgl = QWidget()
+        self.stackedWidget.insertWidget(2, widget_mgl)
+        self.setupMGL(QVBoxLayout(widget_mgl))
+
         self.layout_file2 = QHBoxLayout()
         layout.addLayout(self.layout_file2)
 
@@ -1904,15 +1951,386 @@ class WidgetParameter:
 
         
 
+    # ---------------- lower arch : the mucogingival patch ----------------
+
+    def setupMGL(self, layout):
+        '''
+        Build the lower-arch page : where the landmarks come from, which ones
+        the joystick acts on, and the joystick itself.
+        '''
+        self.mgl_builder = MGLPatchBuilder()
+        self.mgl_landmarks = None
+        self.mgl_names = []
+        self.mgl_buccal = np.zeros(len(MGL_ORDER))
+        self.mgl_apical = np.zeros(len(MGL_ORDER))
+        self.mgl_heights = np.full(len(MGL_ORDER), DEFAULT_HEIGHT)
+        self.mgl_checkboxes = {}
+        self.mgl_preview_node = None
+        self._mgl_pad_origin = (0.0, 0.0)
+
+        # --- landmarks ---
+        row_landmarks = QHBoxLayout()
+        row_landmarks.addWidget(QLabel('Landmarks :'))
+        self.lineedit_mgl_landmarks = QLineEdit()
+        self.lineedit_mgl_landmarks.setPlaceholderText('MG landmarks json, or press Compute')
+        row_landmarks.addWidget(self.lineedit_mgl_landmarks)
+        self.button_mgl_browse = QPushButton('Select')
+        self.button_mgl_browse.pressed.connect(self.selectMGLLandmarks)
+        row_landmarks.addWidget(self.button_mgl_browse)
+        self.button_mgl_compute = QPushButton('Compute')
+        self.button_mgl_compute.setToolTip('Predict the MG landmarks of this scan with ALI')
+        self.button_mgl_compute.pressed.connect(self.computeMGLLandmarks)
+        row_landmarks.addWidget(self.button_mgl_compute)
+        layout.addLayout(row_landmarks)
+
+        # --- which landmarks the pad moves ---
+        row_select = QHBoxLayout()
+        row_select.addWidget(QLabel('Selection :'))
+        for text, action in (('All', self.selectAllMGL), ('None', self.selectNoMGL),
+                             ('Left', self.selectLeftMGL), ('Right', self.selectRightMGL)):
+            button = QPushButton(text)
+            button.pressed.connect(action)
+            row_select.addWidget(button)
+        layout.addLayout(row_select)
+
+        grid_checkboxes = QGridLayout()
+        for index, name in enumerate(MGL_ORDER):
+            checkbox = QCheckBox(name.replace('MG', ''))
+            checkbox.setToolTip(f'{name} : include in what the joystick moves')
+            checkbox.stateChanged.connect(self.onMGLSelectionChanged)
+            self.mgl_checkboxes[name] = checkbox
+            grid_checkboxes.addWidget(checkbox, index // 5, index % 5)
+        layout.addLayout(grid_checkboxes)
+
+        # --- the joystick and the height it carries ---
+        row_pad = QHBoxLayout()
+        self.mgl_pad = JoystickPad(
+            outward_right=True,
+            adjust_range=MGL_OFFSET_RANGE,
+            ratio_range=(-MGL_OFFSET_RANGE, MGL_OFFSET_RANGE),
+            side_labels=('LING', 'BUCC'),
+        )
+        self.mgl_pad.setValues(0.0, 0.0)
+        self.mgl_pad.setDefaults(0.0, 0.0)
+        self.mgl_pad.onChanged = self.onMGLPadMoved
+        self.mgl_pad.onWheel = self.onMGLPadWheel
+        self.mgl_pad.setToolTip(
+            'Drag to move the checked landmarks : sideways towards the cheek or '
+            'the tongue, up and down towards the crown or the vestibule. '
+            'The wheel changes their height.'
+        )
+        row_pad.addWidget(self.mgl_pad)
+
+        column_values = QVBoxLayout()
+        column_values.addWidget(QLabel('Height (mm)'))
+        self.lineedit_mgl_height = QLineEdit(f'{DEFAULT_HEIGHT:.1f}')
+        self.lineedit_mgl_height.setMaximumWidth(80)
+        self.lineedit_mgl_height.textEdited.connect(self.onMGLHeightEdited)
+        column_values.addWidget(self.lineedit_mgl_height)
+        self.label_mgl_state = QLabel('')
+        column_values.addWidget(self.label_mgl_state)
+        column_values.addStretch()
+        row_pad.addLayout(column_values)
+        layout.addLayout(row_pad)
+
+        row_buttons = QHBoxLayout()
+        self.button_mgl_reset = QPushButton('Reset')
+        self.button_mgl_reset.setToolTip('Put the checked landmarks back where ALI placed them')
+        self.button_mgl_reset.pressed.connect(self.resetMGL)
+        row_buttons.addWidget(self.button_mgl_reset)
+        self.button_mgl_update = QPushButton('Update')
+        self.button_mgl_update.pressed.connect(self.applyMGLPatch)
+        row_buttons.addWidget(self.button_mgl_update)
+        layout.addLayout(row_buttons)
+
+        self.selectAllMGL()
+
+    # --- selection ---
+
+    def selectedMGL(self):
+        '''Indices, in MGL_ORDER, of the landmarks the pad acts on.'''
+        return [index for index, name in enumerate(MGL_ORDER)
+                if self.mgl_checkboxes[name].isChecked()]
+
+    def setMGLSelection(self, names):
+        self._syncing = True
+        try:
+            for name, checkbox in self.mgl_checkboxes.items():
+                checkbox.setChecked(name in names)
+        finally:
+            self._syncing = False
+        self.onMGLSelectionChanged()
+
+    def selectAllMGL(self):
+        self.setMGLSelection(set(MGL_ORDER))
+
+    def selectNoMGL(self):
+        self.setMGLSelection(set())
+
+    def selectLeftMGL(self):
+        self.setMGLSelection({name for name in MGL_ORDER if name.startswith('LL')})
+
+    def selectRightMGL(self):
+        self.setMGLSelection({name for name in MGL_ORDER if name.startswith('LR')})
+
+    def onMGLSelectionChanged(self, _state=None):
+        '''
+        The pad and the height field show the average of the selection, so the
+        knob always sits where the checked points sit.
+        '''
+        if self._syncing:
+            return
+        selected = self.selectedMGL()
+        self._syncing = True
+        try:
+            if selected:
+                buccal = float(np.mean(self.mgl_buccal[selected]))
+                apical = float(np.mean(self.mgl_apical[selected]))
+                self.mgl_pad.setValues(buccal, apical)
+                self._mgl_pad_origin = (buccal, apical)
+                self.lineedit_mgl_height.setText(f'{np.mean(self.mgl_heights[selected]):.1f}')
+            self.label_mgl_state.setText(f'{len(selected)} / {len(MGL_ORDER)} selected')
+        finally:
+            self._syncing = False
+
+    # --- edition ---
+
+    def onMGLPadMoved(self, pad):
+        '''
+        The joystick moved : every checked landmark takes the same step, so the
+        differences the user already dialled in are kept.
+        '''
+        if self._syncing:
+            return
+        selected = self.selectedMGL()
+        if not selected:
+            return
+        delta_buccal = pad.ratio - self._mgl_pad_origin[0]
+        delta_apical = pad.adjust - self._mgl_pad_origin[1]
+        self._mgl_pad_origin = (pad.ratio, pad.adjust)
+        self.mgl_buccal[selected] += delta_buccal
+        self.mgl_apical[selected] += delta_apical
+        self.markPreviewDirty()
+
+    def onMGLPadWheel(self, _pad, steps):
+        '''The wheel raises or lowers the height of the checked landmarks.'''
+        selected = self.selectedMGL()
+        if not selected:
+            return
+        self.mgl_heights[selected] = np.clip(
+            self.mgl_heights[selected] + 0.5 * steps, MIN_HEIGHT, MAX_HEIGHT)
+        self._syncing = True
+        try:
+            self.lineedit_mgl_height.setText(f'{np.mean(self.mgl_heights[selected]):.1f}')
+        finally:
+            self._syncing = False
+        self.markPreviewDirty()
+
+    def onMGLHeightEdited(self, _text=None):
+        '''A height typed in applies to every checked landmark.'''
+        if self._syncing:
+            return
+        selected = self.selectedMGL()
+        height = self.readFloat(self.lineedit_mgl_height)
+        if height is None or not selected:
+            return  # half-typed number, wait for the rest
+        self.mgl_heights[selected] = min(max(height, MIN_HEIGHT), MAX_HEIGHT)
+        self.markPreviewDirty()
+
+    def resetMGL(self):
+        '''Undo every offset and height on the checked landmarks.'''
+        selected = self.selectedMGL()
+        if not selected:
+            return
+        self.mgl_buccal[selected] = 0.0
+        self.mgl_apical[selected] = 0.0
+        self.mgl_heights[selected] = DEFAULT_HEIGHT
+        self.onMGLSelectionChanged()
+        self.markPreviewDirty()
+
+    # --- landmarks ---
+
+    def selectMGLLandmarks(self):
+        path = QFileDialog.getOpenFileName(None, 'Open the MG landmarks', '', 'Markups (*.json *.mrk.json)')
+        if path:
+            self.lineedit_mgl_landmarks.setText(path)
+            self.loadMGLLandmarks()
+
+    def loadMGLLandmarks(self):
+        '''Read the landmark file and hand it to the patch builder.'''
+        path = self.lineedit_mgl_landmarks.text.strip()
+        if not path or not os.path.isfile(path):
+            return False
+        if self.surf is None:
+            self.viewScan()
+        if self.surf is None:
+            return False
+
+        try:
+            self.mgl_landmarks = ReadLandmarks(path)
+        except Exception as error:
+            logger.error(f"Could not read the MG landmarks: {error}")
+            self.warning(f'This landmark file cannot be read.\n{error}')
+            return False
+
+        if not self.mgl_builder.prepare(self.surf.GetPolyData(), self.mgl_landmarks):
+            self.warning(self.mgl_builder.error or 'The MG landmarks do not fit this scan.')
+            return False
+
+        self.mgl_names = self.mgl_builder.names()
+        for name, checkbox in self.mgl_checkboxes.items():
+            checkbox.setEnabled(name in self.mgl_names)
+            if name not in self.mgl_names:
+                checkbox.setChecked(False)
+        self.markPreviewDirty()
+        return True
+
+    def computeMGLLandmarks(self):
+        '''Predict the MG landmarks of this scan with ALI, in the conda env.'''
+        path = str(self.lineedit.text)
+        if not os.path.isfile(path):
+            self.warning('Select the scan first.')
+            return
+
+        models = self.mglModelsFolder()
+        if models is None:
+            return
+
+        output = os.path.join(tempfile.mkdtemp(), 'MGL_landmarks')
+        os.makedirs(output, exist_ok=True)
+        arguments = [path, models, 'None', 'None', ' '.join(MGL_ORDER), output,
+                     '224', '0', '1', os.path.join(output, 'process.log')]
+
+        progress = QProgressDialog('Predicting the MG landmarks with ALI...', None, 0, 0, None)
+        progress.setWindowTitle('ALI_IOS')
+        progress.setWindowModality(Qt.WindowModal)
+        progress.show()
+        slicer.app.processEvents()
+        try:
+            self.logic.runALI(arguments)
+        finally:
+            progress.close()
+
+        produced = sorted(f for f in os.listdir(output) if f.endswith('.json'))
+        if not produced:
+            self.warning('ALI did not produce any landmark file, see the log for details.')
+            return
+
+        self.lineedit_mgl_landmarks.setText(os.path.join(output, produced[0]))
+        self.loadMGLLandmarks()
+
+    def mglModelsFolder(self):
+        '''Folder holding Lower_MG_*.pth, downloading it once if need be.'''
+        folder = os.path.join(self.SlicerDownloadPath, 'ALI', 'ALI_IOS', 'Models', 'Prediction')
+        if self.hasMGLModel(folder):
+            return folder
+
+        chosen = QFileDialog.getExistingDirectory(None, 'Select the ALI models folder')
+        if chosen and self.hasMGLModel(chosen):
+            return chosen
+        if chosen:
+            self.warning('No MGL model in that folder, a file named "Lower_MG_*.pth" is expected.')
+        return None
+
+    @staticmethod
+    def hasMGLModel(folder):
+        if not folder or not os.path.isdir(folder):
+            return False
+        for root, _dirs, files in os.walk(folder):
+            for name in files:
+                if name.endswith('.pth') and 'Lower' in name and name.split('_')[1:2] == ['MG']:
+                    return True
+        return False
+
+    # --- preview and patch ---
+
+    def refreshMGLPreview(self):
+        '''Repaint the band for the current offsets and heights.'''
+        if not self.mgl_builder.ready:
+            return
+        labels, _samples = self.mgl_builder.compute(
+            self.mgl_buccal[:len(self.mgl_names)],
+            self.mgl_apical[:len(self.mgl_names)],
+            self.mgl_heights[:len(self.mgl_names)],
+        )
+        self.showMGLPreview(labels)
+
+    def showMGLPreview(self, labels):
+        polydata = self.surf.GetPolyData()
+        array = self.mgl_builder.toArray(labels, MGL_PREVIEW_ARRAY_NAME)
+        polydata.GetPointData().AddArray(array)
+        polydata.GetPointData().SetActiveScalars(MGL_PREVIEW_ARRAY_NAME)
+        display = self.surf.GetDisplayNode()
+        if display is not None:
+            display.SetActiveScalarName(MGL_PREVIEW_ARRAY_NAME)
+            display.SetScalarVisibility(True)
+        polydata.Modified()
+
+    def clearMGLPreview(self):
+        if self.surf is None:
+            return
+        polydata = self.surf.GetPolyData()
+        if polydata.GetPointData().GetArray(MGL_PREVIEW_ARRAY_NAME):
+            polydata.GetPointData().RemoveArray(MGL_PREVIEW_ARRAY_NAME)
+            polydata.Modified()
+
+    def applyMGLPatch(self):
+        '''
+        Write the patch into the scan. The band is computed here rather than by
+        the CLI: it needs no GPU, so what the user sees is exactly what is
+        written.
+        '''
+        if not self.mgl_builder.ready:
+            self.warning('Load or compute the MG landmarks first.')
+            return
+
+        labels, _samples = self.mgl_builder.compute(
+            self.mgl_buccal[:len(self.mgl_names)],
+            self.mgl_apical[:len(self.mgl_names)],
+            self.mgl_heights[:len(self.mgl_names)],
+        )
+        if labels.sum() == 0:
+            self.warning('The patch is empty, raise the height.')
+            return
+
+        path = str(self.lineedit.text)
+        reader = vtk.vtkPolyDataReader()
+        reader.SetFileName(path)
+        reader.Update()
+        polydata = reader.GetOutput()
+
+        if polydata.GetNumberOfPoints() != len(labels):
+            self.warning('The scan on disk no longer matches the one displayed.')
+            return
+
+        polydata.GetPointData().AddArray(self.mgl_builder.toArray(labels, MGL_ARRAY_NAME))
+        writer = vtk.vtkPolyDataWriter()
+        writer.SetFileName(path)
+        writer.SetInputData(polydata)
+        writer.Write()
+
+        self.preview_dirty = False
+        self.button_mgl_update.setText('Update')
+        logger.info(f"Wrote the {MGL_ARRAY_NAME} patch of {int(labels.sum())} points to {path}")
+
+    def warning(self, text):
+        qt.QMessageBox.warning(None, 'Warning', text)
+
     def handleStackedWidgetChange(self, index):
         # When stackedWidget change of page, this is called.
         # Check if the new page is page 0 (index 0) and called hideLandmark if its the case.
         if index == 0:
+            self.clearMGLPreview()
+            self.hideLandmark()
+            self.schedulePreview()
+        elif index == 2:
+            self.clearPreview()
             self.hideLandmark()
             self.schedulePreview()
         else :
             # The joystick preview has no meaning in the drawn-curve mode.
             self.clearPreview()
+            self.clearMGLPreview()
             self.viewLandmark()
 
     def onCheckboxStateChanged(self):
@@ -1937,6 +2355,21 @@ class WidgetParameter:
     
     def changeMode(self,index):
         self.stackedWidget.setCurrentIndex(index)
+
+    def isLowerArch(self):
+        return self.combobox_arch.currentIndex == 1
+
+    def changeArch(self, index):
+        '''
+        Upper keeps the two ways of drawing the palatal patch; lower has a
+        single one, built from the landmarks, so the method selector goes away.
+        '''
+        lower = index == 1
+        self.combobox_choice_method.setVisible(not lower)
+        self.stackedWidget.setCurrentIndex(2 if lower else self.combobox_choice_method.currentIndex)
+        for widget in (self.label_patch, self.combobox_patch,
+                       self.add_patch, self.label_addpatch, self.delete_patch):
+            widget.setVisible(False if lower else widget.isVisible())
 
     def getPath(self):
         return self.lineedit.text
@@ -2324,7 +2757,9 @@ class WidgetParameter:
 
     def markPreviewDirty(self):
         self.preview_dirty = True
-        self.button_update.setText('Update   (preview not applied)')
+        button = (self.button_mgl_update if self.stackedWidget.currentIndex == 2
+                  else self.button_update)
+        button.setText('Update   (preview not applied)')
         self.schedulePreview()
 
     def schedulePreview(self):
@@ -2336,7 +2771,17 @@ class WidgetParameter:
             self.preview_timer.start(15)
 
     def refreshPreview(self):
-        if self.surf is None or self.stackedWidget.currentIndex != 0:
+        if self.surf is None:
+            return
+        try:
+            page = self.stackedWidget.currentIndex
+        except ValueError:
+            # the panel was closed while a redraw was still pending
+            return
+        if page == 2:
+            self.refreshMGLPreview()
+            return
+        if page != 0:
             return
 
         teeth = self.teethMapping()

--- a/FlexReg/FlexReg_utils/mgl_patch.py
+++ b/FlexReg/FlexReg_utils/mgl_patch.py
@@ -1,0 +1,287 @@
+# Build the lower registration patch from the mucogingival landmarks predicted
+# by ALI_IOS, with a height the user sets tooth by tooth.
+#
+# The upper arch is registered on a patch drawn over the palate. The mandible
+# has no such plateau, but it has the mucogingival line: the 13 MG landmarks run
+# along the arch, a B-spline joins them, and the band of surface around that
+# curve plays the same role.
+#
+# Two properties matter for the result to be usable, and a third for it to be
+# editable:
+#   - every sample of the curve is snapped onto the mesh, because a curve
+#     interpolated between landmarks leaves the surface in the concavities
+#     between teeth;
+#   - the band grows along the surface, never through it, so a buccal patch
+#     cannot appear on the lingual side where the ridge is thin;
+#   - the height is carried by the landmarks and interpolated in between, so
+#     moving one point only reshapes the patch around it.
+import logging
+import sys
+
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
+
+logger = logging.getLogger("FlexReg_mgl_patch")
+
+# Landmark names of the MG model, in arch order. L0MG is the midline (tooth 25),
+# so the right side is shifted by one against the tooth numbers.
+MGL_ORDER = ['LL6MG', 'LL5MG', 'LL4MG', 'LL3MG', 'LL2MG', 'LL1MG', 'L0MG',
+             'LR1MG', 'LR2MG', 'LR3MG', 'LR4MG', 'LR5MG', 'LR6MG']
+
+# Name of the point array the patch is written to, matching what AREG_IOS reads.
+MGL_ARRAY_NAME = "Bottom_MGL"
+MGL_PREVIEW_ARRAY_NAME = "Bottom_MGLPreview"
+
+DEFAULT_HEIGHT = 5.0        # mm of surface on each side of the line
+MIN_HEIGHT = 0.5
+MAX_HEIGHT = 20.0
+SAMPLES_PER_SEGMENT = 25    # spline samples between two consecutive landmarks
+
+# Universal_ID labels of the lower teeth. The crowns move between the two
+# timepoints, so they must never end up inside the patch.
+LOWER_TOOTH_LABELS = range(18, 32)
+
+
+def ReadLandmarks(path):
+    """Read a Slicer markups json as {label: position}."""
+    import json
+    with open(path) as f:
+        data = json.load(f)
+    return {point["label"]: np.array(point["position"], dtype=float)
+            for point in data["markups"][0]["controlPoints"]
+            if point.get("position")}
+
+
+def OrderedLandmarks(landmarks):
+    """MG landmark names and positions in arch order.
+
+    Returns (names, positions). Missing teeth are skipped rather than fatal: a
+    scan where ALI could not place every point still yields a usable curve.
+    """
+    names = [name for name in MGL_ORDER if name in landmarks]
+    if len(names) < 3:
+        raise ValueError(
+            f"Fewer than 3 MG landmarks found, expected names such as "
+            f"{MGL_ORDER[:3]}, got {sorted(landmarks)}"
+        )
+    return names, np.array([landmarks[name] for name in names], dtype=float)
+
+
+def LocalFrames(points):
+    """Buccal and apical unit vectors at each landmark.
+
+    The apical axis is the normal of the plane the landmarks lie in, so it does
+    not depend on how the scan happens to be oriented in world space. The buccal
+    axis is perpendicular to both that normal and the local arch tangent, and is
+    flipped where needed so it always points away from the arch.
+
+    Returns (buccal, apical) with buccal of shape (N, 3) and apical of shape (3,).
+    """
+    centre = points.mean(axis=0)
+    centred = points - centre
+    # smallest singular direction of a ribbon of points is its plane normal
+    apical = np.linalg.svd(centred)[2][2]
+    apical = apical / np.linalg.norm(apical)
+
+    tangents = np.gradient(points, axis=0)
+    buccal = np.cross(tangents, apical)
+    norms = np.linalg.norm(buccal, axis=1, keepdims=True)
+    buccal = buccal / np.where(norms < 1e-9, 1.0, norms)
+
+    outward = centred - np.outer(centred @ apical, apical)
+    flip = np.sum(buccal * outward, axis=1) < 0
+    buccal[flip] *= -1.0
+    return buccal, apical
+
+
+def OrientApical(apical, points, tooth_points):
+    """Return the apical axis signed away from the crowns.
+
+    The plane normal has an arbitrary sign; the teeth tell which way is up, so
+    apical is the direction leading away from them.
+    """
+    if tooth_points is None or len(tooth_points) == 0:
+        return apical
+    if np.dot(tooth_points.mean(axis=0) - points.mean(axis=0), apical) > 0:
+        return -apical
+    return apical
+
+
+def SplineThroughPoints(points, samples_per_segment=SAMPLES_PER_SEGMENT):
+    """Sample a spline passing through `points`.
+
+    Returns (samples, weights) where weights[i] holds, for each sample, how much
+    it belongs to each landmark: the sample sits between two landmarks and the
+    pair of weights says where. That is what lets a height set on one landmark
+    fade into its neighbours instead of stepping.
+    """
+    vtk_points = vtk.vtkPoints()
+    for point in points:
+        vtk_points.InsertNextPoint(*point)
+
+    spline = vtk.vtkParametricSpline()
+    spline.SetPoints(vtk_points)
+    spline.ClosedOff()
+
+    n_samples = max(2, (len(points) - 1) * samples_per_segment + 1)
+    source = vtk.vtkParametricFunctionSource()
+    source.SetParametricFunction(spline)
+    source.SetUResolution(n_samples - 1)
+    source.Update()
+
+    samples = vtk_to_numpy(source.GetOutput().GetPoints().GetData())
+
+    # Arc position of every sample, expressed in landmark index units. The
+    # spline is sampled evenly in its parameter, which passes through the
+    # landmarks at regular intervals.
+    positions = np.linspace(0.0, len(points) - 1.0, len(samples))
+    return samples, positions
+
+
+def InterpolateHeights(heights, positions):
+    """Height at each spline sample, linearly interpolated between landmarks."""
+    return np.interp(positions, np.arange(len(heights)), heights)
+
+
+class MGLPatchBuilder:
+    """Turns landmark offsets and heights into a patch, fast enough to drag.
+
+    The per-scan work -- reading the mesh, building the edge graph, locating the
+    teeth -- is done once by prepare(). Each compute() then only moves the
+    landmarks, redraws the spline and walks the graph, which is what makes a
+    live preview possible.
+    """
+
+    def __init__(self):
+        self.clear()
+
+    def clear(self):
+        self.ready = False
+        self.error = None
+        self._points = None
+        self._graph = None
+        self._tooth_mask = None
+        self._landmarks = None
+        self._names = []
+
+    def prepare(self, polydata, landmarks):
+        """Cache what does not change while the user drags. True on success."""
+        try:
+            self._names, self._landmarks = OrderedLandmarks(landmarks)
+        except ValueError as error:
+            self.error = str(error)
+            self.ready = False
+            return False
+
+        self._points = vtk_to_numpy(polydata.GetPoints().GetData())
+        self._graph = self._buildGraph(polydata)
+        self._tooth_mask = self._buildToothMask(polydata)
+        self._locator = vtk.vtkPointLocator()
+        self._locator.SetDataSet(polydata)
+        self._locator.BuildLocator()
+
+        tooth_points = self._points[self._tooth_mask] if self._tooth_mask.any() else None
+        buccal, apical = LocalFrames(self._landmarks)
+        self._buccal = buccal
+        self._apical = OrientApical(apical, self._landmarks, tooth_points)
+
+        self.ready = True
+        self.error = None
+        return True
+
+    def _buildGraph(self, polydata):
+        """Edge graph of the mesh, one entry per edge.
+
+        Every interior edge belongs to two triangles, and a sparse matrix built
+        from the raw list would add those duplicates together, silently doubling
+        the length of most edges and halving the reach of the patch.
+        """
+        from scipy.sparse import coo_matrix
+
+        faces = vtk_to_numpy(polydata.GetPolys().GetData()).reshape(-1, 4)[:, 1:]
+        edges = np.vstack([faces[:, [0, 1]], faces[:, [1, 2]], faces[:, [2, 0]]])
+        edges = np.unique(np.sort(edges, axis=1), axis=0)
+
+        lengths = np.linalg.norm(self._points[edges[:, 0]] - self._points[edges[:, 1]], axis=1)
+        n_points = len(self._points)
+        return coo_matrix(
+            (np.r_[lengths, lengths],
+             (np.r_[edges[:, 0], edges[:, 1]], np.r_[edges[:, 1], edges[:, 0]])),
+            shape=(n_points, n_points),
+        ).tocsr()
+
+    def _buildToothMask(self, polydata):
+        """True where a vertex belongs to a crown, False on the gingiva."""
+        point_data = polydata.GetPointData()
+        for name in ("Universal_ID", "PredictedID", "UniversalID"):
+            scalars = point_data.GetScalars(name) or point_data.GetArray(name)
+            if scalars is not None:
+                return np.isin(vtk_to_numpy(scalars), list(LOWER_TOOTH_LABELS))
+
+        logger.warning("No teeth segmentation on the mesh, the patch is not kept off the crowns")
+        return np.zeros(len(self._points), dtype=bool)
+
+    def names(self):
+        return list(self._names)
+
+    def movedLandmarks(self, buccal_offsets, apical_offsets):
+        """Landmark positions after the offsets the user dialled in."""
+        moved = self._landmarks.copy()
+        moved = moved + self._buccal * np.asarray(buccal_offsets, dtype=float)[:, None]
+        moved = moved + np.outer(np.asarray(apical_offsets, dtype=float), self._apical)
+        return moved
+
+    def compute(self, buccal_offsets, apical_offsets, heights, exclude_teeth=True):
+        """Patch labels for the current settings, as a 0/1 array over the mesh.
+
+        Each vertex is reached from the nearest spline sample; the height that
+        sample carries is the one it is judged against, so a tall stretch and a
+        short stretch can sit side by side on the same curve.
+        """
+        from scipy.sparse.csgraph import dijkstra
+
+        moved = self.movedLandmarks(buccal_offsets, apical_offsets)
+        samples, positions = SplineThroughPoints(moved)
+        sample_heights = InterpolateHeights(np.asarray(heights, dtype=float), positions)
+
+        seeds, seed_heights = [], []
+        seen = {}
+        for sample, height in zip(samples, sample_heights):
+            point_id = self._locator.FindClosestPoint(sample)
+            if point_id in seen:
+                # one vertex can serve several samples: keep the tallest, so a
+                # height raised anywhere is never swallowed by a neighbour
+                seed_heights[seen[point_id]] = max(seed_heights[seen[point_id]], height)
+                continue
+            seen[point_id] = len(seeds)
+            seeds.append(point_id)
+            seed_heights.append(height)
+
+        seeds = np.asarray(seeds)
+        seed_heights = np.asarray(seed_heights)
+
+        distances, _, sources = dijkstra(
+            self._graph, directed=False, indices=seeds,
+            limit=float(seed_heights.max()), min_only=True, return_predecessors=True,
+        )
+
+        reached = np.isfinite(distances)
+        inside = np.zeros(len(self._points), dtype=bool)
+        if reached.any():
+            # sources holds the seed vertex each node was reached from
+            seed_index = {seed: i for i, seed in enumerate(seeds)}
+            source_ids = sources[reached]
+            heights_here = np.array([seed_heights[seed_index[s]] for s in source_ids])
+            inside[np.flatnonzero(reached)] = distances[reached] <= heights_here
+
+        if exclude_teeth:
+            inside &= ~self._tooth_mask
+
+        return inside.astype(np.float32), samples
+
+    def toArray(self, labels, name=MGL_ARRAY_NAME):
+        """Wrap patch labels as a named vtk array."""
+        array = numpy_to_vtk(labels.astype(np.float32), deep=True)
+        array.SetName(name)
+        return array

--- a/FlexReg/FlexReg_utils/mgl_patch.py
+++ b/FlexReg/FlexReg_utils/mgl_patch.py
@@ -29,13 +29,99 @@ logger = logging.getLogger("FlexReg_mgl_patch")
 MGL_ORDER = ['LL6MG', 'LL5MG', 'LL4MG', 'LL3MG', 'LL2MG', 'LL1MG', 'L0MG',
              'LR1MG', 'LR2MG', 'LR3MG', 'LR4MG', 'LR5MG', 'LR6MG']
 
+# The hand annotations of the training set spoke an older naming for the
+# same 13 points, placed symmetrically about the midline: 6 on each side of
+# a central point, no L0. One side carries seven names, and that side counts
+# the midline point as its "1" (verified against the 24|25 incisor plane on
+# the annotated scans: the file with an LL7 has its midline on LL1MG, the
+# file with an LR7 on LR1MG). Translating shifts that side's names inward by
+# one and renames its "1" to L0MG; nothing is lost, an old file keeps its 13
+# points. Which side got the seven varies from file to file, so both markers
+# are recognized.
+MGL_TRAINING_TABLES = {
+    'LL7MG': {
+        'LL7MG': 'LL6MG', 'LL6MG': 'LL5MG', 'LL5MG': 'LL4MG', 'LL4MG': 'LL3MG',
+        'LL3MG': 'LL2MG', 'LL2MG': 'LL1MG', 'LL1MG': 'L0MG',
+        'LR1MG': 'LR1MG', 'LR2MG': 'LR2MG', 'LR3MG': 'LR3MG', 'LR4MG': 'LR4MG',
+        'LR5MG': 'LR5MG', 'LR6MG': 'LR6MG',
+    },
+    'LR7MG': {
+        'LR7MG': 'LR6MG', 'LR6MG': 'LR5MG', 'LR5MG': 'LR4MG', 'LR4MG': 'LR3MG',
+        'LR3MG': 'LR2MG', 'LR2MG': 'LR1MG', 'LR1MG': 'L0MG',
+        'LL1MG': 'LL1MG', 'LL2MG': 'LL2MG', 'LL3MG': 'LL3MG', 'LL4MG': 'LL4MG',
+        'LL5MG': 'LL5MG', 'LL6MG': 'LL6MG',
+    },
+}
+
+
+def CanonicalLandmarks(landmarks):
+    """Landmarks renamed to the canonical naming when the file uses the old one."""
+    for marker, table in MGL_TRAINING_TABLES.items():
+        if marker not in landmarks:
+            continue
+        logger.info(f"Old MG naming detected ({marker} present): translating to "
+                    f"the canonical naming, their midline {table_centre(table)} "
+                    "becomes L0MG")
+        translated = {}
+        for name, position in landmarks.items():
+            canonical = table.get(name)
+            if canonical:
+                translated[canonical] = position
+            else:
+                logger.warning(f"Landmark {name} is not an MG name, dropped")
+        return translated
+    return dict(landmarks)
+
+
+def table_centre(table):
+    """The old name a translation table sends to L0MG."""
+    return next(old for old, new in table.items() if new == 'L0MG')
+
+
+def RecentreNames(landmarks):
+    """Keep the counting anchored on the midline when points are missing.
+
+    The 13 points are symmetric positions about the midline, not fixed tooth
+    identities: when one is missing mid-arch, the names of the points distal
+    to it on its side slide inward by one, so the hole surfaces at the far
+    end of that side and never at L0. A missing midline point is replaced by
+    the innermost right point (then the innermost left one).
+    """
+    left = [name for name in MGL_ORDER[:6] if name in landmarks]    # LL6..LL1
+    right = [name for name in MGL_ORDER[7:] if name in landmarks]   # LR1..LR6
+
+    mapping = {}
+    if 'L0MG' in landmarks:
+        mapping['L0MG'] = 'L0MG'
+    elif right:
+        mapping[right.pop(0)] = 'L0MG'
+    elif left:
+        mapping[left.pop()] = 'L0MG'
+    else:
+        return dict(landmarks)
+
+    for old_name, new_name in zip(reversed(left),
+                                  ('LL1MG', 'LL2MG', 'LL3MG', 'LL4MG', 'LL5MG', 'LL6MG')):
+        mapping[old_name] = new_name
+    for old_name, new_name in zip(right,
+                                  ('LR1MG', 'LR2MG', 'LR3MG', 'LR4MG', 'LR5MG', 'LR6MG')):
+        mapping[old_name] = new_name
+
+    moved = {old: new for old, new in mapping.items() if old != new}
+    if moved:
+        logger.info(f"Renamed to keep the counting anchored on the midline: {moved}")
+    return {new: landmarks[old] for old, new in mapping.items()}
+
 # Name of the point array the patch is written to, matching what AREG_IOS reads.
 MGL_ARRAY_NAME = "Bottom_MGL"
 MGL_PREVIEW_ARRAY_NAME = "Bottom_MGLPreview"
 
-DEFAULT_HEIGHT = 5.0        # mm of surface on each side of the line
-MIN_HEIGHT = 0.5
-MAX_HEIGHT = 20.0
+DEFAULT_HEIGHT = 2.5        # mm of surface on each side of the line
+# 0 is meaningful: the band degenerates into the snapped curve itself, so the
+# registration runs on the mucogingival line rather than on a patch. A short
+# slider travel keeps every 0.1 mm step wide under the finger.
+MIN_HEIGHT = 0.0
+MAX_HEIGHT = 5.0
 SAMPLES_PER_SEGMENT = 25    # spline samples between two consecutive landmarks
 
 # Universal_ID labels of the lower teeth. The crowns move between the two
@@ -53,12 +139,43 @@ def ReadLandmarks(path):
             if point.get("position")}
 
 
-def OrderedLandmarks(landmarks):
-    """MG landmark names and positions in arch order.
+def WriteLandmarks(path, names, positions):
+    """Write landmarks as a Slicer markups json, in the file's coordinates.
 
-    Returns (names, positions). Missing teeth are skipped rather than fatal: a
-    scan where ALI could not place every point still yields a usable curve.
+    The coordinateSystem is declared LPS like the training annotations : the
+    positions passed in must therefore be those of the mesh file on disk, not
+    the RAS ones Slicer displays. What is written reads back with
+    ReadLandmarks and can join the training corpus as it is.
     """
+    import json
+    content = {
+        "@schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/"
+                   "Modules/Loadable/Markups/Resources/Schema/"
+                   "markups-schema-v1.0.3.json",
+        "markups": [{
+            "type": "Fiducial",
+            "coordinateSystem": "LPS",
+            "coordinateUnits": "mm",
+            "controlPoints": [
+                {"id": str(index + 1), "label": name,
+                 "position": [float(value) for value in position]}
+                for index, (name, position) in enumerate(zip(names, positions))
+            ],
+        }],
+    }
+    with open(path, 'w') as handle:
+        json.dump(content, handle, indent=2)
+
+
+def OrderedLandmarks(landmarks):
+    """MG landmark names and positions in arch order, in the canonical naming.
+
+    Files annotated with the older naming (recognizable by their LL7MG) are
+    translated first, so the same name always designates the same tooth
+    downstream. Missing teeth are skipped rather than fatal: a scan where ALI
+    could not place every point still yields a usable curve.
+    """
+    landmarks = RecentreNames(CanonicalLandmarks(landmarks))
     names = [name for name in MGL_ORDER if name in landmarks]
     if len(names) < 3:
         raise ValueError(
@@ -69,14 +186,16 @@ def OrderedLandmarks(landmarks):
 
 
 def LocalFrames(points):
-    """Buccal and apical unit vectors at each landmark.
+    """Buccal, tangent and apical unit vectors at each landmark.
 
     The apical axis is the normal of the plane the landmarks lie in, so it does
-    not depend on how the scan happens to be oriented in world space. The buccal
-    axis is perpendicular to both that normal and the local arch tangent, and is
-    flipped where needed so it always points away from the arch.
+    not depend on how the scan happens to be oriented in world space. The
+    tangent follows the arch in landmark order, from LL6 towards LR6. The
+    buccal axis is perpendicular to both, flipped where needed so it always
+    points away from the arch.
 
-    Returns (buccal, apical) with buccal of shape (N, 3) and apical of shape (3,).
+    Returns (buccal, tangent, apical) with buccal and tangent of shape (N, 3)
+    and apical of shape (3,).
     """
     centre = points.mean(axis=0)
     centred = points - centre
@@ -85,6 +204,9 @@ def LocalFrames(points):
     apical = apical / np.linalg.norm(apical)
 
     tangents = np.gradient(points, axis=0)
+    norms = np.linalg.norm(tangents, axis=1, keepdims=True)
+    tangent = tangents / np.where(norms < 1e-9, 1.0, norms)
+
     buccal = np.cross(tangents, apical)
     norms = np.linalg.norm(buccal, axis=1, keepdims=True)
     buccal = buccal / np.where(norms < 1e-9, 1.0, norms)
@@ -92,7 +214,7 @@ def LocalFrames(points):
     outward = centred - np.outer(centred @ apical, apical)
     flip = np.sum(buccal * outward, axis=1) < 0
     buccal[flip] *= -1.0
-    return buccal, apical
+    return buccal, tangent, apical
 
 
 def OrientApical(apical, points, tooth_points):
@@ -182,8 +304,9 @@ class MGLPatchBuilder:
         self._locator.BuildLocator()
 
         tooth_points = self._points[self._tooth_mask] if self._tooth_mask.any() else None
-        buccal, apical = LocalFrames(self._landmarks)
+        buccal, tangent, apical = LocalFrames(self._landmarks)
         self._buccal = buccal
+        self._tangent = tangent
         self._apical = OrientApical(apical, self._landmarks, tooth_points)
 
         self.ready = True
@@ -225,45 +348,81 @@ class MGLPatchBuilder:
     def names(self):
         return list(self._names)
 
-    def movedLandmarks(self, buccal_offsets, apical_offsets):
+    def movedLandmarks(self, buccal_offsets, apical_offsets, tangent_offsets=None):
         """Landmark positions after the offsets the user dialled in."""
         moved = self._landmarks.copy()
         moved = moved + self._buccal * np.asarray(buccal_offsets, dtype=float)[:, None]
         moved = moved + np.outer(np.asarray(apical_offsets, dtype=float), self._apical)
+        if tangent_offsets is not None:
+            moved = moved + self._tangent * np.asarray(tangent_offsets, dtype=float)[:, None]
         return moved
 
-    def compute(self, buccal_offsets, apical_offsets, heights, exclude_teeth=True):
+    def snappedLandmarkIds(self, buccal_offsets, apical_offsets, tangent_offsets=None):
+        """Vertex id under each moved landmark.
+
+        The coordinate-free form of snappedLandmarks : an id designates the
+        same vertex in every copy of the mesh, whatever the coordinate system
+        or centering, which is what makes it worth saving into the file.
+        """
+        moved = self.movedLandmarks(buccal_offsets, apical_offsets, tangent_offsets)
+        return [int(self._locator.FindClosestPoint(point)) for point in moved]
+
+    def snappedLandmarks(self, buccal_offsets, apical_offsets, tangent_offsets=None):
+        """Moved landmarks, brought back onto the mesh.
+
+        The offsets push the points along straight axes, off the surface; the
+        band is built from the curve snapped back onto it, so this is where
+        the landmarks effectively act — and where they should be displayed.
+        """
+        ids = self.snappedLandmarkIds(buccal_offsets, apical_offsets, tangent_offsets)
+        return self._points[ids]
+
+    def compute(self, buccal_offsets, apical_offsets, heights, heights_down=None,
+                exclude_teeth=True, tangent_offsets=None):
         """Patch labels for the current settings, as a 0/1 array over the mesh.
 
         Each vertex is reached from the nearest spline sample; the height that
         sample carries is the one it is judged against, so a tall stretch and a
         short stretch can sit side by side on the same curve.
+
+        With `heights_down`, the band is asymmetric: `heights` bounds the crown
+        side of the curve and `heights_down` the vestibule side. Left to None,
+        both sides use `heights` and the band is the symmetric one of before.
         """
         from scipy.sparse.csgraph import dijkstra
 
-        moved = self.movedLandmarks(buccal_offsets, apical_offsets)
+        moved = self.movedLandmarks(buccal_offsets, apical_offsets, tangent_offsets)
         samples, positions = SplineThroughPoints(moved)
-        sample_heights = InterpolateHeights(np.asarray(heights, dtype=float), positions)
+        heights_up = np.asarray(heights, dtype=float)
+        heights_down = (heights_up if heights_down is None
+                        else np.asarray(heights_down, dtype=float))
+        sample_up = InterpolateHeights(heights_up, positions)
+        sample_down = InterpolateHeights(heights_down, positions)
 
-        seeds, seed_heights = [], []
+        seeds, seed_up, seed_down = [], [], []
         seen = {}
-        for sample, height in zip(samples, sample_heights):
+        for sample, up, down in zip(samples, sample_up, sample_down):
             point_id = self._locator.FindClosestPoint(sample)
             if point_id in seen:
                 # one vertex can serve several samples: keep the tallest, so a
                 # height raised anywhere is never swallowed by a neighbour
-                seed_heights[seen[point_id]] = max(seed_heights[seen[point_id]], height)
+                at = seen[point_id]
+                seed_up[at] = max(seed_up[at], up)
+                seed_down[at] = max(seed_down[at], down)
                 continue
             seen[point_id] = len(seeds)
             seeds.append(point_id)
-            seed_heights.append(height)
+            seed_up.append(up)
+            seed_down.append(down)
 
         seeds = np.asarray(seeds)
-        seed_heights = np.asarray(seed_heights)
+        seed_up = np.asarray(seed_up)
+        seed_down = np.asarray(seed_down)
 
         distances, _, sources = dijkstra(
             self._graph, directed=False, indices=seeds,
-            limit=float(seed_heights.max()), min_only=True, return_predecessors=True,
+            limit=float(max(seed_up.max(), seed_down.max())),
+            min_only=True, return_predecessors=True,
         )
 
         reached = np.isfinite(distances)
@@ -271,9 +430,18 @@ class MGLPatchBuilder:
         if reached.any():
             # sources holds the seed vertex each node was reached from
             seed_index = {seed: i for i, seed in enumerate(seeds)}
+            reached_ids = np.flatnonzero(reached)
             source_ids = sources[reached]
-            heights_here = np.array([seed_heights[seed_index[s]] for s in source_ids])
-            inside[np.flatnonzero(reached)] = distances[reached] <= heights_here
+            source_at = np.array([seed_index[s] for s in source_ids])
+            # Which side of the curve each vertex sits on: the apical axis
+            # leads away from the crowns, so a positive component along it is
+            # the vestibule side. On the curve itself the component is ~0 and
+            # both heights agree well enough for the tie not to matter.
+            below = np.sum(
+                (self._points[reached_ids] - self._points[source_ids]) * self._apical,
+                axis=1) > 0
+            allowed = np.where(below, seed_down[source_at], seed_up[source_at])
+            inside[reached_ids] = distances[reached] <= allowed
 
         if exclude_teeth:
             inside &= ~self._tooth_mask

--- a/FlexReg/Testing/Python/CMakeLists.txt
+++ b/FlexReg/Testing/Python/CMakeLists.txt
@@ -1,2 +1,3 @@
 
-#slicer_add_python_unittest(SCRIPT ${MODULE_NAME}ModuleTest.py)
+# Geometry tests of the MGL patch engine: synthetic mesh, no scan and no GPU.
+slicer_add_python_unittest(SCRIPT test_mgl_patch.py)

--- a/FlexReg/Testing/Python/test_mgl_patch.py
+++ b/FlexReg/Testing/Python/test_mgl_patch.py
@@ -12,6 +12,7 @@
 # Run with:  python -m unittest discover FlexReg/Testing/Python
 import os
 import sys
+import tempfile
 import unittest
 
 import numpy as np
@@ -118,6 +119,66 @@ class OrderedLandmarksTest(unittest.TestCase):
             mgl_patch.OrderedLandmarks({"LL6MG": np.zeros(3), "L0MG": np.ones(3)})
         self.assertIn("LL6MG", str(caught.exception))
 
+    def test_old_training_naming_is_translated_to_canonical(self):
+        # An old annotation file : 13 symmetric points whose left names count
+        # from the midline point inclusive, so their LL1MG is the midline
+        # itself. After translation L0MG must sit exactly there, every point
+        # must survive, and the arch order must hold.
+        old_names = ['LL7MG', 'LL6MG', 'LL5MG', 'LL4MG', 'LL3MG', 'LL2MG', 'LL1MG',
+                     'LR1MG', 'LR2MG', 'LR3MG', 'LR4MG', 'LR5MG', 'LR6MG']
+        xs = np.linspace(-12, 12, len(old_names))
+        landmarks = {name: np.array([x, x ** 2 / 60.0 - 2.0, 0.0])
+                     for name, x in zip(old_names, xs)}
+        names, positions = mgl_patch.OrderedLandmarks(landmarks)
+
+        self.assertEqual(names, mgl_patch.MGL_ORDER)  # all 13, L0MG included
+        np.testing.assert_allclose(positions[names.index('L0MG')],
+                                   landmarks['LL1MG'])
+        np.testing.assert_allclose(positions[names.index('LL6MG')],
+                                   landmarks['LL7MG'])
+        np.testing.assert_allclose(positions[names.index('LR6MG')],
+                                   landmarks['LR6MG'])
+
+    def test_the_lr7_variant_of_the_old_naming_is_translated_too(self):
+        # Some old files carry the seven names on the RIGHT side : their
+        # midline point is LR1MG and LR7MG is their distal-right end.
+        old_names = ['LR7MG', 'LR6MG', 'LR5MG', 'LR4MG', 'LR3MG', 'LR2MG', 'LR1MG',
+                     'LL1MG', 'LL2MG', 'LL3MG', 'LL4MG', 'LL5MG', 'LL6MG']
+        xs = np.linspace(12, -12, len(old_names))
+        landmarks = {name: np.array([x, x ** 2 / 60.0 - 2.0, 0.0])
+                     for name, x in zip(old_names, xs)}
+        names, positions = mgl_patch.OrderedLandmarks(landmarks)
+
+        self.assertEqual(names, mgl_patch.MGL_ORDER)  # all 13, L0MG included
+        np.testing.assert_allclose(positions[names.index('L0MG')],
+                                   landmarks['LR1MG'])
+        np.testing.assert_allclose(positions[names.index('LR6MG')],
+                                   landmarks['LR7MG'])
+        np.testing.assert_allclose(positions[names.index('LL6MG')],
+                                   landmarks['LL6MG'])
+
+    def test_a_missing_midline_point_is_refilled_from_the_right(self):
+        # L0 must always exist : when the midline point itself is missing,
+        # the counting recentres and the hole surfaces at the LR6 end.
+        landmarks = ArchLandmarks()
+        del landmarks['L0MG']
+        old_lr1 = landmarks['LR1MG'].copy()
+        names, positions = mgl_patch.OrderedLandmarks(landmarks)
+        self.assertIn('L0MG', names)
+        self.assertNotIn('LR6MG', names)
+        np.testing.assert_allclose(positions[names.index('L0MG')], old_lr1)
+
+    def test_a_hole_in_the_middle_of_a_side_surfaces_at_its_end(self):
+        landmarks = ArchLandmarks()
+        del landmarks['LL3MG']
+        old_ll4 = landmarks['LL4MG'].copy()
+        names, positions = mgl_patch.OrderedLandmarks(landmarks)
+        self.assertIn('LL3MG', names)     # refilled by the next point out
+        self.assertNotIn('LL6MG', names)  # the hole surfaced at the far end
+        self.assertIn('L0MG', names)      # the centre and the right side
+        self.assertIn('LR6MG', names)     # are left alone
+        np.testing.assert_allclose(positions[names.index('LL3MG')], old_ll4)
+
 
 class EdgeGraphTest(unittest.TestCase):
     """The reach of the patch is only as trustworthy as the edge lengths."""
@@ -174,6 +235,17 @@ class PatchReachTest(unittest.TestCase):
         self.assertGreater(tall, 5.0)
         self.assertLess(short, 4.0)
         self.assertGreater(tall, short + 2.0)
+
+    def test_zero_height_keeps_only_the_curve(self):
+        # Height 0 must not be empty : the band degenerates into the snapped
+        # curve itself, so the registration can run on the line alone.
+        labels = self.patch(np.zeros(self.n))
+        selected = self.vertices[labels > 0.5]
+        self.assertGreater(len(selected), 0)
+        spline, _ = mgl_patch.SplineThroughPoints(self.builder._landmarks)
+        to_curve = np.linalg.norm(
+            selected[:, None, :] - spline[None, :, :], axis=2).min(axis=1)
+        self.assertLessEqual(to_curve.max(), GRID_STEP)
 
     def test_a_tall_landmark_is_not_swallowed_by_a_short_neighbour(self):
         # Dozens of spline samples land on the same vertex, and the tall
@@ -239,6 +311,122 @@ class OffsetTest(unittest.TestCase):
         travelled = np.linalg.norm(moved - self.builder._landmarks, axis=1)
         self.assertAlmostEqual(travelled[4], 3.0, places=9)
         self.assertAlmostEqual(np.delete(travelled, 4).max(), 0.0, places=9)
+
+    def test_a_tangent_offset_slides_along_the_arch(self):
+        moved = self.builder.movedLandmarks(self.zero, self.zero,
+                                            np.full(self.n, 2.0))
+        travelled = np.linalg.norm(moved - self.builder._landmarks, axis=1)
+        np.testing.assert_allclose(travelled, 2.0, atol=1e-9)
+        # every point moves towards its next neighbour along the arch,
+        # i.e. from the LL6 end towards the LR6 end
+        for index in range(self.n - 1):
+            towards_next = (self.builder._landmarks[index + 1]
+                            - self.builder._landmarks[index])
+            self.assertGreater(
+                np.dot(moved[index] - self.builder._landmarks[index], towards_next), 0)
+
+    def test_snapped_landmarks_stay_on_the_mesh(self):
+        # An apical offset leaves the mesh plane entirely; the displayed
+        # points must come back onto the surface, near where they started.
+        snapped = self.builder.snappedLandmarks(self.zero, np.full(self.n, 3.0))
+        self.assertAlmostEqual(np.abs(snapped[:, 2]).max(), 0.0, places=9)
+        drift = np.linalg.norm(
+            snapped[:, :2] - self.builder._landmarks[:, :2], axis=1)
+        self.assertLessEqual(drift.max(), GRID_STEP)
+
+
+class AsymmetricHeightTest(unittest.TestCase):
+    """The band can climb a different distance towards the crowns and towards
+    the vestibule.
+
+    The landmark ribbon is tilted out of the mesh plane so its normal -- the
+    apical axis -- has an in-plane component, which is what gives 'up' and
+    'down' a direction on the flat mesh; tooth labels on the crown side pin
+    its sign, exactly as the real segmentation does.
+    """
+
+    def setUp(self):
+        self.polydata, self.vertices = FlatMesh()
+        labels = np.where(self.vertices[:, 1] > 6.0, 20, 0).astype(np.int16)
+        array = numpy_to_vtk(labels, deep=True)
+        array.SetName("Universal_ID")
+        self.polydata.GetPointData().AddArray(array)
+
+        tilted = {name: position + np.array([0.0, 0.0, 0.5 * position[1]])
+                  for name, position in ArchLandmarks().items()}
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, tilted))
+        self.n = len(self.builder.names())
+        self.zero = np.zeros(self.n)
+
+    def sideReach(self, labels, x_centre=0.0, window=0.6):
+        """Extent of the patch on each side of the curve, in one mesh column.
+
+        Returns (towards the crowns, towards the vestibule): the teeth sit at
+        positive y, so positive offsets from the curve are the crown side.
+        """
+        column = np.abs(self.vertices[:, 0] - x_centre) < window
+        selected = column & (labels > 0.5)
+        curve_y = x_centre ** 2 / 60.0 - 2.0
+        offsets = self.vertices[selected][:, 1] - curve_y
+        crown = float(offsets[offsets > 0].max()) if (offsets > 0).any() else 0.0
+        vestibule = float(-offsets[offsets < 0].min()) if (offsets < 0).any() else 0.0
+        return crown, vestibule
+
+    def test_the_two_sides_of_the_band_are_independent(self):
+        labels, _ = self.builder.compute(
+            self.zero, self.zero,
+            np.full(self.n, 2.0), np.full(self.n, 8.0),
+            exclude_teeth=False)
+        crown, vestibule = self.sideReach(labels)
+        self.assertLess(crown, 4.0)
+        self.assertGreater(vestibule, 6.0)
+
+    def test_the_asymmetry_goes_both_ways(self):
+        labels, _ = self.builder.compute(
+            self.zero, self.zero,
+            np.full(self.n, 8.0), np.full(self.n, 2.0),
+            exclude_teeth=False)
+        crown, vestibule = self.sideReach(labels)
+        self.assertGreater(crown, 6.0)
+        self.assertLess(vestibule, 4.0)
+
+    def test_no_second_height_keeps_the_symmetric_band(self):
+        symmetric, _ = self.builder.compute(
+            self.zero, self.zero, np.full(self.n, 5.0), exclude_teeth=False)
+        explicit, _ = self.builder.compute(
+            self.zero, self.zero,
+            np.full(self.n, 5.0), np.full(self.n, 5.0),
+            exclude_teeth=False)
+        np.testing.assert_array_equal(symmetric, explicit)
+
+
+class SavedLineTest(unittest.TestCase):
+    """What Update records for a future training set."""
+
+    def setUp(self):
+        self.polydata, self.vertices = FlatMesh()
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, ArchLandmarks()))
+        self.n = len(self.builder.names())
+        self.zero = np.zeros(self.n)
+
+    def test_the_ids_designate_the_snapped_positions(self):
+        apical = np.full(self.n, 2.0)
+        ids = self.builder.snappedLandmarkIds(self.zero, apical)
+        snapped = self.builder.snappedLandmarks(self.zero, apical)
+        np.testing.assert_allclose(self.vertices[ids], snapped)
+
+    def test_landmarks_written_for_training_read_back_identically(self):
+        names = mgl_patch.MGL_ORDER[:4]
+        positions = np.arange(12, dtype=float).reshape(4, 3)
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, 'line.mrk.json')
+            mgl_patch.WriteLandmarks(path, names, positions)
+            read = mgl_patch.ReadLandmarks(path)
+        self.assertEqual(sorted(read), sorted(names))
+        for name, position in zip(names, positions):
+            np.testing.assert_allclose(read[name], position)
 
 
 class ArrayNamingTest(unittest.TestCase):

--- a/FlexReg/Testing/Python/test_mgl_patch.py
+++ b/FlexReg/Testing/Python/test_mgl_patch.py
@@ -1,0 +1,253 @@
+# Invariants of the lower-arch MGL patch engine, checked on a synthetic mesh so
+# the suite needs no patient scan and no GPU.
+#
+# Two of these guard bugs that were live during development and were both
+# invisible on screen -- the patch still looked plausible, it was simply the
+# wrong size:
+#   - an edge graph built from the raw triangle list adds every interior edge
+#     twice, doubling its length and halving the reach of the patch;
+#   - a height raised on one landmark must not be swallowed where its spline
+#     samples land on a vertex a shorter neighbour also claims.
+#
+# Run with:  python -m unittest discover FlexReg/Testing/Python
+import os
+import sys
+import unittest
+
+import numpy as np
+import vtk
+from vtk.util.numpy_support import numpy_to_vtk
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "FlexReg_utils"))
+
+import mgl_patch  # noqa: E402
+
+
+GRID_STEP = 1.0  # mm between neighbouring vertices of the test plane
+
+
+def FlatMesh(half_size=20, step=GRID_STEP):
+    """A flat triangulated square in z=0, vertices `step` mm apart.
+
+    Geodesic distance across it is Euclidean, which is what makes the reach of
+    the patch something the test can predict in closed form.
+    """
+    coords = np.arange(-half_size, half_size + step, step)
+    nx = len(coords)
+    xs, ys = np.meshgrid(coords, coords, indexing="ij")
+    vertices = np.column_stack([xs.ravel(), ys.ravel(), np.zeros(xs.size)])
+
+    points = vtk.vtkPoints()
+    points.SetData(numpy_to_vtk(vertices, deep=True))
+    polydata = vtk.vtkPolyData()
+    polydata.SetPoints(points)
+
+    cells = vtk.vtkCellArray()
+    for i in range(nx - 1):
+        for j in range(nx - 1):
+            a, b = i * nx + j, i * nx + j + 1
+            c, d = (i + 1) * nx + j, (i + 1) * nx + j + 1
+            for triangle in ((a, b, d), (a, d, c)):
+                cells.InsertNextCell(3)
+                for point_id in triangle:
+                    cells.InsertCellPoint(point_id)
+    polydata.SetPolys(cells)
+    return polydata, vertices
+
+
+def ArchLandmarks(span=12.0):
+    """The 13 MG landmarks on a shallow in-plane arc.
+
+    Deliberately curved: three collinear points leave the plane the landmarks
+    lie in undefined, and with it the apical axis derived from it.
+    """
+    xs = np.linspace(-span, span, len(mgl_patch.MGL_ORDER))
+    ys = xs ** 2 / 60.0 - 2.0
+    return {name: np.array([x, y, 0.0])
+            for name, x, y in zip(mgl_patch.MGL_ORDER, xs, ys)}
+
+
+def ReachAround(vertices, labels, builder, index):
+    """How far the patch extends from one landmark, over the mesh it owns.
+
+    Measured per landmark rather than across the arch, because a neighbour's
+    band can reach the same distance and hide a height that was lost here.
+    """
+    landmarks = builder._landmarks
+    selected = vertices[labels > 0.5]
+    if not len(selected):
+        return 0.0
+    to_each = np.linalg.norm(selected[:, None, :] - landmarks[None, :, :], axis=2)
+    owned = selected[to_each.argmin(axis=1) == index]
+    if not len(owned):
+        return 0.0
+    return float(np.linalg.norm(owned - landmarks[index], axis=1).max())
+
+
+def BandHalfWidth(vertices, labels, x_centre, window=0.6):
+    """Extent of the patch across the arch, in the slice of mesh at `x_centre`.
+
+    The band straddles the curve, so this is measured from the curve outwards
+    on the wider of the two sides.
+    """
+    column = np.abs(vertices[:, 0] - x_centre) < window
+    selected = column & (labels > 0.5)
+    if not selected.any():
+        return 0.0
+    curve_y = x_centre ** 2 / 60.0 - 2.0
+    return float(np.abs(vertices[selected][:, 1] - curve_y).max())
+
+
+class OrderedLandmarksTest(unittest.TestCase):
+    def test_orders_along_the_arch_not_by_json_order(self):
+        landmarks = ArchLandmarks()
+        shuffled = {name: landmarks[name] for name in reversed(mgl_patch.MGL_ORDER)}
+        names, _ = mgl_patch.OrderedLandmarks(shuffled)
+        self.assertEqual(names, mgl_patch.MGL_ORDER)
+
+    def test_a_scan_missing_some_landmarks_still_yields_a_curve(self):
+        landmarks = ArchLandmarks()
+        for name in ("LL6MG", "LR4MG", "LR6MG"):
+            del landmarks[name]
+        names, positions = mgl_patch.OrderedLandmarks(landmarks)
+        self.assertEqual(len(names), len(mgl_patch.MGL_ORDER) - 3)
+        self.assertEqual(len(positions), len(names))
+
+    def test_too_few_landmarks_is_an_error_naming_what_was_expected(self):
+        with self.assertRaises(ValueError) as caught:
+            mgl_patch.OrderedLandmarks({"LL6MG": np.zeros(3), "L0MG": np.ones(3)})
+        self.assertIn("LL6MG", str(caught.exception))
+
+
+class EdgeGraphTest(unittest.TestCase):
+    """The reach of the patch is only as trustworthy as the edge lengths."""
+
+    def setUp(self):
+        self.polydata, self.vertices = FlatMesh(half_size=4)
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, ArchLandmarks(span=3.0)))
+
+    def test_neighbouring_vertices_are_one_step_apart_not_two(self):
+        graph = self.builder._graph
+        nx = int(round(np.sqrt(len(self.vertices))))
+        for a, b in ((0, 1), (0, nx), (5, 6)):
+            self.assertAlmostEqual(graph[a, b], GRID_STEP, places=6,
+                                   msg="interior edges counted twice")
+
+    def test_graph_is_symmetric(self):
+        difference = abs(self.builder._graph - self.builder._graph.T).max()
+        self.assertAlmostEqual(difference, 0.0, places=9)
+
+
+class PatchReachTest(unittest.TestCase):
+    def setUp(self):
+        self.polydata, self.vertices = FlatMesh()
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, ArchLandmarks()))
+        self.n = len(self.builder.names())
+        self.zero = np.zeros(self.n)
+
+    def patch(self, heights, **kwargs):
+        labels, _ = self.builder.compute(self.zero, self.zero, heights, **kwargs)
+        return labels
+
+    def test_a_uniform_height_gives_a_band_of_that_height(self):
+        for height in (3.0, 6.0):
+            labels = self.patch(np.full(self.n, height))
+            width = BandHalfWidth(self.vertices, labels, x_centre=0.0)
+            # halved edges would put this at height/2, well under the lower bound
+            self.assertGreater(width, 0.8 * height)
+            self.assertLess(width, 1.25 * height)
+
+    def test_raising_the_height_only_ever_grows_the_patch(self):
+        small = self.patch(np.full(self.n, 3.0))
+        large = self.patch(np.full(self.n, 6.0))
+        self.assertTrue(np.all(large[small > 0.5] > 0.5))
+        self.assertGreater(large.sum(), small.sum())
+
+    def test_a_height_set_on_one_end_does_not_reshape_the_other(self):
+        heights = np.full(self.n, 2.0)
+        heights[:3] = 8.0  # the LL6..LL4 stretch, at negative x
+        labels = self.patch(heights)
+        tall = BandHalfWidth(self.vertices, labels, x_centre=-11.0)
+        short = BandHalfWidth(self.vertices, labels, x_centre=11.0)
+        self.assertGreater(tall, 5.0)
+        self.assertLess(short, 4.0)
+        self.assertGreater(tall, short + 2.0)
+
+    def test_a_tall_landmark_is_not_swallowed_by_a_short_neighbour(self):
+        # Dozens of spline samples land on the same vertex, and the tall
+        # landmark is flanked by short ones, so the samples writing that vertex
+        # arrive tall then short. Keeping the last one instead of the tallest
+        # quietly delivers a fraction of the height that was asked for.
+        tall = 12.0
+        heights = np.full(self.n, 0.5)
+        heights[self.n // 2] = tall
+        labels = self.patch(heights)
+        reach = ReachAround(self.vertices, labels, self.builder, self.n // 2)
+        self.assertGreater(reach, 0.9 * tall)
+
+
+class ToothExclusionTest(unittest.TestCase):
+    """Crowns move between timepoints, so they must stay out of the patch."""
+
+    def setUp(self):
+        self.polydata, self.vertices = FlatMesh()
+        labels = np.where(self.vertices[:, 1] > 0.0, 20, 0).astype(np.int16)
+        array = numpy_to_vtk(labels, deep=True)
+        array.SetName("Universal_ID")
+        self.polydata.GetPointData().AddArray(array)
+        self.crown = self.vertices[:, 1] > 0.0
+
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, ArchLandmarks()))
+        self.heights = np.full(len(self.builder.names()), 6.0)
+        self.zero = np.zeros(len(self.builder.names()))
+
+    def test_no_crown_vertex_is_labelled(self):
+        labels, _ = self.builder.compute(self.zero, self.zero, self.heights)
+        self.assertEqual(labels[self.crown].sum(), 0.0)
+        self.assertGreater(labels.sum(), 0.0)
+
+    def test_the_crowns_are_within_reach_when_not_excluded(self):
+        labels, _ = self.builder.compute(self.zero, self.zero, self.heights,
+                                         exclude_teeth=False)
+        self.assertGreater(labels[self.crown].sum(), 0.0)
+
+
+class OffsetTest(unittest.TestCase):
+    def setUp(self):
+        self.polydata, _ = FlatMesh()
+        self.builder = mgl_patch.MGLPatchBuilder()
+        self.assertTrue(self.builder.prepare(self.polydata, ArchLandmarks()))
+        self.n = len(self.builder.names())
+        self.zero = np.zeros(self.n)
+
+    def test_no_offset_leaves_the_landmarks_where_ali_put_them(self):
+        moved = self.builder.movedLandmarks(self.zero, self.zero)
+        np.testing.assert_allclose(moved, self.builder._landmarks, atol=1e-9)
+
+    def test_a_shared_offset_moves_every_landmark_the_same_distance(self):
+        moved = self.builder.movedLandmarks(np.full(self.n, 2.0), self.zero)
+        travelled = np.linalg.norm(moved - self.builder._landmarks, axis=1)
+        np.testing.assert_allclose(travelled, 2.0, atol=1e-9)
+
+    def test_moving_one_landmark_leaves_the_others_untouched(self):
+        offsets = np.zeros(self.n)
+        offsets[4] = 3.0
+        moved = self.builder.movedLandmarks(offsets, self.zero)
+        travelled = np.linalg.norm(moved - self.builder._landmarks, axis=1)
+        self.assertAlmostEqual(travelled[4], 3.0, places=9)
+        self.assertAlmostEqual(np.delete(travelled, 4).max(), 0.0, places=9)
+
+
+class ArrayNamingTest(unittest.TestCase):
+    def test_the_array_carries_the_name_areg_reads(self):
+        builder = mgl_patch.MGLPatchBuilder()
+        array = builder.toArray(np.ones(4, dtype=np.float32))
+        self.assertEqual(array.GetName(), "Bottom_MGL")
+        self.assertEqual(array.GetNumberOfTuples(), 4)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/FlexReg_CLI/FlexReg_CLI.py
+++ b/FlexReg_CLI/FlexReg_CLI.py
@@ -284,7 +284,9 @@ def main(args):
 
     
     writer = vtk.vtkPolyDataWriter()
-    if args.type!="icp":
+    # A registration writes its result to the output folder; the patch modes
+    # write back into the scan they were given.
+    if args.type not in ("icp", "icp_mgl"):
         writer.SetFileName(args.lineedit)
     else:
         outpath = args.lineedit.replace(os.path.dirname(args.lineedit),args.path_output)

--- a/FlexReg_CLI/FlexReg_CLI.py
+++ b/FlexReg_CLI/FlexReg_CLI.py
@@ -137,7 +137,7 @@ def main(args):
         # Delete last array
         modelNode.GetPointData().RemoveArray(f"Butterfly{index-1}")
 
-    elif args.type=="icp":
+    elif args.type in ("icp", "icp_mgl"):
         # Reading the T1 model to register
         reader = vtk.vtkPolyDataReader()
         reader.SetFileName(args.path_reg)
@@ -173,7 +173,11 @@ def main(args):
 
         # ICP
         methode = [vtkICP()]
-        option = vtkMeshTeeth(list_teeth=[1], property="Butterfly")
+        # The palate patch and the mucogingival band live in arrays of their own,
+        # so the arch decides which one the registration is computed on.
+        patch_array = "Bottom_MGL" if args.type == "icp_mgl" else "Butterfly"
+        logger.info(f"registering on the {patch_array} patch")
+        option = vtkMeshTeeth(list_teeth=[1], property=patch_array)
         icp = ICP(methode, option=option)
         output_icp = icp.run(modelNode, modelNodeT1)
 
@@ -232,8 +236,10 @@ def main(args):
     index = 1
     final_array = None
 
-    # Create the patch Butterfly
-    while True:
+    # Create the patch Butterfly. Skipped for the lower arch: there is no
+    # Butterfly1..N to merge there, and the pass needs a GPU the mucogingival
+    # workflow does without.
+    while args.type != "icp_mgl":
         array_name = f"Butterfly{index}"
         
         if modelNode.GetPointData().HasArray(array_name):
@@ -249,15 +255,16 @@ def main(args):
         else:
             break
 
-    if final_array is None:
-        num_points = modelNode.GetNumberOfPoints()
-        V_label = torch.zeros(num_points).to(torch.float32).cuda()
-    else:
-        V_label = final_array
-        
-    V_labels_prediction = numpy_to_vtk(V_label.cpu().numpy())
-    V_labels_prediction.SetName('Butterfly')
-    modelNode.GetPointData().AddArray(V_labels_prediction)
+    if args.type != "icp_mgl":
+        if final_array is None:
+            num_points = modelNode.GetNumberOfPoints()
+            V_label = torch.zeros(num_points).to(torch.float32).cuda()
+        else:
+            V_label = final_array
+
+        V_labels_prediction = numpy_to_vtk(V_label.cpu().numpy())
+        V_labels_prediction.SetName('Butterfly')
+        modelNode.GetPointData().AddArray(V_labels_prediction)
 
 
     # Put back the data in the LPS coordinate


### PR DESCRIPTION
- ADD: Build the lower registration patch from the MGL landmarks
- ADD: MGL registration mode for the lower arch in AREG_IOS
- FIX: Pass teeth_mg to ALI_IOS from AREG IOSCBCT
- ADD: Choice between palatal and MGL registration in the AREG interface
- FIX: Widen the MGL height box and hide the fields MGL does not use
- FIX: Use a line edit for the MGL patch height so the value is readable
- FIX: Tell the AREG validation which registration reference is selected
- FIX: Run the MGL pipeline steps instead of stopping after the first
- ADD: Browse button and ALI models download for the AREG models folder
- FIX: Count the lower scans in MGL so the progress does not divide by zero
- FIX: Update the ALI timer only once it has been set
- ADD: Name the lower patch array Bottom_MGL instead of Butterfly
- FIX: Install butterfly_preview.py with the FlexReg module
- ADD: MGL patch engine with per-landmark height for FlexReg
- ADD: Lower arch page in FlexReg to edit the MGL patch
- ADD: Register the lower arch on the MGL patch in FlexReg
- FIX: Write the MGL registration to the output folder, not over the input
- ADD: Tests for the MGL patch engine geometry
- ADD: Rework the MGL patch editing page in FlexReg
- ADD: Run the MGL patch engine tests at build time
- ADD: Estimate unsegmented teeth from the arch in ALI_IOS
- ADD: Height 0 registers on the mucogingival line only
- FIX: Install check_deps.py with the AREG_IOS module
