### PR TITLE
FIX: Ship the VFACE model description, and keep its logging from freezing Slicer

### DIFF
--- a/VFACE/CMakeLists.txt
+++ b/VFACE/CMakeLists.txt
@@ -19,6 +19,13 @@ set(MODULE_PYTHON_SCRIPTS
 set(MODULE_PYTHON_RESOURCES
   Resources/Icons/${MODULE_NAME}.png
   Resources/UI/${MODULE_NAME}.ui
+  # The nnUNet model description travels with the module: without these the
+  # installed extension has an empty Resources/ML, the weight downloader finds
+  # no URL and the dental segmentation fails on every scan. Only the checkpoint
+  # itself is left out, it is fetched at first use.
+  Resources/ML/download_info.json
+  Resources/ML/Dataset111_453CT/nnUNetTrainer__nnUNetPlans__3d_fullres/dataset.json
+  Resources/ML/Dataset111_453CT/nnUNetTrainer__nnUNetPlans__3d_fullres/plans.json
   )
 
 #-----------------------------------------------------------------------------

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1408,6 +1408,26 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         except IndexError:
             self.OnEndProcess()
 
+    # onCliUpdated runs inside a VTK observer callback, where the Qt event loop is
+    # not running. With --disable-terminal-outputs Slicer captures its own stdout
+    # into a pipe that it drains from that same loop, so a single oversized write
+    # fills the pipe and blocks the main thread for good - Slicer goes black and
+    # never comes back. Slicer already logs each CLI's full standard output
+    # itself, so echoing a bounded tail here is enough.
+    MAX_CLI_OUTPUT_CHARS = 8000
+
+    @classmethod
+    def _briefCliOutput(cls, text) -> str:
+        """The tail of a CLI's output, small enough to never fill the stdout pipe."""
+        text = text or ""
+        if len(text) <= cls.MAX_CLI_OUTPUT_CHARS:
+            return text
+        kept = text[-cls.MAX_CLI_OUTPUT_CHARS:]
+        return (
+            f"[... {len(text) - len(kept)} characters omitted, "
+            f"full output in the Slicer log ...]\n{kept}"
+        )
+
     def onCliUpdated(self, caller, event):
         import time
         import json
@@ -1434,7 +1454,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.removeObserver(cliNode, vtk.vtkCommand.ModifiedEvent, self.onCliUpdated)
 
             logger.info("\n\n ========= PROCESSED ========= \n")
-            logger.info(caller.GetOutputText())
+            logger.info(self._briefCliOutput(caller.GetOutputText()))
             
             if self.shouldPauseAfterProcess(self.current_process_info) and self.ui.checkBox_2.isChecked():
                 output_path = self.getOutputPathForModule(self.module_name)

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1453,8 +1453,15 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
             self.removeObserver(cliNode, vtk.vtkCommand.ModifiedEvent, self.onCliUpdated)
 
-            logger.info("\n\n ========= PROCESSED ========= \n")
-            logger.info(self._briefCliOutput(caller.GetOutputText()))
+            # Deferred on purpose: Slicer captures its own stdout into a pipe
+            # that it drains from the Qt event loop, and this method runs inside
+            # a VTK observer callback where that loop cannot run. Writing here
+            # is what lets the pipe fill until the main thread blocks in write()
+            # with no reader left - the black window that never comes back.
+            cli_output = self._briefCliOutput(caller.GetOutputText())
+            qt.QTimer.singleShot(
+                0, lambda: logger.info(f"\n\n ========= PROCESSED ========= \n{cli_output}")
+            )
             
             if self.shouldPauseAfterProcess(self.current_process_info) and self.ui.checkBox_2.isChecked():
                 output_path = self.getOutputPathForModule(self.module_name)


### PR DESCRIPTION
VFACE/CMakeLists.txt declared only the icon and the .ui file, so Resources/ML/ was never packaged and the installed extension shipped an empty model folder. Without download_info.json the weight downloader has no URL, the DentalSegmentator weights are never fetched, and the dental segmentation fails on every scan — five times per run. This is invisible when the module is loaded from a source checkout, which is why it only showed up on an installed Slicer and not in development. The three JSON descriptions are now packaged; the 220 MB checkpoint itself is still fetched on first use. Note that the Check Dependency button does not cover these weights — it downloads the ALI, AMASSS, ASO and classifier models only.

The two other commits address the freeze that followed. onCliUpdated echoed each CLI's full standard output — up to 28 KB in a single write — from inside a VTK observer callback. Slicer captures its own stdout into a pipe that it drains from the Qt event loop, and that loop cannot run during the callback, so the write eventually blocks with no reader left: the main thread sits in pipe_write and the window never repaints again. The echo is now bounded to a tail and deferred to the event loop, and nothing is lost since Slicer already logs each CLI's full output itself. To be clear about confidence: the packaging bug is measured and reproducible, whereas the freeze mechanism is established but its trigger is a race I could not reproduce on demand — these two commits reduce the exposure, they are not a proof-level fix