### PR TITLE
FIX: Get the AREG IOS/CBCT pipeline running end to end again

### DIFF
--- a/ALI/ALI.py
+++ b/ALI/ALI.py
@@ -2130,11 +2130,14 @@ class ALILogic(ScriptedLoadableModuleLogic):
     self.process.start()
     
   def install_shapeaxi(self):
-    self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.pythonVersion,["ocnn==2.2.1","shapeaxi>=2.0.2","SimpleITK"],)) #run in parallel to not block slicer
+    # shapeaxi is installed later, by install_pytorch: it declares pytorch3d,
+    # which PyPI does not carry, so pip fails here and the env is never created.
+    # torch has to come first, install_pytorch reads its version to pick a wheel.
+    self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.pythonVersion,["torch>=2.8,<2.13","ocnn==2.2.1","SimpleITK"],)) #run in parallel to not block slicer
     
   def check_if_pytorch3d(self):
     conda_exe = self.conda.getCondaExecutable()
-    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer\""]
+    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
     return self.conda.condaRunCommand(command)
 
   def install_pytorch3d(self):

--- a/ALI/ALI.py
+++ b/ALI/ALI.py
@@ -2137,7 +2137,7 @@ class ALILogic(ScriptedLoadableModuleLogic):
     
   def check_if_pytorch3d(self):
     conda_exe = self.conda.getCondaExecutable()
-    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
+    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi.dental_model_seg as d;d.saxi_nets_lightning.DentalModelSeg\""]
     return self.conda.condaRunCommand(command)
 
   def install_pytorch3d(self):

--- a/ALI/ALI_Method/install_pytorch.py
+++ b/ALI/ALI_Method/install_pytorch.py
@@ -202,13 +202,58 @@ def install_shapeaxi(pip_path):
     return False
 
 
+STALE_CALL = "saxi_nets.DentalModelSeg"
+STALE_IMPORT = "from shapeaxi import saxi_nets, utils"
+FIXED_IMPORT = "from shapeaxi import saxi_nets_lightning, utils"
+
+
+def patch_dentalmodelseg():
+    """Repoint dentalmodelseg at the class it needs, on shapeaxi 2.0.0 - 2.0.2.
+
+    `dental_model_seg.py` calls `saxi_nets.DentalModelSeg`, but the class moved
+    to `saxi_nets_lightning` in the 2.0 split and `saxi_nets` never re-exported
+    it, so every crown segmentation dies on
+
+        AttributeError: module 'shapeaxi.saxi_nets' has no attribute 'DentalModelSeg'
+
+    Reported upstream (ImageMindAnalytics/ShapeAXI); this rewrites the two stale
+    references until a release carries the fix. It is a no-op on any version
+    that does not have the problem, so it disappears on its own once shapeaxi is
+    updated. `saxi_nets` is not used anywhere else in that file.
+    """
+    try:
+        from shapeaxi import dental_model_seg
+        path = dental_model_seg.__file__
+        with open(path) as handle:
+            source = handle.read()
+    except Exception as exc:
+        logger.warning("Could not read shapeaxi.dental_model_seg: {}".format(exc))
+        return False
+
+    if STALE_CALL not in source:
+        logger.info("dentalmodelseg needs no patching on this shapeaxi")
+        return True
+
+    try:
+        with open(path, "w") as handle:
+            handle.write(source.replace(STALE_IMPORT, FIXED_IMPORT)
+                               .replace(STALE_CALL, "saxi_nets_lightning.DentalModelSeg"))
+    except Exception as exc:
+        logger.error("Could not patch {}: {}".format(path, exc))
+        return False
+
+    logger.info("Patched {} so dentalmodelseg finds DentalModelSeg".format(path))
+    return True
+
+
 def main(pip_path):
     if not install_pytorch3d(pip_path):
         logger.error(
             "Not installing shapeaxi: it requires a working pytorch3d, and pip "
             "cannot resolve pytorch3d from PyPI on its own.")
         return
-    install_shapeaxi(pip_path)
+    if install_shapeaxi(pip_path):
+        patch_dentalmodelseg()
 
 
 if __name__ == "__main__":

--- a/ALI/ALI_Method/install_pytorch.py
+++ b/ALI/ALI_Method/install_pytorch.py
@@ -183,8 +183,32 @@ def install_pytorch3d(pip_path):
     return verify_gpu()
 
 
+SHAPEAXI_REQUIREMENT = "shapeaxi>=2.0.2"
+
+
+def install_shapeaxi(pip_path):
+    """Install shapeaxi once pytorch3d is in place.
+
+    shapeaxi declares pytorch3d as a hard requirement, and PyPI serves no
+    distribution for it at all, so asking pip for shapeaxi in a bare
+    environment ends on "No matching distribution found for pytorch3d" and
+    leaves nothing behind. Installing it here, after the wheel above, gives
+    pip an already-satisfied requirement to resolve against.
+    """
+    if run_pip(pip_path, [SHAPEAXI_REQUIREMENT]):
+        logger.info("{} installed in the environment".format(SHAPEAXI_REQUIREMENT))
+        return True
+    logger.error("{} installation failed.".format(SHAPEAXI_REQUIREMENT))
+    return False
+
+
 def main(pip_path):
