### PR TITLE
FIX: Unblock AREG IOS-CBCT registration on LAS-oriented scans and speed up its ICP

### DIFF
--- a/ALI/ALI.py
+++ b/ALI/ALI.py
@@ -874,7 +874,7 @@ class ALIWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
   def onPredictButton(self):
     if self.type == "CBCT":
-      list_libs_CBCT = [('itk', None), ('dicom2nifti', '2.3.0'), ('pydicom', '2.2.2')]
+      list_libs_CBCT = [('itk', None), ('dicom2nifti', '2.6.2'), ('pydicom', '3.0.2')]
       monai_version = '1.3.2' if sys.version_info >= (3, 10) else '0.7.0'
       list_libs_CBCT.append(('monai', monai_version))
       
@@ -886,7 +886,7 @@ class ALIWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
       logger.debug(f"Environment check result: {check_env}")
       
       if check_env:
-        list_libs_IOS = [('itk', None), ('dicom2nifti', '2.3.0'), ('pydicom', '2.2.2')]
+        list_libs_IOS = [('itk', None), ('dicom2nifti', '2.6.2'), ('pydicom', '3.0.2')]
         monai_version = '1.3.2' if sys.version_info >= (3, 10) else '0.7.0'
         list_libs_IOS.append(('monai', monai_version))
 

--- a/ALI_CBCT/ALI_CBCT_utils/environment.py
+++ b/ALI_CBCT/ALI_CBCT_utils/environment.py
@@ -71,6 +71,14 @@ class Environment :
         for scale_id,path in images_path.items():
             data = {"path":path}
             img = sitk.ReadImage(path)