-    install_pytorch3d(pip_path)
+    if not install_pytorch3d(pip_path):
+        logger.error(
+            "Not installing shapeaxi: it requires a working pytorch3d, and pip "
+            "cannot resolve pytorch3d from PyPI on its own.")
+        return
+    install_shapeaxi(pip_path)
 
 
 if __name__ == "__main__":

--- a/ALI_IOS/CMakeLists.txt
+++ b/ALI_IOS/CMakeLists.txt
@@ -13,7 +13,9 @@ set(MODULE_PYTHON_SCRIPTS
   ${FOLDER_LIBRARY}/io.py
   ${FOLDER_LIBRARY}/mask_renderer.py
   ${FOLDER_LIBRARY}/model.py
+  ${FOLDER_LIBRARY}/orientation.py
   ${FOLDER_LIBRARY}/render.py
+  ${FOLDER_LIBRARY}/segmentation.py
   ${FOLDER_LIBRARY}/surface.py
 )
 

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -2626,7 +2626,7 @@ class AREGLogic(ScriptedLoadableModuleLogic):
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi.dental_model_seg as d;d.saxi_nets_lightning.DentalModelSeg\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -2619,11 +2619,14 @@ class AREGLogic(ScriptedLoadableModuleLogic):
         self.process.start()
         
     def install_shapeaxi(self):
-        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["ocnn==2.2.1","shapeaxi>=2.0.2","SimpleITK"],)) #run in parallel to not block slicer
+        # shapeaxi is installed later, by install_pytorch: it declares pytorch3d,
+        # which PyPI does not carry, so pip fails here and the env is never created.
+        # torch has to come first, install_pytorch reads its version to pick a wheel.
+        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["torch>=2.8,<2.13","ocnn==2.2.1","SimpleITK"],)) #run in parallel to not block slicer
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -189,9 +189,10 @@ class Auto_IOS(Method):
         return platform.system() == "Linux" and "microsoft" in platform.release().lower()
     
     def create_csv(self, input_dir, name_csv):
-        file_path = os.path.abspath(__file__)
-        folder_path = os.path.dirname(file_path)
-        csv_file = os.path.join(folder_path, f"{name_csv}.csv")
+        # Written next to the module until now, which needs the extension
+        # install to be writable. The basename is what CrownSegmentation names
+        # its output subfolder after, so only the folder changes here.
+        csv_file = os.path.join(slicer.util.tempDirectory(), f"{name_csv}.csv")
         with open(csv_file, 'w', newline='') as fichier:
             writer = csv.writer(fichier)
             writer.writerow(["surf"])

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -489,7 +489,7 @@ class Auto_IOS(Method):
         input_csv_T1 = "None"
         vtk_folder_T1 = "None"
         if os.path.isfile(path_input_T1):
-            extension = os.path.splitext(self.input)[1]
+            extension = os.path.splitext(path_input_T1)[1]
             if extension == ".vtk" or extension == ".stl":
               surf_T1 = path_input_T1
 
@@ -515,7 +515,7 @@ class Auto_IOS(Method):
         input_csv_T2 = "None"
         vtk_folder_T2 = "None"
         if os.path.isfile(path_input_T2):
-            extension = os.path.splitext(self.input)[1]
+            extension = os.path.splitext(path_input_T2)[1]
             if extension == ".vtk" or extension == ".stl":
               surf_T2 = path_input_T2
 

--- a/AREG/AREG_Method/IOSCBCT.py
+++ b/AREG/AREG_Method/IOSCBCT.py
@@ -242,7 +242,7 @@ class Semi_IOSCBCT(IOSCBCT):
         input_csv = "None"
         vtk_folder = "None"
         if os.path.isfile(kwargs["input_t1_folder"]):
-            extension = os.path.splitext(self.input)[1]
+            extension = os.path.splitext(kwargs["input_t1_folder"])[1]
             if extension == ".vtk" or extension == ".stl":
               surf = kwargs["input_t1_folder"]
               
@@ -675,7 +675,7 @@ class Auto_IOSCBCT(IOSCBCT):
         input_csv = "None"
         vtk_folder = "None"
         if os.path.isfile(kwargs["input_t1_folder"]):
-            extension = os.path.splitext(self.input)[1]
+            extension = os.path.splitext(kwargs["input_t1_folder"])[1]
             if extension == ".vtk" or extension == ".stl":
               surf = kwargs["input_t1_folder"]
               

--- a/AREG/AREG_Method/IOSCBCT.py
+++ b/AREG/AREG_Method/IOSCBCT.py
@@ -214,9 +214,10 @@ class Semi_IOSCBCT(IOSCBCT):
         return platform.system() == "Linux" and "microsoft" in platform.release().lower()
     
     def create_csv(self, input_dir, name_csv):
-        file_path = os.path.abspath(__file__)
-        folder_path = os.path.dirname(file_path)
-        csv_file = os.path.join(folder_path, f"{name_csv}.csv")
+        # Written next to the module until now, which needs the extension
+        # install to be writable. The basename is what CrownSegmentation names
+        # its output subfolder after, so only the folder changes here.
+        csv_file = os.path.join(slicer.util.tempDirectory(), f"{name_csv}.csv")
         with open(csv_file, 'w', newline='') as fichier:
             writer = csv.writer(fichier)
             writer.writerow(["surf"])
@@ -541,9 +542,10 @@ class Auto_IOSCBCT(IOSCBCT):
         return platform.system() == "Linux" and "microsoft" in platform.release().lower()
     
     def create_csv(self, input_dir, name_csv):
-        file_path = os.path.abspath(__file__)
-        folder_path = os.path.dirname(file_path)
-        csv_file = os.path.join(folder_path, f"{name_csv}.csv")
+        # Written next to the module until now, which needs the extension
+        # install to be writable. The basename is what CrownSegmentation names
+        # its output subfolder after, so only the folder changes here.
+        csv_file = os.path.join(slicer.util.tempDirectory(), f"{name_csv}.csv")
         with open(csv_file, 'w', newline='') as fichier:
             writer = csv.writer(fichier)
             writer.writerow(["surf"])

--- a/AREG/AREG_Method/install_pytorch.py
+++ b/AREG/AREG_Method/install_pytorch.py
@@ -202,13 +202,58 @@ def install_shapeaxi(pip_path):
     return False
 
 
+STALE_CALL = "saxi_nets.DentalModelSeg"
+STALE_IMPORT = "from shapeaxi import saxi_nets, utils"
+FIXED_IMPORT = "from shapeaxi import saxi_nets_lightning, utils"
+
+
+def patch_dentalmodelseg():
+    """Repoint dentalmodelseg at the class it needs, on shapeaxi 2.0.0 - 2.0.2.
+
+    `dental_model_seg.py` calls `saxi_nets.DentalModelSeg`, but the class moved
+    to `saxi_nets_lightning` in the 2.0 split and `saxi_nets` never re-exported
+    it, so every crown segmentation dies on
+
+        AttributeError: module 'shapeaxi.saxi_nets' has no attribute 'DentalModelSeg'
+
+    Reported upstream (ImageMindAnalytics/ShapeAXI); this rewrites the two stale
+    references until a release carries the fix. It is a no-op on any version
+    that does not have the problem, so it disappears on its own once shapeaxi is
+    updated. `saxi_nets` is not used anywhere else in that file.
+    """
+    try:
+        from shapeaxi import dental_model_seg
+        path = dental_model_seg.__file__
+        with open(path) as handle:
+            source = handle.read()
+    except Exception as exc:
+        logger.warning("Could not read shapeaxi.dental_model_seg: {}".format(exc))
+        return False
+
+    if STALE_CALL not in source:
+        logger.info("dentalmodelseg needs no patching on this shapeaxi")
+        return True
+
+    try:
+        with open(path, "w") as handle:
+            handle.write(source.replace(STALE_IMPORT, FIXED_IMPORT)
+                               .replace(STALE_CALL, "saxi_nets_lightning.DentalModelSeg"))
+    except Exception as exc:
+        logger.error("Could not patch {}: {}".format(path, exc))
+        return False
+
+    logger.info("Patched {} so dentalmodelseg finds DentalModelSeg".format(path))
+    return True
+
+
 def main(pip_path):
     if not install_pytorch3d(pip_path):
         logger.error(
             "Not installing shapeaxi: it requires a working pytorch3d, and pip "
             "cannot resolve pytorch3d from PyPI on its own.")
         return
-    install_shapeaxi(pip_path)
+    if install_shapeaxi(pip_path):
+        patch_dentalmodelseg()
 
 
 if __name__ == "__main__":

--- a/AREG/AREG_Method/install_pytorch.py
+++ b/AREG/AREG_Method/install_pytorch.py
@@ -183,8 +183,32 @@ def install_pytorch3d(pip_path):
     return verify_gpu()
 
 
+SHAPEAXI_REQUIREMENT = "shapeaxi>=2.0.2"
+
+
+def install_shapeaxi(pip_path):
+    """Install shapeaxi once pytorch3d is in place.
+
+    shapeaxi declares pytorch3d as a hard requirement, and PyPI serves no
+    distribution for it at all, so asking pip for shapeaxi in a bare
+    environment ends on "No matching distribution found for pytorch3d" and
+    leaves nothing behind. Installing it here, after the wheel above, gives
+    pip an already-satisfied requirement to resolve against.
+    """
+    if run_pip(pip_path, [SHAPEAXI_REQUIREMENT]):
+        logger.info("{} installed in the environment".format(SHAPEAXI_REQUIREMENT))
+        return True
+    logger.error("{} installation failed.".format(SHAPEAXI_REQUIREMENT))
+    return False
+
+
 def main(pip_path):