+            # The agents move through the raw array and never look at the
+            # direction cosines, so a volume stored as LAS reaches them
+            # mirrored front to back against the LPS volumes the nets were
+            # trained on: the learned policy then walks them away from the
+            # anatomy until they stall against the far wall of the volume.
+            # Reorienting keeps every voxel at the same physical point and is
+            # a no-op on a volume that is already LPS.
+            img = sitk.DICOMOrient(img, "LPS")
             img_ar = sitk.GetArrayFromImage(img)
             if sys.version_info >= (3, 10):
                 data["image"] = self.transform(img_ar).to(dtype=torch.int16)

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1382,8 +1382,10 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 list_libs_CBCT_windows = [
                     ('itk', '==5.4.0', None),
                     ('itk-elastix', '==0.19.2', None),
-                    ('dicom2nifti', '==2.3.0', None),
-                    ('pydicom', '==2.2.2', None),
+                    ('dicom2nifti', '==2.6.2', None),
+                    # pydicom is kept on the version Slicer ships: downgrading it to 2.x breaks
+                    # dicomweb-client and highdicom, hence every DICOM module of Slicer.
+                    ('pydicom', '==3.0.2', None),
                     ('einops', None, None),
                     ('nibabel', None, None),
                     ('connected-components-3d', '>=3.13.0', None),
@@ -1398,8 +1400,10 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 list_libs_CBCT = [
                     ('itk', '==5.4.0', None),
                     ('itk-elastix', '==0.19.2', None),
-                    ('dicom2nifti', '==2.3.0', None),
-                    ('pydicom', '==2.2.2', None),
+                    ('dicom2nifti', '==2.6.2', None),
+                    # pydicom is kept on the version Slicer ships: downgrading it to 2.x breaks
+                    # dicomweb-client and highdicom, hence every DICOM module of Slicer.
+                    ('pydicom', '==3.0.2', None),
                     ('einops', None, None),
                     ('nibabel', None, None),
                     ('connected-components-3d', '>=3.13.0', None),

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -95,7 +95,10 @@ def run_icp_point_to_plane(moving_mesh, fixed_mesh, max_dist=1.5):
 
     for iteration in range(max_iterations):
         # 2. Find correspondances (nearest neighbors)
-        distances, indices = kdtree.query(moving_pts_transformed, k=1)
+        # workers=-1 spreads the query over every core: it is the dominant cost
+        # of the loop (one lookup per moving point, per iteration) and the
+        # default of a single worker left the other cores idle.
+        distances, indices = kdtree.query(moving_pts_transformed, k=1, workers=-1)
         
         # Filter the points too far
         valid_mask = distances < max_dist

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -29,7 +29,83 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-def align_by_landmarks(moving_mesh, moving_lms, fixed_lms):
+# vtkLandmarkTransform needs as many source points as target points: given
+# anything else it logs an error on stderr and returns the identity, so the
+# mesh is never pre-aligned and nothing says so in the log. ALI_CBCT regularly
+# finds only part of the landmarks, so the IOS and CBCT lists match neither in
+# size nor in content, and pairing them by position would align landmarks that
+# have nothing to do with each other. Only keep what exists on both sides.
+MIN_LANDMARK_PAIRS = 3
+MAX_LANDMARK_RESIDUAL_MM = float(os.environ.get("AREG_MAX_LANDMARK_RESIDUAL", 10.0))
+
+
+def _labeled_landmarks(json_path):
+    with open(json_path, "r") as f:
+        data = json.load(f)
+    out = {}
+    if data.get("markups"):
+        for cp in data["markups"][0].get("controlPoints", []):
+            label = cp.get("label")
+            if label:
+                out[label] = list(cp["position"])
+    return out
+
+
+def _pair_landmarks(cbct_json, ios_json, jaw, patient_id):
+    cbct = _labeled_landmarks(cbct_json)
+    ios = _labeled_landmarks(ios_json)
+    common = [l for l in ios if l in cbct]
+    missing = [l for l in ios if l not in cbct]
+    logger.info("%s / %s: %d common landmark pair(s) %s%s" % (
+        patient_id, jaw, len(common), common,
+        "  |  missing from the CBCT: %s" % missing if missing else ""))
+    return (common,
+            np.array([cbct[l] for l in common], dtype=float).reshape(-1, 3),
+            np.array([ios[l] for l in common], dtype=float).reshape(-1, 3))
+
+
+def _alignment_residual(moving_lms, fixed_lms, matrix):
+    """How far each moved landmark still sits from its counterpart, as an RMS.
+
+    A rigid transform preserves distances, so a large residual proves the two
+    sets do not describe the same anatomy and the transform fitted to them is a
+    meaningless compromise.
+    """
+    res = []
+    for src, dst in zip(moving_lms, fixed_lms):
+        moved = matrix.MultiplyPoint([src[0], src[1], src[2], 1])[:3]
+        res.append(np.linalg.norm(np.array(moved) - np.array(dst)))
+    return float(np.sqrt(np.mean(np.square(res)))) if res else float("inf")
+
+
+def _write_positions(cbct_json, positions, labels):
+    """Store the registered positions in the CBCT json, matched by label.
+
+    This used to walk the CBCT control points and index the IOS array by
+    position, so a CBCT holding one landmark against six on the IOS side saved
+    the IOS UL1O coordinates under the UR6O label.
+    """
+    if not cbct_json.get("markups"):
+        return
+    control_points = cbct_json["markups"][0].get("controlPoints", [])
+    if labels is None:
+        for i, cp in enumerate(control_points):
+            if i < len(positions):
+                cp["position"] = list(positions[i])
+        return
+    by_label = dict(zip(labels, positions))
+    kept = []
+    for cp in control_points:
+        label = cp.get("label")
+        if label in by_label:
+            cp["position"] = list(by_label[label])
+            kept.append(cp)
+        else:
+            logger.warning("CBCT landmark %s has no IOS counterpart: dropped from the output" % label)
+    cbct_json["markups"][0]["controlPoints"] = kept
+
+
+def align_by_landmarks(moving_mesh, moving_lms, fixed_lms, jaw="", patient_id=""):
     # 1. Create VTK transformation object
     landmark_transform = vtk.vtkLandmarkTransform()
     
@@ -48,6 +124,30 @@ def align_by_landmarks(moving_mesh, moving_lms, fixed_lms):
     # 3. Apply matrix to moving mesh
     # Get the 4x4 matrix
     matrix = landmark_transform.GetMatrix()
+
+    # Falling back to the identity leaves the ICP to start from the raw pose,
+    # which is what already happened whenever the two lists had different
+    # sizes -- only now it is a decision, and it is written down.
+    n = len(moving_lms)
+    if n < MIN_LANDMARK_PAIRS:
+        logger.warning(
+            "%s / %s: %d landmark pair(s), %d needed. A rigid fit is "
+            "underdetermined below that (one point is a plain translation, two "
+            "leave a free rotation about the axis). Skipping the pre-alignment."
+            % (patient_id, jaw, n, MIN_LANDMARK_PAIRS))
+        matrix = vtk.vtkMatrix4x4()
+    else:
+        rms = _alignment_residual(moving_lms, fixed_lms, matrix)
+        if rms > MAX_LANDMARK_RESIDUAL_MM:
+            logger.warning(
+                "%s / %s: %.1f mm residual over %d pairs (threshold %.1f). The "
+                "IOS and CBCT landmarks do not describe the same points. "
+                "Skipping the pre-alignment."
+                % (patient_id, jaw, rms, n, MAX_LANDMARK_RESIDUAL_MM))
+            matrix = vtk.vtkMatrix4x4()
+        else:
+            logger.info("%s / %s: pre-alignment accepted, %.1f mm residual over %d pairs"
+                        % (patient_id, jaw, rms, n))
     # Apply it with PyVista
     aligned_mesh = moving_mesh.transform(matrix,inplace=False)
     
@@ -175,7 +275,7 @@ def save_registered_ios(registered_vtk_upper,registered_vtk_lower,output_path,nu
     file_path_L = os.path.join(output_path,f"{num_patient}_Reg_L.vtk")
     registered_vtk_lower.save(file_path_L)
 
-def apply_matrix_and_save_landmarks(aligned_upper_lm,aligned_lower_lm,mat_u,mat_l,json_output_path,num_patient,landmarks_json_cbct_U,landmarks_json_cbct_L):
+def apply_matrix_and_save_landmarks(aligned_upper_lm,aligned_lower_lm,mat_u,mat_l,json_output_path,num_patient,landmarks_json_cbct_U,landmarks_json_cbct_L,labels_u=None,labels_l=None):
     # Apply transformations using NumPy (no Open3D dependency)
     # Convert landmarks to homogeneous coordinates, apply transformation, convert back
     
@@ -190,20 +290,12 @@ def apply_matrix_and_save_landmarks(aligned_upper_lm,aligned_lower_lm,mat_u,mat_
     json_output_path_IOS_U = os.path.join(json_output_path,f"{num_patient}_lm_Reg_U.mrk.json")
     json_output_path_IOS_L = os.path.join(json_output_path,f"{num_patient}_lm_Reg_L.mrk.json")
 
-    if 'markups' in landmarks_json_cbct_U:
-        i=0
-        for markup in landmarks_json_cbct_U['markups'][0]['controlPoints']:
-            markup['position'] = list(aligned_icp_lm_upper[i])
-            i+=1
+    _write_positions(landmarks_json_cbct_U, aligned_icp_lm_upper, labels_u)
 
     with open(json_output_path_IOS_U, "w") as file:
         json.dump(landmarks_json_cbct_U, file,indent=4, ensure_ascii=False)
 
-    if 'markups' in landmarks_json_cbct_L:
-        i=0
-        for markup in landmarks_json_cbct_L['markups'][0]['controlPoints']:
-            markup['position'] = list(aligned_icp_lm_lower[i])
-            i+=1
+    _write_positions(landmarks_json_cbct_L, aligned_icp_lm_lower, labels_l)
 
     with open(json_output_path_IOS_L, "w") as file:
         json.dump(landmarks_json_cbct_L, file,indent=4, ensure_ascii=False)
@@ -407,6 +499,12 @@ def main(args):
                 patient_data["ios_lm_lower"]
             )
             
+            # Keep only the landmarks present on both sides, in the same order
+            labels_U, lm_cbct_U, lm_ios_U = _pair_landmarks(
+                patient_data["cbct_lm_upper"], patient_data["ios_lm_upper"], "Upper", patient_id)
+            labels_L, lm_cbct_L, lm_ios_L = _pair_landmarks(
+                patient_data["cbct_lm_lower"], patient_data["ios_lm_lower"], "Lower", patient_id)
+
             # Load IOS meshes (VTK files)
             ios_upper_mesh = pv.read(patient_data["ios_upper"])
             ios_lower_mesh = pv.read(patient_data["ios_lower"])
@@ -417,13 +515,13 @@ def main(args):
             # 2. ALIGN BY LANDMARKS
             logger.debug(f"Aligning IOS upper jaw by landmarks")
             aligned_ios_upper, mat_ios_upper, aligned_lms_ios_upper = align_by_landmarks(
-                ios_upper_mesh, lm_ios_U, lm_cbct_U
+                ios_upper_mesh, lm_ios_U, lm_cbct_U, "Upper", patient_id
             )
             logger.info(f"IOS Upper landmarks after alignment:\n{aligned_lms_ios_upper}")
             
             logger.debug(f"Aligning IOS lower jaw by landmarks")
             aligned_ios_lower, mat_ios_lower, aligned_lms_ios_lower = align_by_landmarks(
-                ios_lower_mesh, lm_ios_L, lm_cbct_L
+                ios_lower_mesh, lm_ios_L, lm_cbct_L, "Lower", patient_id
             )
             logger.debug(f"IOS Lower landmarks after alignment shape: {aligned_lms_ios_lower.shape}")
             logger.debug(f"IOS Lower landmarks after alignment:\n{aligned_lms_ios_lower}")
@@ -457,7 +555,8 @@ def main(args):
                 aligned_lms_ios_upper, aligned_lms_ios_lower,
                 mat_icp_upper, mat_icp_lower,
                 output_dir, patient_id,
-                landmarks_json_cbct_U, landmarks_json_cbct_L
+                landmarks_json_cbct_U, landmarks_json_cbct_L,
+                labels_U, labels_L
             )
             registered += 1
             logger.info(f"Patient {patient_id} processed successfully")

--- a/ASO/ASO.py
+++ b/ASO/ASO.py
@@ -73,7 +73,7 @@ def install_function(self):
         
         # ===== BUILD LIBRARY LIST =====
         try:
-            libs = [('itk', None), ('torch','2.2.0'),('pytorch_lightning',None),('dicom2nifti', '2.3.0'),('pydicom', '2.2.2')]
+            libs = [('itk', None), ('torch','2.2.0'),('pytorch_lightning',None),('dicom2nifti', '2.6.2'),('pydicom', '3.0.2')]
             monai_version = '1.3.2' if sys.version_info >= (3, 10) else '0.7.0'
             libs.append(('monai', monai_version))
             logger.debug(f"Library list created with {len(libs)} libraries")

--- a/GreedyReg/GreedyReg_Method/Logic.py
+++ b/GreedyReg/GreedyReg_Method/Logic.py
@@ -335,7 +335,7 @@ class GreedyRegLogic(ScriptedLoadableModuleLogic):
 
   def _aliRequiredLibs(self):
     monaiVersion = '1.3.2' if sys.version_info >= (3, 10) else '0.7.0'
-    return [('itk', None), ('dicom2nifti', '2.3.0'), ('pydicom', '2.2.2'), ('monai', monaiVersion)]
+    return [('itk', None), ('dicom2nifti', '2.6.2'), ('pydicom', '3.0.2'), ('monai', monaiVersion)]
 
   def _checkLibInstalled(self, libName, requiredVersion=None):
     import importlib.metadata

--- a/MRI2CBCT/MRI2CBCT.py
+++ b/MRI2CBCT/MRI2CBCT.py
@@ -79,8 +79,10 @@ def install_function():
     libs = [
         ('itk', None),
         ('einops', None),
-        ('dicom2nifti', '==2.3.0'),
-        ('pydicom', '==2.2.2'),
+        ('dicom2nifti', '==2.6.2'),
+        # pydicom is kept on the version Slicer ships: downgrading it to 2.x breaks
+        # dicomweb-client and highdicom, hence every DICOM module of Slicer.
+        ('pydicom', '==3.0.2'),
         ('nibabel', None),
         ('itk-elastix', None),
         ('pandas', None),


### PR DESCRIPTION
Four independent fixes found while debugging an AREG IOS→CBCT run that ended in
PROCESS CANCELED.

- **LAS-oriented scans broke landmark search.** The agents ignore the direction
  cosines, so those scans reach them mirrored front to back and they drift into
  the wall of the volume. Reorienting to LPS on load is a no-op on scans that
  were already fine. One patient went from 4/12 landmarks in 15 min to 12/12 in
  1 min.
- **IOS and CBCT landmarks were paired by position rather than by label**, which
  silently produced either no pre-alignment at all or one built from unrelated
  points. Now paired by label, and skipped when the residual shows the two sets
  do not describe the same anatomy.
- **The ICP nearest-neighbour search ran on a single core.** 39 min → 7 min on
  one patient, byte-identical output.
- **pydicom was pinned to 2.2.2**, which breaks Slicer's bundled DICOM modules.
  Aligned on the versions AMASSS already uses.

The reference case shipped with the models comes out byte-identical, fitness
unchanged. On the failing patient both jaws improved.