-    install_pytorch3d(pip_path)
+    if not install_pytorch3d(pip_path):
+        logger.error(
+            "Not installing shapeaxi: it requires a working pytorch3d, and pip "
+            "cannot resolve pytorch3d from PyPI on its own.")
+        return
+    install_shapeaxi(pip_path)
 
 
 if __name__ == "__main__":

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -258,11 +258,17 @@ def getPatients(ios_folder, cbct_folder, ios_lm_folder, cbct_lm_folder):
         return match.group(0) if match else None
     
     def extract_jaw(filename):
-        """Extract jaw from filename (_u, _U, u_, _l, _L, l_)"""
-        # Check for patterns: _u, _U, u_, _l, _L, l_
-        if re.search(r'[_]?[uU][_]?', filename):
+        """Extract jaw from filename (_u, _U, u_, _l, _L, l_, _upper, _lower)
+
+        The letter has to be a token of its own, delimited by an underscore,
+        the start of the name or a dot. Matching a bare "u" anywhere used to
+        read "Dupont_003_T1_L.vtk" or "P001_T1_L_Surface.vtk" as upper, which
+        registers the lower arch against the upper CBCT landmarks without any
+        error being raised.
+        """
+        if re.search(r'(?:^|_)(?:u|upper)(?=_|\.|$)', filename, re.IGNORECASE):
             return 'upper'
-        elif re.search(r'[_]?[lL][_]?', filename):
+        elif re.search(r'(?:^|_)(?:l|lower)(?=_|\.|$)', filename, re.IGNORECASE):
             return 'lower'
         return None
     

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -87,10 +87,14 @@ def run_icp_point_to_plane(moving_mesh, fixed_mesh, max_dist=1.5):
     rmse_threshold = 1e-8
     fitness_threshold = 1e-8
     prev_fitness = 0
-    
+
+    # Only the moving points change from one iteration to the next, so the tree
+    # over the fixed points is built once instead of being rebuilt up to
+    # max_iterations times over the very same coordinates.
+    kdtree = cKDTree(fixed_pts)
+
     for iteration in range(max_iterations):
         # 2. Find correspondances (nearest neighbors)
-        kdtree = cKDTree(fixed_pts)
         distances, indices = kdtree.query(moving_pts_transformed, k=1)
         
         # Filter the points too far

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -389,6 +389,7 @@ def main(args):
         logger.info(f"Created output directory: {output_dir}")
     
     # Process each patient
+    registered = 0
     for patient_id, patient_data in sorted(patients.items()):
         logger.info(f"Processing patient {patient_id}...")
         
@@ -455,6 +456,7 @@ def main(args):
                 output_dir, patient_id,
                 landmarks_json_cbct_U, landmarks_json_cbct_L
             )
+            registered += 1
             logger.info(f"Patient {patient_id} processed successfully")
             
         except Exception as e:
@@ -462,6 +464,14 @@ def main(args):
             continue
     
     logger.info("AREG_IOSCBCT processing completed")
+    # Every patient can fail on a missing landmark file and the loop still ends
+    # normally, which used to exit 0 and let Slicer report the whole pipeline as
+    # a success while the output folder stayed empty.
+    if not registered:
+        raise RuntimeError(
+            "No patient could be registered: check that every patient has an "
+            "IOS surface, a CBCT, and the landmark files for both arches.")
+    logger.info(f"{registered}/{len(patients)} patient(s) registered")
 
 
 if __name__ == "__main__":

--- a/ASO/ASO.py
+++ b/ASO/ASO.py
@@ -2437,11 +2437,14 @@ class ASOLogic(ScriptedLoadableModuleLogic):
         self.process.start()
         
     def install_shapeaxi(self):
-        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["ocnn==2.2.1","shapeaxi>=2.0.2","SimpleITK"],)) #run in parallel to not block slicer
+        # shapeaxi is installed later, by install_pytorch: it declares pytorch3d,
+        # which PyPI does not carry, so pip fails here and the env is never created.
+        # torch has to come first, install_pytorch reads its version to pick a wheel.
+        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["torch>=2.8,<2.13","ocnn==2.2.1","SimpleITK"],)) #run in parallel to not block slicer
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/ASO/ASO.py
+++ b/ASO/ASO.py
@@ -2444,7 +2444,7 @@ class ASOLogic(ScriptedLoadableModuleLogic):
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi.dental_model_seg as d;d.saxi_nets_lightning.DentalModelSeg\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/ASO/ASO_Method/install_pytorch.py
+++ b/ASO/ASO_Method/install_pytorch.py
@@ -202,13 +202,58 @@ def install_shapeaxi(pip_path):
     return False
 
 
+STALE_CALL = "saxi_nets.DentalModelSeg"
+STALE_IMPORT = "from shapeaxi import saxi_nets, utils"
+FIXED_IMPORT = "from shapeaxi import saxi_nets_lightning, utils"
+
+
+def patch_dentalmodelseg():
+    """Repoint dentalmodelseg at the class it needs, on shapeaxi 2.0.0 - 2.0.2.
+
+    `dental_model_seg.py` calls `saxi_nets.DentalModelSeg`, but the class moved
+    to `saxi_nets_lightning` in the 2.0 split and `saxi_nets` never re-exported
+    it, so every crown segmentation dies on
+
+        AttributeError: module 'shapeaxi.saxi_nets' has no attribute 'DentalModelSeg'
+
+    Reported upstream (ImageMindAnalytics/ShapeAXI); this rewrites the two stale
+    references until a release carries the fix. It is a no-op on any version
+    that does not have the problem, so it disappears on its own once shapeaxi is
+    updated. `saxi_nets` is not used anywhere else in that file.
+    """
+    try:
+        from shapeaxi import dental_model_seg
+        path = dental_model_seg.__file__
+        with open(path) as handle:
+            source = handle.read()
+    except Exception as exc:
+        logger.warning("Could not read shapeaxi.dental_model_seg: {}".format(exc))
+        return False
+
+    if STALE_CALL not in source:
+        logger.info("dentalmodelseg needs no patching on this shapeaxi")
+        return True
+
+    try:
+        with open(path, "w") as handle:
+            handle.write(source.replace(STALE_IMPORT, FIXED_IMPORT)
+                               .replace(STALE_CALL, "saxi_nets_lightning.DentalModelSeg"))
+    except Exception as exc:
+        logger.error("Could not patch {}: {}".format(path, exc))
+        return False
+
+    logger.info("Patched {} so dentalmodelseg finds DentalModelSeg".format(path))
+    return True
+
+
 def main(pip_path):
     if not install_pytorch3d(pip_path):
         logger.error(
             "Not installing shapeaxi: it requires a working pytorch3d, and pip "
             "cannot resolve pytorch3d from PyPI on its own.")
         return
-    install_shapeaxi(pip_path)
+    if install_shapeaxi(pip_path):
+        patch_dentalmodelseg()
 
 
 if __name__ == "__main__":

--- a/ASO/ASO_Method/install_pytorch.py
+++ b/ASO/ASO_Method/install_pytorch.py
@@ -183,8 +183,32 @@ def install_pytorch3d(pip_path):
     return verify_gpu()
 
 
+SHAPEAXI_REQUIREMENT = "shapeaxi>=2.0.2"
+
+
+def install_shapeaxi(pip_path):
+    """Install shapeaxi once pytorch3d is in place.
+
+    shapeaxi declares pytorch3d as a hard requirement, and PyPI serves no
+    distribution for it at all, so asking pip for shapeaxi in a bare
+    environment ends on "No matching distribution found for pytorch3d" and
+    leaves nothing behind. Installing it here, after the wheel above, gives
+    pip an already-satisfied requirement to resolve against.
+    """
+    if run_pip(pip_path, [SHAPEAXI_REQUIREMENT]):
+        logger.info("{} installed in the environment".format(SHAPEAXI_REQUIREMENT))
+        return True
+    logger.error("{} installation failed.".format(SHAPEAXI_REQUIREMENT))
+    return False
+
+
 def main(pip_path):
-    install_pytorch3d(pip_path)
+    if not install_pytorch3d(pip_path):
+        logger.error(
+            "Not installing shapeaxi: it requires a working pytorch3d, and pip "
+            "cannot resolve pytorch3d from PyPI on its own.")
+        return
+    install_shapeaxi(pip_path)
 
 
 if __name__ == "__main__":

--- a/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
+++ b/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
@@ -595,8 +595,11 @@ if __name__ == "__main__":
         logger.info("PRE_ASO_IOS processing completed")
         logger.info("="*80)
         
-        # Exit with appropriate status
-        sys.exit(0 if result['failed'] == 0 else 1)
+        # Exit with appropriate status. Every stage that bails out early
+        # returns failed=0 with nothing processed, so testing only 'failed'
+        # reported "no surface file found" as a success and Slicer showed a
+        # green PROCESS COMPLETED for a run that wrote no file at all.
+        sys.exit(0 if result['successful'] > 0 and result['failed'] == 0 else 1)
     
     except Exception as e:
         logger.error(f"Fatal error in PRE_ASO_IOS: {str(e)}", exc_info=True)

--- a/DOCShapeAXI/DOCShapeAXI.py
+++ b/DOCShapeAXI/DOCShapeAXI.py
@@ -836,11 +836,14 @@ class DOCShapeAXILogic(ScriptedLoadableModuleLogic):
     self.process.start()
 
   def install_shapeaxi(self):
-        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,"3.12",["ocnn==2.2.1","shapeaxi>=2.0.2","SimpleITK"],)) #run in parallel to not block slicer
+        # shapeaxi is installed later, by install_pytorch: it declares pytorch3d,
+        # which PyPI does not carry, so pip fails here and the env is never created.
+        # torch has to come first, install_pytorch reads its version to pick a wheel.
+        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,"3.12",["torch>=2.8,<2.13","ocnn==2.2.1","SimpleITK"],)) #run in parallel to not block slicer
 
   def check_if_pytorch3d(self):
     conda_exe = self.conda.getCondaExecutable()
-    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer\""]
+    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
     return self.conda.condaRunCommand(command)
     
   def install_pytorch3d(self):

--- a/DOCShapeAXI/DOCShapeAXI.py
+++ b/DOCShapeAXI/DOCShapeAXI.py
@@ -843,7 +843,7 @@ class DOCShapeAXILogic(ScriptedLoadableModuleLogic):
 
   def check_if_pytorch3d(self):
     conda_exe = self.conda.getCondaExecutable()
-    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
+    command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi.dental_model_seg as d;d.saxi_nets_lightning.DentalModelSeg\""]
     return self.conda.condaRunCommand(command)
     
   def install_pytorch3d(self):

--- a/DOCShapeAXI/DOCShapeAXI_utils/install_pytorch.py
+++ b/DOCShapeAXI/DOCShapeAXI_utils/install_pytorch.py
@@ -202,13 +202,58 @@ def install_shapeaxi(pip_path):
     return False
 
 
+STALE_CALL = "saxi_nets.DentalModelSeg"
+STALE_IMPORT = "from shapeaxi import saxi_nets, utils"
+FIXED_IMPORT = "from shapeaxi import saxi_nets_lightning, utils"
+
+
+def patch_dentalmodelseg():
+    """Repoint dentalmodelseg at the class it needs, on shapeaxi 2.0.0 - 2.0.2.
+
+    `dental_model_seg.py` calls `saxi_nets.DentalModelSeg`, but the class moved
+    to `saxi_nets_lightning` in the 2.0 split and `saxi_nets` never re-exported
+    it, so every crown segmentation dies on
+
+        AttributeError: module 'shapeaxi.saxi_nets' has no attribute 'DentalModelSeg'
+
+    Reported upstream (ImageMindAnalytics/ShapeAXI); this rewrites the two stale
+    references until a release carries the fix. It is a no-op on any version
+    that does not have the problem, so it disappears on its own once shapeaxi is
+    updated. `saxi_nets` is not used anywhere else in that file.
+    """
+    try:
+        from shapeaxi import dental_model_seg
+        path = dental_model_seg.__file__
+        with open(path) as handle:
+            source = handle.read()
+    except Exception as exc:
+        logger.warning("Could not read shapeaxi.dental_model_seg: {}".format(exc))
+        return False
+
+    if STALE_CALL not in source:
+        logger.info("dentalmodelseg needs no patching on this shapeaxi")
+        return True
+
+    try:
+        with open(path, "w") as handle:
+            handle.write(source.replace(STALE_IMPORT, FIXED_IMPORT)
+                               .replace(STALE_CALL, "saxi_nets_lightning.DentalModelSeg"))
+    except Exception as exc:
+        logger.error("Could not patch {}: {}".format(path, exc))
+        return False
+
+    logger.info("Patched {} so dentalmodelseg finds DentalModelSeg".format(path))
+    return True
+
+
 def main(pip_path):
     if not install_pytorch3d(pip_path):
         logger.error(
             "Not installing shapeaxi: it requires a working pytorch3d, and pip "
             "cannot resolve pytorch3d from PyPI on its own.")
         return
-    install_shapeaxi(pip_path)
+    if install_shapeaxi(pip_path):
+        patch_dentalmodelseg()
 
 
 if __name__ == "__main__":

--- a/DOCShapeAXI/DOCShapeAXI_utils/install_pytorch.py
+++ b/DOCShapeAXI/DOCShapeAXI_utils/install_pytorch.py
@@ -183,8 +183,32 @@ def install_pytorch3d(pip_path):
     return verify_gpu()
 
 
+SHAPEAXI_REQUIREMENT = "shapeaxi>=2.0.2"
+
+
+def install_shapeaxi(pip_path):
+    """Install shapeaxi once pytorch3d is in place.
+
+    shapeaxi declares pytorch3d as a hard requirement, and PyPI serves no
+    distribution for it at all, so asking pip for shapeaxi in a bare
+    environment ends on "No matching distribution found for pytorch3d" and
+    leaves nothing behind. Installing it here, after the wheel above, gives
+    pip an already-satisfied requirement to resolve against.
+    """
+    if run_pip(pip_path, [SHAPEAXI_REQUIREMENT]):
+        logger.info("{} installed in the environment".format(SHAPEAXI_REQUIREMENT))
+        return True
+    logger.error("{} installation failed.".format(SHAPEAXI_REQUIREMENT))
+    return False
+
+
 def main(pip_path):
-    install_pytorch3d(pip_path)
+    if not install_pytorch3d(pip_path):
+        logger.error(
+            "Not installing shapeaxi: it requires a working pytorch3d, and pip "
+            "cannot resolve pytorch3d from PyPI on its own.")
+        return
+    install_shapeaxi(pip_path)
 
 
 if __name__ == "__main__":

--- a/FlexReg/FlexReg.py
+++ b/FlexReg/FlexReg.py
@@ -985,11 +985,14 @@ class FlexRegLogic(ScriptedLoadableModuleLogic):
         self.process.start()
         
     def install_shapeaxi(self):
-        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["ocnn==2.2.1","shapeaxi>=2.0.2","SimpleITK"],)) #run in parallel to not block slicer
+        # shapeaxi is installed later, by install_pytorch: it declares pytorch3d,
+        # which PyPI does not carry, so pip fails here and the env is never created.
+        # torch has to come first, install_pytorch reads its version to pick a wheel.
+        self.run_conda_command(target=self.conda.condaCreateEnv, command=(self.name_env,self.python_version,["torch>=2.8,<2.13","ocnn==2.2.1","SimpleITK"],)) #run in parallel to not block slicer
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/FlexReg/FlexReg.py
+++ b/FlexReg/FlexReg.py
@@ -992,7 +992,7 @@ class FlexRegLogic(ScriptedLoadableModuleLogic):
         
     def check_if_pytorch3d(self):
         conda_exe = self.conda.getCondaExecutable()
-        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi\""]
+        command = [conda_exe, "run", "-n", self.name_env, "python" ,"-c", f"\"import pytorch3d;import pytorch3d.renderer;import shapeaxi.dental_model_seg as d;d.saxi_nets_lightning.DentalModelSeg\""]
         return self.conda.condaRunCommand(command)
     
     def install_pytorch3d(self):

--- a/FlexReg/FlexReg_utils/install_pytorch.py
+++ b/FlexReg/FlexReg_utils/install_pytorch.py
@@ -202,13 +202,58 @@ def install_shapeaxi(pip_path):
     return False
 
 
+STALE_CALL = "saxi_nets.DentalModelSeg"
+STALE_IMPORT = "from shapeaxi import saxi_nets, utils"
+FIXED_IMPORT = "from shapeaxi import saxi_nets_lightning, utils"
+
+
+def patch_dentalmodelseg():
+    """Repoint dentalmodelseg at the class it needs, on shapeaxi 2.0.0 - 2.0.2.
+
+    `dental_model_seg.py` calls `saxi_nets.DentalModelSeg`, but the class moved
+    to `saxi_nets_lightning` in the 2.0 split and `saxi_nets` never re-exported
+    it, so every crown segmentation dies on
+
+        AttributeError: module 'shapeaxi.saxi_nets' has no attribute 'DentalModelSeg'
+
+    Reported upstream (ImageMindAnalytics/ShapeAXI); this rewrites the two stale
+    references until a release carries the fix. It is a no-op on any version
+    that does not have the problem, so it disappears on its own once shapeaxi is
+    updated. `saxi_nets` is not used anywhere else in that file.
+    """
+    try:
+        from shapeaxi import dental_model_seg
+        path = dental_model_seg.__file__
+        with open(path) as handle:
+            source = handle.read()
+    except Exception as exc:
+        logger.warning("Could not read shapeaxi.dental_model_seg: {}".format(exc))
+        return False
+
+    if STALE_CALL not in source:
+        logger.info("dentalmodelseg needs no patching on this shapeaxi")
+        return True
+
+    try:
+        with open(path, "w") as handle:
+            handle.write(source.replace(STALE_IMPORT, FIXED_IMPORT)
+                               .replace(STALE_CALL, "saxi_nets_lightning.DentalModelSeg"))
+    except Exception as exc:
+        logger.error("Could not patch {}: {}".format(path, exc))
+        return False
+
+    logger.info("Patched {} so dentalmodelseg finds DentalModelSeg".format(path))
+    return True
+
+
 def main(pip_path):
     if not install_pytorch3d(pip_path):
         logger.error(
             "Not installing shapeaxi: it requires a working pytorch3d, and pip "
             "cannot resolve pytorch3d from PyPI on its own.")
         return
-    install_shapeaxi(pip_path)
+    if install_shapeaxi(pip_path):
+        patch_dentalmodelseg()
 
 
 if __name__ == "__main__":

--- a/FlexReg/FlexReg_utils/install_pytorch.py
+++ b/FlexReg/FlexReg_utils/install_pytorch.py
@@ -183,8 +183,32 @@ def install_pytorch3d(pip_path):
     return verify_gpu()
 
 
+SHAPEAXI_REQUIREMENT = "shapeaxi>=2.0.2"
+
+
+def install_shapeaxi(pip_path):
+    """Install shapeaxi once pytorch3d is in place.
+
+    shapeaxi declares pytorch3d as a hard requirement, and PyPI serves no
+    distribution for it at all, so asking pip for shapeaxi in a bare
+    environment ends on "No matching distribution found for pytorch3d" and
+    leaves nothing behind. Installing it here, after the wheel above, gives
+    pip an already-satisfied requirement to resolve against.
+    """
+    if run_pip(pip_path, [SHAPEAXI_REQUIREMENT]):
+        logger.info("{} installed in the environment".format(SHAPEAXI_REQUIREMENT))
+        return True
+    logger.error("{} installation failed.".format(SHAPEAXI_REQUIREMENT))
+    return False
+
+
 def main(pip_path):
-    install_pytorch3d(pip_path)
+    if not install_pytorch3d(pip_path):
+        logger.error(
+            "Not installing shapeaxi: it requires a working pytorch3d, and pip "
+            "cannot resolve pytorch3d from PyPI on its own.")
+        return
+    install_shapeaxi(pip_path)
 
 
 if __name__ == "__main__":

--- a/MRI2CBCT_CLI/MRI2CBCT_CLI_utils/__init__.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_CLI_utils/__init__.py
@@ -1,16 +1,44 @@
-from .resample_create_csv import (
-    create_csv,
-)
+# The submodules of this package do not share the same dependencies: resample
+# and resample_create_csv only need SimpleITK/numpy/pandas, while the others
+# pull in torch, nibabel, sklearn, itk or torchreg. Importing them all eagerly
+# meant that a caller asking only for resample_images (AREG_IOSCBCT, VFACE)
+# still had to have torchreg installed, and crashed with a ModuleNotFoundError
+# if it wasn't. Each name is therefore resolved to its submodule on first
+# access, so a caller only pays for the dependencies it actually uses.
 
-from .resample import resample_images, run_resample
+import importlib
 
-from .mri_inverse import invert_mri_intensity
-from .normalize_percentile import normalize
-from .apply_mask import apply_mask_f
-from .AREG_MRI import registration
-from .approximate import approximation
-from .condyle_segmentation import segment_condyle
-from .nmi import NMI
-from .crop_approximation import get_transformation, crop_volume
-from .LR_crop import crop_mri, crop_cbct
-from .TMJ_crop import GetPatients
+_EXPORTS = {
+    "create_csv": "resample_create_csv",
+    "resample_images": "resample",
+    "run_resample": "resample",
+    "invert_mri_intensity": "mri_inverse",
+    "normalize": "normalize_percentile",
+    "apply_mask_f": "apply_mask",
+    "registration": "AREG_MRI",
+    "approximation": "approximate",
+    "segment_condyle": "condyle_segmentation",
+    "NMI": "nmi",
+    "get_transformation": "crop_approximation",
+    "crop_volume": "crop_approximation",
+    "crop_mri": "LR_crop",
+    "crop_cbct": "LR_crop",
+    "GetPatients": "TMJ_crop",
+}
+
+__all__ = list(_EXPORTS)
+
+
+def __getattr__(name):
+    try:
+        module_name = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+
+    value = getattr(importlib.import_module(f".{module_name}", __name__), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(__all__)


### PR DESCRIPTION
AREG IOS/CBCT stopped on its first step with `ModuleNotFoundError: No module
named 'torchreg'`, and fixing that surfaced the rest, because every downstream
failure was being reported as a success. This makes the MRI2CBCT CLI imports
lazy so resample no longer drags in torchreg, installs `orientation.py` and
`segmentation.py` with ALI_IOS, installs pytorch3d before shapeaxi so the conda
env can be created at all, and makes PRE_ASO_IOS and AREG_IOSCBCT exit non-zero
instead of ending on `PROCESS DONE` over an empty output folder. Along the way:
`self.input` was referenced in four places and assigned nowhere, `extract_jaw`
read any `u` in a filename as "upper" and silently registered the lower arch
against the upper CBCT landmarks, `create_csv` wrote into the extension install
folder, and the ICP kd-tree was rebuilt every iteration over 2.8M unchanging
points (524s to 96s, byte-identical outputs). `install_pytorch` also carries a
conditional, idempotent patch for the shapeaxi 2.0.x regression that breaks
crown segmentation, reported upstream with a PR. Verified end to end on the
test files on Slicer 5.12.3 and 5.13.0: nine steps, four output files, and the
Python 3.12 / torch 2.11 / pytorch3d 0.7.9 environment matches the 3.9 / 2.0.1 /
0.7.4 reference within 0.02 mm.
