### PR TITLE
AREG: pause for review at chosen steps, with batch navigation and selective replay

### DIFF
--- a/AMASSS_CLI/AMASSS_CLI.py
+++ b/AMASSS_CLI/AMASSS_CLI.py
@@ -3,9 +3,10 @@
 AMASSS_CLI.py – Adaptation for nnUNet v2 (MAX, MAND, CB)
 """
 import argparse
-import time, os, sys, glob, subprocess, shutil
+import inspect
+import time, os, sys, glob, shutil
 import numpy as np
-import torch, itk, cc3d, dicom2nifti
+import torch, cc3d, dicom2nifti
 import SimpleITK as sitk
 import vtk
 import re
@@ -49,59 +50,208 @@ for g,d in LABELS.items():
     for k,v in d.items():
         NAMES_FROM_LABELS[g][v] = k
 
-def wait_for_stable_output(process, output_path, timeout_s=900, poll_s=1.0, stable_checks=3, min_size_bytes=262144):
-    """Wait until process exits or output file exists with stable, significant size."""
-    start_t = time.time()
-    last_size = -1
-    stable_count = 0
+# ---------------------------------------------------------------------------
+# nnUNet v2 inference, called through the Python API instead of the
+# `nnUNetv2_predict` command line. Ported from the cloud version of AMASSS
+# (sadt_amasss/nnunet_runner.py), which fixes three defects of the subprocess
+# version this file used to have:
+#
+# 1. No `nnUNet_results` environment variable. The CLI set it before spawning
+#    `nnUNetv2_predict`, and `os.environ` is process-global: two overlapping
+#    AMASSS runs would overwrite each other's model path.
+#    `initialize_from_trained_model_folder` takes an explicit path instead.
+# 2. No output-file polling. The CLI killed the predictor once the output file
+#    stopped growing for three seconds, which could interrupt nnUNet
+#    mid-postprocessing. The Python API simply returns when it is done.
+# 3. The resampling runs on the GPU too (see EnableGpuResampling), which is
+#    where the run time actually went -- the network was an eighth of it.
+#
+# In-process also means the checkpoint is loaded once per structure rather than
+# once per (scan x structure): no process start-up and no model load per scan.
+#
+# nnunetv2 is imported lazily inside these functions: the CPU path never needs
+# the resampler module, and an installation without nnunetv2 should fail where
+# it is used, with a message about inference, rather than at import time.
+# ---------------------------------------------------------------------------
 
-    while True:
-        rc = process.poll()
+CHECKPOINT_NAME = "checkpoint_final.pth"
+PLANS_FOLDER_PATTERN = "*__nnUNetPlans__3d_fullres"
 
-        if os.path.isfile(output_path):
-            try:
-                cur_size = os.path.getsize(output_path)
-            except OSError:
-                cur_size = -1
 
-            if cur_size >= min_size_bytes:
-                if cur_size == last_size:
-                    stable_count += 1
-                else:
-                    stable_count = 1
-                    last_size = cur_size
+def ResolveDevice():
+    """Return the device to actually use, falling back to CPU when needed."""
+    if torch.cuda.is_available():
+        return "cuda"
+    logger.info("No CUDA device available; running nnUNet on CPU")
+    return "cpu"
 
-                if stable_count >= stable_checks:
-                    logger.info(
-                        f"Stable output detected ({cur_size} bytes) at {output_path}"
-                    )
-                    return True
-            else:
-                stable_count = 0
-                last_size = cur_size
 
-        if rc is not None:
-            if rc != 0:
-                raise subprocess.CalledProcessError(rc, process.args)
+def FindModelFolder(model_root, structure_code):
+    """Locate the trained nnUNet folder for one structure, or None.
 
-            if os.path.isfile(output_path):
-                try:
-                    final_size = os.path.getsize(output_path)
-                except OSError:
-                    final_size = -1
-                logger.info(
-                    f"Prediction process exited cleanly; output found ({final_size} bytes)"
-                )
-                return True
+    Layout expected under the model bundle:
+        <model_root>/<CODE>/**/<Dataset...>__nnUNetPlans__3d_fullres/fold_0/checkpoint_final.pth
 
-            raise FileNotFoundError(f"Process exited but output file is missing: {output_path}")
+    A candidate is only accepted once its fold_0 checkpoint is confirmed
+    present, so a half-copied bundle degrades to "this structure is
+    unavailable" rather than crashing minutes into the run.
+    """
+    structure_root = os.path.join(model_root, structure_code)
+    if not os.path.isdir(structure_root):
+        return None
 
-        if (time.time() - start_t) > timeout_s:
-            raise TimeoutError(
-                f"Timeout waiting for stable output file: {output_path}"
-            )
+    pattern = os.path.join(structure_root, "**", PLANS_FOLDER_PATTERN)
+    for candidate in sorted(glob.glob(pattern, recursive=True)):
+        if os.path.isfile(os.path.join(candidate, "fold_0", CHECKPOINT_NAME)):
+            return candidate
 
-        time.sleep(poll_s)
+    # Also accept the plans folder being the structure folder itself.
+    if os.path.isfile(os.path.join(structure_root, "fold_0", CHECKPOINT_NAME)):
+        return structure_root
+    return None
+
+
+def BuildPredictor(device, tile_step_size=0.5):
+    """Instantiate an nnUNetPredictor, tolerating nnUNet's renamed kwargs.
+
+    nnUNet 2.x renamed `perform_everything_on_gpu` to
+    `perform_everything_on_device` mid-series; passing whichever the installed
+    version declares keeps this working across the range.
+    """
+    from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
+
+    options = {
+        "tile_step_size": float(tile_step_size),
+        "use_gaussian": True,
+        # Equivalent to the command line's --disable_tta: no test-time mirroring.
+        "use_mirroring": False,
+        "device": torch.device(device),
+        "verbose": False,
+        "verbose_preprocessing": False,
+        "allow_tqdm": False,
+    }
+    accepted = set(inspect.signature(nnUNetPredictor.__init__).parameters)
+    for name in ("perform_everything_on_device", "perform_everything_on_gpu"):
+        if name in accepted:
+            options[name] = device.startswith("cuda")
+            break
+
+    return nnUNetPredictor(**{k: v for k, v in options.items() if k in accepted})
+
+
+# The resampler nnUNet's own plans name by default, and the only one we are
+# willing to substitute. A bundle asking for anything else (no_resampling, a
+# custom function) was configured that way deliberately and its geometry is not
+# ours to reinterpret.
+_STOCK_RESAMPLER = "resample_data_or_seg_to_shape"
+_RESAMPLING_KEYS = ("resampling_fn_data", "resampling_fn_probabilities")
+
+
+def EnableGpuResampling(predictor, device):
+    """Point this predictor's resamplers at the GPU. Returns whether it applied.
+
+    Resampling, not inference, is what makes AMASSS slow: nnUNet's defaults are
+    scipy splines on one core and outweigh the network by roughly seven to one.
+    nnUNet ships torch equivalents, so there is nothing to reimplement, only to
+    select.
+
+    Selected by NAME: nnUNet resolves both resampling functions out of the
+    configuration dict via `recursive_find_resampling_fn_by_name`, so rewriting
+    the two names redirects both ends. No monkeypatching.
+
+    Mutating that dict is safe because PlansManager hands out a `deepcopy`: it
+    touches neither the shared plans nor a concurrent run, and the
+    `torch.device` put in here never reaches the `plans.json` nnUNet writes
+    beside its output (which `json.dump` could not serialize).
+    """
+    if not device.startswith("cuda"):
+        return False
+
+    try:
+        from nnunetv2.preprocessing.resampling.resample_torch import (  # noqa: F401
+            resample_torch_fornnunet,
+        )
+    except ImportError:
+        logger.info("This nnUNet has no torch resampler; keeping the scipy one")
+        return False
+
+    configuration_manager = predictor.configuration_manager
+    configuration = configuration_manager.configuration
+
+    if any(configuration.get(key) != _STOCK_RESAMPLER for key in _RESAMPLING_KEYS):
+        logger.info("Model plans request a non-default resampler; leaving it alone")
+        return False
+
+    for key in _RESAMPLING_KEYS:
+        configuration[key] = "resample_torch_fornnunet"
+        # 'linear' is order 1, already what the plans ask for on the
+        # probabilities. The input data drops from order 3 to order 1 (torch
+        # has no 3D cubic interpolation): that is the whole numerical
+        # difference.
+        configuration[f"{key}_kwargs"] = {
+            "is_seg": False,
+            "device": torch.device(device),
+            "mode": "linear",
+        }
+
+    # Both are `@property @lru_cache`, so a value read before this point would
+    # otherwise outlive the swap.
+    manager_class = type(configuration_manager)
+    for key in _RESAMPLING_KEYS:
+        getattr(manager_class, key).fget.cache_clear()
+
+    return True
+
+
+def PredictFolder(model_folder, input_dir, output_dir, device, tile_step_size=0.5):
+    """Segment every `*_0000.nii.gz` in `input_dir`, writing masks to `output_dir`.
+
+    A whole folder per call is deliberate: the model is loaded once per
+    structure rather than once per (scan x structure), which on a batch run is
+    the difference between N*S and S checkpoint loads.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    def run(gpu_resampling):
+        predictor = BuildPredictor(device, tile_step_size)
+        # Explicit path: no nnUNet_results env var, hence no cross-run race.
+        predictor.initialize_from_trained_model_folder(
+            model_folder,
+            use_folds=(0,),
+            checkpoint_name=CHECKPOINT_NAME,
+        )
+
+        on_gpu = gpu_resampling and EnableGpuResampling(predictor, device)
+        logger.info(
+            f"nnUNet predicting on {device} (GPU resampling: {'on' if on_gpu else 'off'})"
+        )
+
+        # `predict_from_files` fans preprocessing and export out to SPAWNED
+        # processes, each of which would need its own CUDA context to run a GPU
+        # resampler -- and under Slicer a spawned worker re-imports this module
+        # and pays the whole torch import again. Everything therefore runs in
+        # this process, trading away the CPU/GPU overlap on multi-scan batches
+        # -- a smaller loss than the resampling win.
+        predictor.predict_from_files_sequential(
+            input_dir,
+            output_dir,
+            save_probabilities=False,
+            overwrite=True,
+        )
+
+    try:
+        run(True)
+    except torch.cuda.OutOfMemoryError as e:
+        # Resampling a whole CBCT on the GPU needs a few GB on top of the
+        # network, which a small card may not have. The cloud version has a
+        # `gpu_resampling` argument for this; the CLI's parameter list is fixed
+        # by AMASSS_CLI.xml and its callers, so the fallback is automatic
+        # instead: give the memory back and redo this structure with nnUNet's
+        # own scipy resampler rather than failing the run.
+        logger.warning(f"GPU out of memory ({e}); retrying with CPU resampling")
+        torch.cuda.empty_cache()
+        run(False)
+
 
 MODELS_GROUP = {
     "LARGE":{
@@ -269,53 +419,6 @@ def SavePredToVTK(file_path, temp_folder, smoothing, vtk_output_path, model_size
         logger.error(f"Error in SavePredToVTK: {e}")
         raise
 
-def SetSpacingFromRef(filepath, refFile, interpolator="NearestNeighbor", outpath=-1):
-    """Set spacing from reference file with error handling."""
-    try:
-        if not os.path.exists(filepath):
-            logger.error(f"Input file not found: {filepath}")
-            raise FileNotFoundError(f"File does not exist: {filepath}")
-        
-        if not os.path.exists(refFile):
-            logger.error(f"Reference file not found: {refFile}")
-            raise FileNotFoundError(f"Reference file does not exist: {refFile}")
-        
-        logger.debug(f"Setting spacing from reference: {refFile}")
-        
-        img = itk.imread(filepath)
-        ref = itk.imread(refFile)
-        sp_i, sz_i = np.array(img.GetSpacing()), np.array(itk.size(img))
-        sp_r, sz_r = np.array(ref.GetSpacing()), np.array(itk.size(ref))
-        
-        if not np.allclose(sp_i, sp_r) or not np.array_equal(sz_i, sz_r):
-            PixelType = itk.template(img)[1][0]
-            Dim = 3
-            IVec = itk.Image[PixelType, Dim]
-            interp = itk.NearestNeighborInterpolateImageFunction[IVec, itk.D].New() \
-                     if interpolator == "NearestNeighbor" else itk.LinearInterpolateImageFunction[IVec, itk.D].New()
-            res = itk.ResampleImageFilter[IVec, IVec].New(
-                Input=img,
-                OutputSpacing=sp_r.tolist(), 
-                OutputOrigin=ref.GetOrigin(),
-                OutputDirection=ref.GetDirection(), 
-                Interpolator=interp,
-                Size=sz_r.tolist()
-            )
-            res.Update()
-            out = sitk.GetImageFromArray(itk.GetArrayFromImage(res.GetOutput()))
-            out.CopyInformation(sitk.ReadImage(refFile))
-        else:
-            out = sitk.ReadImage(filepath)
-        
-        out = sitk.Cast(out, sitk.sitkInt16)
-        if outpath != -1:
-            sitk.WriteImage(out, outpath)
-            logger.debug(f"Spacing set and saved to {outpath}")
-        return out
-    except Exception as e:
-        logger.error(f"Error setting spacing: {e}")
-        raise
-
 def CleanArray(seg_arr, radius):
     """Clean segmentation array using morphological operations with error handling."""
     try:
@@ -396,67 +499,151 @@ def CropSkin(skin_seg_arr,thickness):
         crop=(cc==(1+int(np.argmax(sizes)))).astype(np.uint8)
     return crop
 
-def SavePrediction(img,ref_filepath,outpath,output_spacing):
-    ref = sitk.ReadImage(ref_filepath)
-    out = sitk.GetImageFromArray(img.astype(np.int16))
-    out.SetSpacing(output_spacing)
-    out.SetDirection(ref.GetDirection())
-    out.SetOrigin(ref.GetOrigin())
-    sitk.WriteImage(out, outpath)
+def MatchReferenceGeometry(mask_img, ref_img):
+    """Put a predicted mask back onto the reference scan's exact grid.
 
-def SaveSeg(file_path, spacing, seg_arr, input_path, temp_path, outputdir, temp_folder, save_vtk, smoothing=5, model_size="LARGE"):
-    """Save segmentation with error handling for prediction, spacing correction, and VTK conversion."""
+    nnUNet already returns its prediction on the input grid, so the resample is
+    a no-op in the normal case and only fires when a model bundle hands back a
+    different geometry.
+    """
+    same_geometry = (
+        mask_img.GetSize() == ref_img.GetSize()
+        and np.allclose(mask_img.GetSpacing(), ref_img.GetSpacing())
+        and np.allclose(mask_img.GetOrigin(), ref_img.GetOrigin())
+        and np.allclose(mask_img.GetDirection(), ref_img.GetDirection())
+    )
+    if not same_geometry:
+        logger.debug("Prediction geometry differs from the scan; resampling")
+        mask_img = sitk.Resample(
+            mask_img, ref_img, sitk.Transform(), sitk.sitkNearestNeighbor, 0,
+            mask_img.GetPixelID(),
+        )
+    return sitk.Cast(mask_img, sitk.sitkInt16)
+
+
+def SaveSeg(file_path, seg_arr, ref_img, outputdir, temp_folder, save_vtk, smoothing=5, model_size="LARGE"):
+    """Write one segmentation array beside the scan it came from.
+
+    Ported from the cloud version's `_write_segmentation`: one write, not two.
+    The old path saved the mask to a temporary volume and read it back through
+    ITK only to force the geometry -- two extra gzip round-trips of a full CBCT
+    per structure, for a resample that in practice had nothing to do.
+
+    `useCompression` covers the formats whose extension does not already imply
+    it (.nrrd); for a .nii.gz the gz is applied from the name either way.
+    """
     try:
-        logger.debug(f"Saving segmentation for: {file_path}")
-        
-        # Step 1: Save prediction
-        try:
-            logger.debug(f"Step 1: Saving prediction with spacing {spacing}")
-            SavePrediction(seg_arr, input_path, temp_path, output_spacing=spacing)
-            logger.info("Prediction saved successfully")
-        except Exception as e:
-            logger.error(f"Error saving prediction: {e}")
-            raise
-        
-        # Step 2: Set spacing from reference
-        try:
-            logger.debug(f"Step 2: Setting spacing from reference image: {input_path}")
-            SetSpacingFromRef(
-                temp_path,
-                input_path,
-                outpath=file_path
-            )
-            logger.info(f"Spacing corrected and saved to: {file_path}")
-        except Exception as e:
-            logger.error(f"Error setting spacing: {e}")
-            raise
-        
-        # Step 3: Save VTK mesh if requested
+        logger.debug(f"Saving segmentation to: {file_path}")
+
+        out = sitk.GetImageFromArray(seg_arr.astype(np.int16))
+        out.SetSpacing(ref_img.GetSpacing())
+        out.SetDirection(ref_img.GetDirection())
+        out.SetOrigin(ref_img.GetOrigin())
+        sitk.WriteImage(MatchReferenceGeometry(out, ref_img), file_path, useCompression=True)
+        logger.info(f"Segmentation saved: {file_path}")
+
         if save_vtk:
             try:
-                logger.debug(f"Step 3: Converting to VTK with smoothing: {smoothing}")
+                logger.debug(f"Converting to VTK with smoothing: {smoothing}")
                 SavePredToVTK(file_path, temp_folder, smoothing, vtk_output_path=outputdir)
                 logger.info("VTK mesh saved successfully")
             except Exception as e:
                 logger.error(f"Error saving VTK mesh: {e}")
                 raise
-        
-        logger.info(f"Segmentation saving completed successfully for: {file_path}")
     except Exception as e:
         logger.error(f"Error in SaveSeg: {e}")
         raise
+
+def PrepareScanForNnunet(scan_path, destination):
+    """Put one scan into the folder nnUNet reads, as a real NIfTI.
+
+    Ported fix: the original did `shutil.copy(volume_file, "p_XXX_0000.nii.gz")`
+    -- an NRRD renamed to .nii.gz, handed to a reader that picks its format from
+    the extension. NRRD is Slicer's own default format, so "supported" input was
+    in practice only reliable for NIfTI. A read + write actually converts.
+
+    A file that is already a gzipped NIfTI is copied instead: converting it
+    would be a gunzip + gzip of a full CBCT for no change. The voxel type is
+    left alone -- nnUNet's reader casts to float32 itself.
+    """
+    if scan_path.lower().endswith(".nii.gz"):
+        shutil.copy(scan_path, destination)
+        return
+    sitk.WriteImage(sitk.ReadImage(scan_path), destination)
+
+
+def AssembleScanOutputs(record, predictions, args, temp_folder):
+    """Turn one scan's per-structure nnUNet masks into its final files."""
+    ref_img = sitk.ReadImage(record["path"])
+
+    masks = {}
+    for struct, pred_dir in predictions.items():
+        predicted_file = os.path.join(pred_dir, f"p_{record['case_id']}.nii.gz")
+        if not os.path.isfile(predicted_file):
+            logger.warning(f"No {struct} prediction for {record['name']}")
+            continue
+        arr = sitk.GetArrayFromImage(sitk.ReadImage(predicted_file))
+        masks[struct] = (arr > 0).astype(np.uint8)
+
+    if not masks:
+        raise FileNotFoundError(f"nnUNet produced no prediction for {record['name']}")
+
+    outdir = record["outdir"]
+    base = record["base"]
+    ext = record["ext"]
+    pid = args["prediction_ID"]
+    written = []
+
+    # SEPARATE mode: requested, or unavoidable when there is only one structure
+    # (a "merged" volume of one structure is just that structure).
+    if "SEPARATE" in args["merge"] or len(masks) == 1:
+        for struct, mask in masks.items():
+            outfn = os.path.join(outdir, f"{base}_{pid}_{struct}{ext}")
+            SaveSeg(
+                outfn, mask, ref_img, outdir, temp_folder,
+                args["genVtk"], args["vtk_smooth"], "LARGE",
+            )
+            written.append(outfn)
+
+    # MERGE mode
+    if "MERGE" in args["merge"] and len(masks) > 1:
+        shape = next(iter(masks.values())).shape
+        merged = np.zeros(shape, dtype=np.int16)
+        for struct in args["merging_order"]:
+            if struct in masks:
+                lbl = LABELS["LARGE"].get(struct, 1)
+                merged = np.where(masks[struct] == 1, lbl, merged)
+                logger.debug(f"Merged {struct} with label {lbl}")
+
+        outfn = os.path.join(outdir, f"{base}_{pid}_MERGED{ext}")
+        SaveSeg(
+            outfn, merged, ref_img, outdir, temp_folder,
+            args["genVtk"], args["vtk_smooth"], "LARGE",
+        )
+        written.append(outfn)
+
+    if not written:
+        raise RuntimeError(
+            f"No segmentation was written for {record['name']} "
+            f"(merge modes: {', '.join(args['merge'])})."
+        )
+
+    record["structures"] = sorted(masks)
+    return written
+
+
 # -- Main adapt for nnUNet v2 ---
 def main(args):
     try:
         logger.info("Starting AMASSS_CLI with nnUNet v2 backend")
-        
+
         # ===== SETUP PHASE =====
         try:
             logger.debug("Initializing temporary folder and output setup")
-            
+
             tmp = args["temp_fold"]
             base_output = args["output_folder"]
-            
+
             try:
                 shutil.rmtree(tmp, ignore_errors=True)
                 os.makedirs(tmp, exist_ok=True)
@@ -467,17 +654,17 @@ def main(args):
         except Exception as e:
             logger.error(f"Error during setup phase: {e}")
             raise
-        
+
         # ===== INPUT FILE DISCOVERY PHASE =====
         try:
             logger.debug("Discovering input files")
             input_path = args["inputVolume"]
             extensions = (".nii", ".nii.gz", ".nrrd", ".nrrd.gz")
-            
+
             if not os.path.exists(input_path):
                 logger.error(f"Input path does not exist: {input_path}")
                 raise FileNotFoundError(f"Input path not found: {input_path}")
-            
+
             if os.path.isdir(input_path):
                 logger.debug(f"Input is directory, scanning for volume files")
                 # Walk sub-directories: AREG writes its registered scans to
@@ -507,12 +694,12 @@ def main(args):
                     logger.warning(f"Input file has unexpected extension: {input_path}")
                 input_files = [input_path]
                 logger.debug(f"Single input file: {input_path}")
-            
+
             scan_count = len(input_files)
             if scan_count == 0:
                 logger.error("No valid input files found")
                 sys.exit(1)
-            
+
             logger.info(f"Found {scan_count} input file(s)")
         except Exception as e:
             logger.error(f"Error during input file discovery: {e}")
@@ -522,275 +709,171 @@ def main(args):
         print("<filter-start><filter-name>AMASSS</filter-name></filter-start>", flush=True)
         sys.stdout.flush()
 
-        # ===== MAIN PROCESSING LOOP =====
+        device = ResolveDevice()
+
+        # ===== MODEL DISCOVERY =====
+        # Once for the whole run, not once per scan: the bundle is the same for
+        # every scan, and a missing model must be found out before inference.
+        try:
+            logger.debug("Searching for nnUNet models")
+            nnunet_models = {}
+            missing_structures = []
+            for struct in args["skullStructure"].split(","):
+                struct = struct.strip()
+                if not struct:
+                    continue
+                model_folder = FindModelFolder(args["modelDirectory"], struct)
+                if model_folder is None:
+                    logger.warning(
+                        f"No usable model for structure '{struct}' in {args['modelDirectory']}"
+                    )
+                    missing_structures.append(struct)
+                else:
+                    nnunet_models[struct] = model_folder
+                    logger.debug(f"Found model for {struct}: {model_folder}")
+
+            if not nnunet_models:
+                logger.error("No models found for any structure")
+                raise FileNotFoundError(
+                    f"No nnUNet model found in '{args['modelDirectory']}' for any of the "
+                    f"requested structures ({args['skullStructure']}). Expected "
+                    f"<bundle>/<CODE>/**/*__nnUNetPlans__3d_fullres/fold_0/{CHECKPOINT_NAME}"
+                )
+
+            logger.info(f"Found {len(nnunet_models)} model(s) to process on {device}")
+        except Exception as e:
+            logger.error(f"Error during model discovery: {e}")
+            raise
+
+        # ===== SCAN PREPARATION =====
+        # Every scan is converted ONCE into the single folder nnUNet reads, so
+        # each structure is one folder-wide prediction and each checkpoint is
+        # loaded once instead of once per (scan x structure).
+        nnunet_input = os.path.join(tmp, "nnunet_input")
+        os.makedirs(nnunet_input, exist_ok=True)
+
+        scan_records = []
+        for scan_idx, volume_file in enumerate(input_files, start=1):
+            case_id = f"{scan_idx:03d}"
+            basename = os.path.basename(volume_file)
+            base, ext = os.path.splitext(basename)
+            if ext == ".gz":
+                base, ext2 = os.path.splitext(base)
+                ext = ext2 + ext
+
+            if args.get("save_in_folder"):
+                outdir = os.path.join(base_output, f"{base}_{args['prediction_ID']}_SegOut")
+            else:
+                outdir = base_output
+            os.makedirs(outdir, exist_ok=True)
+
+            record = {
+                "case_id": case_id,
+                "name": basename,
+                "path": volume_file,
+                "base": base,
+                "ext": ext,
+                "outdir": outdir,
+                "status": "pending",
+            }
+            try:
+                PrepareScanForNnunet(
+                    volume_file, os.path.join(nnunet_input, f"p_{case_id}_0000.nii.gz")
+                )
+                logger.debug(f"Prepared {basename} as case p_{case_id}")
+            except Exception as e:
+                logger.error(f"Could not read scan {volume_file}: {e}")
+                record["status"] = "failed"
+                record["error"] = f"Unreadable input: {e}"
+            scan_records.append(record)
+
+        readable = [r for r in scan_records if r["status"] != "failed"]
+        if not readable:
+            raise RuntimeError("None of the input scans could be read as a medical volume.")
+
+        # ===== INFERENCE: one model load per structure =====
+        total_struct = len(nnunet_models)
+        total_steps = scan_count * total_struct
+        predictions = {}
+        failed_structures = {}
+
+        for struct_idx, (struct, model_folder) in enumerate(nnunet_models.items(), start=1):
+            logger.info(f"Processing structure {struct_idx}/{total_struct}: {struct}")
+            outp = os.path.join(tmp, f"pred_{struct}")
+            try:
+                PredictFolder(model_folder, nnunet_input, outp, device)
+                predictions[struct] = outp
+                logger.info(f"Prediction for {struct} completed")
+            except Exception as e:
+                # One structure failing must not lose the others.
+                logger.error(f"Prediction failed for structure {struct}: {e}")
+                failed_structures[struct] = str(e)
+
+            # Progress is still counted in (scan x structure) steps, so the
+            # scale the Slicer modules were written against is unchanged.
+            try:
+                step = struct_idx * scan_count
+                fraction = step / total_steps
+                print(f"<filter-progress>{fraction:.4f}</filter-progress>", flush=True)
+                sys.stdout.flush()
+                logger.debug(f"Progress: {fraction:.4f}")
+            except Exception as e:
+                logger.warning(f"Error reporting progress: {e}")
+
+        if not predictions:
+            raise RuntimeError(
+                "Every structure failed to predict: "
+                + "; ".join(f"{s}: {err}" for s, err in failed_structures.items())
+            )
+
+        # The converted copies are a full CBCT each and inference is done with
+        # them; a batch would otherwise sit on all of them until the run ends.
+        shutil.rmtree(nnunet_input, ignore_errors=True)
+
+        # ===== PER-SCAN OUTPUT ASSEMBLY =====
         processed_scans = 0
         failed_scans = []
-        
-        for scan_idx, volume_file in enumerate(input_files, start=1):
-            scan_context = f"scan {scan_idx}/{scan_count}: {os.path.basename(volume_file)}"
-            logger.info(f"Starting processing of {scan_context}")
-            
+
+        for record in readable:
+            scan_context = f"scan {record['case_id']}: {record['name']}"
+            logger.info(f"Saving outputs for {scan_context}")
             try:
-                # --- FILE PREPARATION ---
-                try:
-                    case_id = f"{scan_idx:03d}"
-                    basename = os.path.basename(volume_file)
-                    base, ext = os.path.splitext(basename)
-                    if ext == ".gz":
-                        base, ext2 = os.path.splitext(base)
-                        ext = ext2 + ext
-                    logger.debug(f"File parsed: base={base}, ext={ext}, case_id={case_id}")
-                except Exception as e:
-                    logger.error(f"Error parsing filename for {volume_file}: {e}")
-                    raise
-
-                # --- OUTPUT DIRECTORY ---
-                try:
-                    if args.get("save_in_folder"):
-                        outdir = os.path.join(base_output, f"{base}_{args['prediction_ID']}_SegOut")
-                    else:
-                        outdir = base_output
-                    os.makedirs(outdir, exist_ok=True)
-                    logger.debug(f"Output directory set to: {outdir}")
-                except Exception as e:
-                    logger.error(f"Error creating output directory: {e}")
-                    raise
-
-                # --- INPUT FILE COPY ---
-                try:
-                    tmp_name = f"p_{case_id}_0000.nii.gz"
-                    input_vol = os.path.join(tmp, tmp_name)
-                    shutil.copy(volume_file, input_vol)
-                    logger.debug(f"Input volume copied to: {input_vol}")
-                except Exception as e:
-                    logger.error(f"Error copying input volume: {e}")
-                    raise
-
-                # --- MODEL DISCOVERY ---
-                try:
-                    logger.debug("Searching for nnUNet models")
-                    nnunet_models = {}
-                    for struct in args["skullStructure"].split(","):
-                        try:
-                            root = os.path.join(args["modelDirectory"], struct)
-                            if not os.path.exists(root):
-                                logger.warning(f"Model directory not found for structure {struct}: {root}")
-                                continue
-                            
-                            pattern = os.path.join(root, "**", "*__nnUNetPlans__3d_fullres")
-                            plans = glob.glob(pattern, recursive=True)
-                            if plans:
-                                nnunet_models[struct] = plans[0]
-                                logger.debug(f"Found model for {struct}: {plans[0]}")
-                            else:
-                                logger.warning(f"No model found for structure {struct}")
-                        except Exception as e:
-                            logger.warning(f"Error searching model for {struct}: {e}")
-                            continue
-                    
-                    if not nnunet_models:
-                        logger.error("No models found for any structure")
-                        raise FileNotFoundError("No nnUNet models found for specified structures")
-                    
-                    logger.info(f"Found {len(nnunet_models)} models to process")
-                except Exception as e:
-                    logger.error(f"Error during model discovery: {e}")
-                    raise
-
-                # --- PREDICTIONS LOOP ---
-                total_struct = len(nnunet_models)
-                total_steps = scan_count * total_struct
-                prediction_segmentation = {}
-
-                logger.debug("Starting predictions for all structures")
-                
-                for struct_idx, (struct, plans_dir) in enumerate(nnunet_models.items(), start=1):
-                    struct_context = f"structure {struct_idx}/{total_struct}: {struct}"
-                    logger.info(f"Processing {struct_context}")
-                    
-                    try:
-                        # Setup nnUNet environment
-                        try:
-                            dataset_name = os.path.basename(os.path.dirname(plans_dir))
-                            os.environ['nnUNet_results'] = os.path.dirname(os.path.dirname(plans_dir))
-                            outp = os.path.join(tmp, f"pred_{struct}")
-                            os.makedirs(outp, exist_ok=True)
-                            logger.debug(f"nnUNet output directory: {outp}")
-                        except Exception as e:
-                            logger.error(f"Error setting up nnUNet environment: {e}")
-                            raise
-
-                        # Find checkpoint
-                        try:
-                            checkpoint = os.path.join(plans_dir, "fold_0", "checkpoint_final.pth")
-                            if not os.path.isfile(checkpoint):
-                                logger.error(f"Checkpoint not found for {struct}: {checkpoint}")
-                                raise FileNotFoundError(f"Model checkpoint not found: {checkpoint}")
-                            logger.debug(f"Checkpoint found: {checkpoint}")
-                        except Exception as e:
-                            logger.error(f"Error locating checkpoint: {e}")
-                            raise
-
-                        # Run nnUNet prediction
-                        try:
-                            if torch.cuda.is_available():
-                                device = "cuda"
-                            else:
-                                device = "cpu"
-                                
-                            logger.info(f"Predicting {struct} on device: {device}")
-                            
-                            cmd = [
-                                "nnUNetv2_predict",
-                                "-i", tmp,
-                                "-o", outp,
-                                "-d", dataset_name,
-                                "-c", "3d_fullres",
-                                "-f", "0",
-                                "-device", device,
-                                "--disable_tta",
-                            ]
-                            print(cmd)
-
-                            nifti_pred = os.path.join(outp, f"p_{case_id}.nii.gz")
-
-                            # Start prediction and keep checking output stability to avoid waiting only on process signal.
-                            proc = subprocess.Popen(cmd, stdout=None, stderr=None, close_fds=True)
-                            wait_for_stable_output(
-                                proc,
-                                nifti_pred,
-                                timeout_s=3600,
-                                poll_s=1.0,
-                                stable_checks=3,
-                                min_size_bytes=100,
-                            )
-
-                            if proc.poll() is None:
-                                logger.info("Stable output reached before process exit; stopping predictor process")
-                                proc.terminate()
-                                try:
-                                    proc.wait(timeout=5)
-                                except subprocess.TimeoutExpired:
-                                    proc.kill()
-                                    proc.wait(timeout=5)
-
-                            logger.info(f"Prediction for {struct} completed")
-                        except subprocess.CalledProcessError as e:
-                            logger.error(f"nnUNet prediction failed for {struct}: {e}")
-                            raise
-                        except Exception as e:
-                            logger.error(f"Error executing nnUNet prediction: {e}")
-                            raise
-
-                        # Report progress
-                        try:
-                            step = (scan_idx - 1) * total_struct + struct_idx
-                            fraction = step / total_steps
-                            print(f"<filter-progress>{fraction:.4f}</filter-progress>", flush=True)
-                            sys.stdout.flush()
-                            logger.debug(f"Progress: {fraction:.4f}")
-                        except Exception as e:
-                            logger.warning(f"Error reporting progress: {e}")
-
-                        # Load prediction
-                        try:
-                            if not os.path.isfile(nifti_pred):
-                                logger.error(f"Prediction output not found: {nifti_pred}")
-                                raise FileNotFoundError(f"nnUNet output file not found: {nifti_pred}")
-                            
-                            img = sitk.ReadImage(nifti_pred)
-                            arr = sitk.GetArrayFromImage(img)
-                            mask = (arr > 0).astype(np.uint8)
-                            prediction_segmentation[struct] = mask
-                            logger.debug(f"Loaded prediction mask for {struct}")
-                        except Exception as e:
-                            logger.error(f"Error loading prediction for {struct}: {e}")
-                            raise
-                    
-                    except Exception as e:
-                        logger.error(f"Error processing {struct_context}: {e}")
-                        raise
-
-                # --- SEGMENTATION SAVING PHASE ---
-                try:
-                    logger.debug("Starting segmentation saving")
-                    
-                    try:
-                        spacing = list(sitk.ReadImage(volume_file).GetSpacing())
-                        logger.debug(f"Image spacing: {spacing}")
-                    except Exception as e:
-                        logger.error(f"Error reading image spacing: {e}")
-                        raise
-
-                    # SEPARATE mode
-                    if "SEPARATE" in args["merge"] or len(prediction_segmentation) == 1:
-                        try:
-                            logger.debug("Saving separate segmentations")
-                            for struct, mask in prediction_segmentation.items():
-                                try:
-                                    outfn = os.path.join(outdir, f"{base}_{args['prediction_ID']}_{struct}{ext}")
-                                    SaveSeg(
-                                        outfn, spacing, mask, volume_file,
-                                        os.path.join(tmp, "tmp.nii.gz"),
-                                        outdir, tmp, args["genVtk"], args["vtk_smooth"], "LARGE"
-                                    )
-                                    logger.info(f"Saved segmentation for {struct}")
-                                except Exception as e:
-                                    logger.error(f"Error saving segmentation for {struct}: {e}")
-                                    raise
-                        except Exception as e:
-                            logger.error(f"Error in separate segmentation mode: {e}")
-                            raise
-
-                    # MERGE mode
-                    if "MERGE" in args["merge"] and len(prediction_segmentation) > 1:
-                        try:
-                            logger.debug("Merging segmentations")
-                            
-                            shape = next(iter(prediction_segmentation.values())).shape
-                            merged = np.zeros(shape, dtype=np.int16)
-                            
-                            for struct in args["merging_order"]:
-                                if struct in prediction_segmentation:
-                                    lbl = LABELS["LARGE"].get(struct, 1)
-                                    merged = np.where(prediction_segmentation[struct] == 1, lbl, merged)
-                                    logger.debug(f"Merged {struct} with label {lbl}")
-                            
-                            outfn = os.path.join(outdir, f"{base}_{args['prediction_ID']}_MERGED{ext}")
-                            SaveSeg(
-                                outfn, spacing, merged, volume_file,
-                                os.path.join(tmp, "tmp.nii.gz"),
-                                outdir, tmp, args["genVtk"], args["vtk_smooth"], "LARGE"
-                            )
-                            logger.info("Merged segmentation saved")
-                        except Exception as e:
-                            logger.error(f"Error in merge segmentation mode: {e}")
-                            raise
-
-                    logger.info(f"Segmentation saving completed for {scan_context}")
-                except Exception as e:
-                    logger.error(f"Error during segmentation saving: {e}")
-                    raise
-
-                # --- CLEANUP ---
-                try:
-                    shutil.rmtree(tmp, ignore_errors=True)
-                    os.makedirs(tmp, exist_ok=True)
-                    logger.debug("Temporary files cleaned up")
-                except Exception as e:
-                    logger.warning(f"Error cleaning up temporary files: {e}")
-
+                AssembleScanOutputs(record, predictions, args, tmp)
+                record["status"] = "ok"
                 processed_scans += 1
                 logger.info(f"Successfully processed {scan_context}")
-            
             except Exception as e:
+                # A failure here is recorded and the run continues: the original
+                # re-raised on the LAST scan only, so a batch could abort at the
+                # very end and lose everything already produced.
                 logger.error(f"Failed to process {scan_context}: {e}")
-                failed_scans.append((scan_idx, volume_file, str(e)))
-                if scan_idx < scan_count:
-                    logger.info("Continuing with next scan")
-                    continue
-                else:
-                    raise
+                record["status"] = "failed"
+                failed_scans.append((record["case_id"], record["path"], str(e)))
+
+            # This scan's predictions are no longer needed.
+            for pred_dir in predictions.values():
+                try:
+                    os.remove(os.path.join(pred_dir, f"p_{record['case_id']}.nii.gz"))
+                except OSError:
+                    pass
+
+        for record in scan_records:
+            if record["status"] == "failed" and "error" in record:
+                failed_scans.append((record["case_id"], record["path"], record["error"]))
+
+        # --- CLEANUP ---
+        try:
+            shutil.rmtree(tmp, ignore_errors=True)
+            os.makedirs(tmp, exist_ok=True)
+            logger.debug("Temporary files cleaned up")
+        except Exception as e:
+            logger.warning(f"Error cleaning up temporary files: {e}")
+
+        if processed_scans == 0:
+            raise RuntimeError(
+                "AMASSS produced no output for any scan. First error: "
+                + (failed_scans[0][2] if failed_scans else "unknown")
+            )
 
         # --- FINAL REPORT ---
         try:
@@ -798,23 +881,31 @@ def main(args):
             logger.info(f"Processing completed in {elapsed:.2f}s")
             print(f"<filter-end><filter-name>AMASSS</filter-name><filter-time>{elapsed:.2f}</filter-time></filter-end>", flush=True)
             sys.stdout.flush()
-            
+
             logger.info(f"Processed {processed_scans}/{scan_count} scans successfully")
+            if missing_structures:
+                logger.warning(
+                    f"No model for structure(s): {', '.join(missing_structures)}"
+                )
+            if failed_structures:
+                for struct, err in failed_structures.items():
+                    logger.warning(f"  Structure {struct} failed: {err}")
             if failed_scans:
                 logger.warning(f"Failed to process {len(failed_scans)} scan(s)")
                 for idx, path, err in failed_scans:
                     logger.warning(f"  Scan {idx} ({os.path.basename(path)}): {err}")
-            
+
             if processed_scans == scan_count:
                 logger.info("All scans processed successfully.")
             else:
-                logger.warning(f"Processing completed with {len(failed_scans)} failure(s).", flush=True)
+                logger.warning(f"Processing completed with {len(failed_scans)} failure(s).")
         except Exception as e:
             logger.error(f"Error generating final report: {e}")
 
     except Exception as e:
         logger.error(f"Fatal error in main(): {e}")
         sys.exit(f"Processing failed: {e}")
+
 
 if __name__=="__main__":
     try:

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -359,6 +359,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.review = Review.ReviewSession()
         self.review_checkboxes = {}
         self.review_step = {}
+        self.executed_steps = []
 
     def setup(self):
         """
@@ -1788,9 +1789,14 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     CONTINUE_TEXT = "Continue"
 
     def startStep(self, step):
-        """Remember the step being launched, so its pause is found when it ends."""
+        """Remember the step being launched, so its pause is found when it ends.
+
+        The run consumes its own list as it goes, so replaying a step needs a
+        record of what has already gone by.
+        """
         self.module_name = step["Module"]
         self.review_step = step
+        self.executed_steps.append(step)
 
     def setupReviewUi(self):
         """Wire the review section up. Called once, from setup()."""
@@ -1799,8 +1805,10 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.ReviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
         self.ui.ReviewContinueButton.connect("clicked(bool)", self.onReviewContinue)
         self.ui.ReviewSkipRestButton.connect("clicked(bool)", self.onReviewSkipRest)
+        self.ui.ReviewGoBackButton.connect("clicked(bool)", self.onReviewGoBack)
         self.ui.ReviewContinueButton.setVisible(False)
         self.ui.ReviewSkipRestButton.setVisible(False)
+        self.ui.ReviewGoBackButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
         self.onReviewEnableToggled(self.ui.ReviewEnableCheckBox.isChecked())
 
@@ -1986,7 +1994,69 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.ReviewSkipRestButton.setText(
             f"The rest is fine - skip {remaining} patient(s)"
         )
+
+        # A result that only reads badly is worth nothing on its own: what the
+        # user needs is the step that caused it.
+        target, _ = self.previousCorrectableStep()
+        self.ui.ReviewGoBackButton.setVisible(target is not None)
+        if target is not None:
+            name = Review.describe(target.get("ReviewId", "")).get("label", "the previous step")
+            self.ui.ReviewGoBackButton.setText(f"Go back and fix: {name}")
         logger.info(f"Review - {title} - {item['patient']}{position}")
+
+    def previousCorrectableStep(self):
+        """The nearest step behind this one the user can actually change.
+
+        Looking at a bad orientation is useless without a way back to the
+        landmarks that caused it. Steps that only ever get looked at are
+        skipped over, so the button lands where something can be done.
+
+        Returns:
+            tuple: (step, steps to replay after it), or (None, []) if there is
+                nothing correctable behind the current one
+        """
+        current = self.review_step or {}
+        history = self.executed_steps
+        try:
+            # the last time this step ran, not the first
+            here = len(history) - 1 - history[::-1].index(current)
+        except ValueError:
+            return None, []
+
+        for i in range(here - 1, -1, -1):
+            kind = Review.describe(history[i].get("ReviewId", "")).get("kind")
+            if kind in (Review.LANDMARKS, Review.REGISTRATION):
+                return history[i], history[i + 1:here + 1]
+        return None, []
+
+    def onReviewGoBack(self):
+        """Return to the last correctable step, then replay everything since.
+
+        Correcting the landmarks changes nothing on its own - the orientation
+        was computed from the old ones. So the steps in between are queued to
+        run again, and the run comes back to this same pause with the new
+        result.
+        """
+        target, replay = self.previousCorrectableStep()
+        if target is None:
+            logger.warning("Nothing correctable behind this step")
+            return
+
+        name = Review.describe(target.get("ReviewId", "")).get("label", target.get("Module"))
+        logger.info(
+            f"Going back to '{name}'; {len(replay)} step(s) will run again afterwards"
+        )
+
+        self.review.reset()
+        self.resetReviewUi()
+
+        # Everything between the two runs again, ahead of whatever was left.
+        self.list_Processes_Parameters[0:0] = replay
+        self.review_step = target
+        # beginReview guards against a pause cancelled between the callback and
+        # the event loop; this one comes from a button, so it is armed here.
+        self.review.pending = True
+        self.beginReview()
 
     def onReviewSkipRest(self):
         """Accept the patients left at this step without looking at each one.
@@ -2032,6 +2102,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.ReviewContinueButton.setVisible(False)
         self.ui.ReviewContinueButton.setText(self.CONTINUE_TEXT)
         self.ui.ReviewSkipRestButton.setVisible(False)
+        self.ui.ReviewGoBackButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
         self.ui.ReviewMessageLabel.setText("")
 

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1964,7 +1964,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         name = step.get("Module", "this step")
         # Output folders are reused between runs: without this the review walks
         # patients this run never processed.
-        self.review.build(step, since=getattr(self, "startTime", None))
+        self.review.build(step, expected=self.runPatientIds())
         if not self.review.total or not self.showReviewItem():
             logger.warning(
                 f"Nothing could be loaded to review after {name}, continuing"
@@ -2034,6 +2034,29 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             name = Review.describe(target.get("ReviewId", "")).get("label", "the previous step")
             self.ui.ReviewGoBackButton.setText(f"Go back and fix: {name}")
         logger.info(f"Review - {title} - {item['patient']}{position}")
+
+    def runPatientIds(self):
+        """The patients this run is about, read from the folder it was given.
+
+        The scans on the input side are what defines the run; an output folder
+        may hold results from months of earlier work, and a step that skips a
+        patient it has already done leaves that patient's file untouched and
+        old. Only the input list says who is really being processed.
+
+        Returns:
+            set: patient ids, empty if the folder cannot be read
+        """
+        folder = self.ui.lineEditScanT1LmPath.text
+        if not folder or not os.path.isdir(folder):
+            return set()
+
+        wanted = Review.VOLUME_EXT + Review.MODEL_EXT + (".json",)
+        ids = set()
+        for root, _, files in os.walk(folder):
+            for name in files:
+                if name.endswith(wanted):
+                    ids.add(Review.patientIdFromFileName(name))
+        return ids
 
     def previousCorrectableStep(self):
         """The nearest step behind this one the user can actually change.

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1,4 +1,4 @@
-import os, sys,logging, time, zipfile, urllib.request, shutil, glob
+import os, sys,logging, time, traceback, zipfile, urllib.request, shutil, glob
 import vtk, qt, slicer
 from qt import (
     QWidget,
@@ -1671,6 +1671,30 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.ui.progressBar.setFormat(f"{progress_bar_value:.2f}%")
 
     def onProcessUpdate(self, caller, event):
+        """Drive the run from the CLI node that just reported in.
+
+        Wrapped because an exception escaping a VTK observer callback is printed
+        by Python straight into the stdout pipe Slicer only drains from the Qt
+        event loop - the very loop this callback is holding. The traceback then
+        freezes the whole application, and the real error is never seen. Report
+        it once the loop turns instead, and stop the run rather than leave it
+        half advanced.
+        """
+        try:
+            self._onProcessUpdate(caller, event)
+        except Exception:
+            details = traceback.format_exc()
+            qt.QTimer.singleShot(0, lambda: self._reportProcessFailure(details))
+
+    def _reportProcessFailure(self, details: str) -> None:
+        """Say what went wrong, then stop the run cleanly."""
+        logger.error(f"The run was stopped by an unexpected error:\n{details}")
+        try:
+            self.onCancel()
+        except Exception as e:
+            logger.error(f"Could not stop the run cleanly: {e}")
+
+    def _onProcessUpdate(self, caller, event):
         # Observers are never removed, and self.process becomes a plain Thread
         # while a conda tool runs. So a finished node can wake this up long
         # after its turn, with self.process pointing at something else - and a

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1707,19 +1707,42 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if caller.GetStatus() & caller.Completed:
             if caller.GetStatus() & caller.ErrorsMask:
                 # error
-                logger.info("========= PROCESS COMPLETED WITH ERRORS =========")
-                logger.info(self.process.GetOutputText())
-                logger.error("========= ERROR DETAILS =========")
-                errorText = self.process.GetErrorText()
-                logger.error(f"CLI execution failed: \n{errorText}")
+                out = self._briefCliOutput(self.process.GetOutputText())
+                err = self._briefCliOutput(self.process.GetErrorText())
+                qt.QTimer.singleShot(0, lambda: logger.error(
+                    "========= PROCESS COMPLETED WITH ERRORS =========\n"
+                    f"{out}\n========= ERROR DETAILS =========\n{err}"
+                ))
                 self.onCancel()
 
             else:
-                logger.info("========= PROCESS COMPLETED SUCCESSFULLY =========")
-                logger.info(self.process.GetOutputText())
+                # Deferred and trimmed on purpose: Slicer captures its own stdout
+                # into a pipe it only drains from the Qt event loop, and this runs
+                # inside a VTK observer callback where that loop cannot turn.
+                # Writing a whole CLI's output here fills the pipe with no reader
+                # left and the main thread blocks in write() for ever - a batch of
+                # three patients through ALI is already enough to do it.
+                cli_output = self._briefCliOutput(self.process.GetOutputText())
+                qt.QTimer.singleShot(0, lambda: logger.info(
+                    f"========= PROCESS COMPLETED SUCCESSFULLY =========\n{cli_output}"
+                ))
                 if self.enterReviewPause():
                     return
                 self.advanceToNextProcess()
+
+    MAX_CLI_OUTPUT_CHARS = 8000
+
+    @classmethod
+    def _briefCliOutput(cls, text) -> str:
+        """The tail of a CLI's output, small enough to never fill the stdout pipe."""
+        text = text or ""
+        if len(text) <= cls.MAX_CLI_OUTPUT_CHARS:
+            return text
+        kept = text[-cls.MAX_CLI_OUTPUT_CHARS:]
+        return (
+            f"[... {len(text) - len(kept)} characters omitted, "
+            f"full output in the Slicer log ...]\n{kept}"
+        )
 
     def advanceToNextProcess(self):
         """Launch the next step of the run, or finish if there is none left."""

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -245,7 +245,10 @@ class PopUpWindow(qt.QDialog):
         type=None,
         tocheck=None,
     ):
-        QWidget.__init__(self)
+        # Without a parent the window manager attaches the dialog to a 1x1
+        # dummy window and never maps it. A modal one then takes every click
+        # with nothing on screen to dismiss - the run looks frozen at the end.
+        QWidget.__init__(self, slicer.util.mainWindow())
         self.setWindowTitle(title)
         layout = QGridLayout()
         self.setLayout(layout)
@@ -1963,6 +1966,18 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.review.reset()
         self.advanceToNextProcess()
 
+    def showDoneMessage(self, text):
+        """Say the run is over without taking the application hostage.
+
+        Nothing waits on this answer, so it is shown rather than executed: a
+        modal dialog that fails to appear leaves the user with no way to click
+        anything, and that is exactly what a finished run must not do.
+        """
+        self.done_popup = PopUpWindow(title="Process Done", text=text)
+        self.done_popup.setModal(False)
+        self.done_popup.show()
+        self.done_popup.raise_()
+
     def resetReviewUi(self):
         """Put the panel back the way it was before the pause."""
         self.ui.ReviewContinueButton.setVisible(False)
@@ -2012,9 +2027,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 int(average_time % 60),
             )
         )
-        qt.QTimer.singleShot(
-            0, lambda: PopUpWindow(title="Process Done", text=done_message).exec_()
-        )
+        qt.QTimer.singleShot(0, lambda: self.showDoneMessage(done_message))
 
         file_path = os.path.abspath(__file__)
         folder_path = os.path.dirname(file_path)

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -360,6 +360,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.review_checkboxes = {}
         self.review_step = {}
         self.executed_steps = []
+        self.review_flagged_carry = []
+        self.review_temp_folders = []
 
     def setup(self):
         """
@@ -1817,7 +1819,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     # ----------------------------------------------------------- review pauses
 
     REVIEW_SETTINGS_KEY = "AREG/ReviewSteps"
-    CONTINUE_TEXT = "Continue"
+    # It only ever goes forward: going back has a button of its own.
+    CONTINUE_TEXT = "Next step"
 
     def startStep(self, step):
         """Remember the step being launched, so its pause is found when it ends.
@@ -1835,12 +1838,16 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.ReviewSelectAllButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(True))
         self.ui.ReviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
         self.ui.ReviewContinueButton.connect("clicked(bool)", self.onReviewContinue)
-        self.ui.ReviewSkipRestButton.connect("clicked(bool)", self.onReviewSkipRest)
         self.ui.ReviewGoBackButton.connect("clicked(bool)", self.onReviewGoBack)
+        self.ui.ReviewPrevPatientButton.connect("clicked(bool)", self.onReviewPreviousPatient)
+        self.ui.ReviewNextPatientButton.connect("clicked(bool)", self.onReviewNextPatient)
+        self.ui.ReviewFlagButton.connect("clicked(bool)", self.onReviewToggleFlag)
         self.ui.ReviewContinueButton.setVisible(False)
-        self.ui.ReviewSkipRestButton.setVisible(False)
         self.ui.ReviewGoBackButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
+        for name in ("ReviewPrevPatientButton", "ReviewNextPatientButton",
+                     "ReviewPatientLabel", "ReviewFlagButton"):
+            getattr(self.ui, name).setVisible(False)
         self.onReviewEnableToggled(self.ui.ReviewEnableCheckBox.isChecked())
 
     def onReviewEnableToggled(self, enabled):
@@ -1963,8 +1970,11 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         step = self.review_step or {}
         name = step.get("Module", "this step")
         # Output folders are reused between runs: without this the review walks
-        # patients this run never processed.
-        self.review.build(step, expected=self.runPatientIds())
+        # patients this run never processed. Coming back from a rollback, the
+        # only patients worth showing are the ones being redone.
+        expected = self.review_flagged_carry or self.runPatientIds()
+        self.review_flagged_carry = []
+        self.review.build(step, expected=expected)
         if not self.review.total or not self.showReviewItem():
             logger.warning(
                 f"Nothing could be loaded to review after {name}, continuing"
@@ -2013,26 +2023,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         )
         self.ui.ReviewMessageLabel.setVisible(True)
 
-        remaining = self.review.remaining
-        self.ui.ReviewContinueButton.setText(
-            f"Continue - {remaining} more patient(s) here" if remaining
-            else self.CONTINUE_TEXT
-        )
-        # On a large batch, stepping through every patient of every step is the
-        # thing that stops people using the pauses at all. Two or three are
-        # usually enough to tell whether the whole batch went the same way.
-        self.ui.ReviewSkipRestButton.setVisible(remaining > 0)
-        self.ui.ReviewSkipRestButton.setText(
-            f"The rest is fine - skip {remaining} patient(s)"
-        )
-
-        # A result that only reads badly is worth nothing on its own: what the
-        # user needs is the step that caused it.
-        target, _ = self.previousCorrectableStep()
-        self.ui.ReviewGoBackButton.setVisible(target is not None)
-        if target is not None:
-            name = Review.describe(target.get("ReviewId", "")).get("label", "the previous step")
-            self.ui.ReviewGoBackButton.setText(f"Go back and fix: {name}")
+        self.updateReviewButtons()
         logger.info(f"Review - {title} - {item['patient']}{position}")
 
     def runPatientIds(self):
@@ -2083,57 +2074,123 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 return history[i], history[i + 1:here + 1]
         return None, []
 
+    def updateReviewButtons(self):
+        """Show the actions this patient, and this step, actually allow.
+
+        Each button does one thing and says so: moving between patients never
+        advances the run, and going back never hides behind a forward label.
+        """
+        session = self.review
+        total, index = session.total, session.index
+
+        self.ui.ReviewPatientLabel.setVisible(True)
+        self.ui.ReviewPatientLabel.setText(
+            f"<b>{session.currentPatient}</b>"
+            + (f" &nbsp;({index + 1} / {total})" if total > 1 else "")
+        )
+
+        self.ui.ReviewPrevPatientButton.setVisible(total > 1)
+        self.ui.ReviewPrevPatientButton.setEnabled(index > 0)
+        self.ui.ReviewNextPatientButton.setVisible(total > 1)
+        self.ui.ReviewNextPatientButton.setEnabled(index < total - 1)
+
+        # Marking is only worth offering when there is somewhere to go back to.
+        target, _ = self.previousCorrectableStep()
+        self.ui.ReviewFlagButton.setVisible(target is not None)
+        if session.isFlagged():
+            self.ui.ReviewFlagButton.setText("Cancel - this patient is fine")
+        else:
+            self.ui.ReviewFlagButton.setText("Go back and edit this patient")
+
+        self.ui.ReviewContinueButton.setVisible(True)
+        self.ui.ReviewContinueButton.setText(self.CONTINUE_TEXT)
+
+        flagged = session.flaggedPatients()
+        self.ui.ReviewGoBackButton.setVisible(bool(flagged) and target is not None)
+        if flagged and target is not None:
+            name = Review.describe(target.get("ReviewId", "")).get("label", "the previous step")
+            self.ui.ReviewGoBackButton.setText(
+                f"Go back to {name} for {len(flagged)} patient(s)"
+            )
+
+
+    def onReviewPreviousPatient(self):
+        """Show the patient before this one, keeping any edit made here."""
+        if self.review.index > 0:
+            self.review.saveEdits()
+            self.review.index -= 1
+            self.showReviewItem()
+
+    def onReviewNextPatient(self):
+        """Show the next patient of this step, keeping any edit made here."""
+        if self.review.index < self.review.total - 1:
+            self.review.saveEdits()
+            self.review.index += 1
+            self.showReviewItem()
+
+    def onReviewToggleFlag(self):
+        """Mark this patient for rework, or take the mark back."""
+        patient = self.review.currentPatient
+        now = self.review.toggleFlag()
+        logger.info(f"{patient}: {'marked for rework' if now else 'mark removed'}")
+        self.updateReviewButtons()
+
     def onReviewGoBack(self):
-        """Return to the last correctable step, then replay everything since.
+        """Return to the last correctable step, for the patients marked there.
 
         Correcting the landmarks changes nothing on its own - the orientation
         was computed from the old ones. So the steps in between are queued to
-        run again, and the run comes back to this same pause with the new
-        result.
+        run again, narrowed to the marked patients: the rest of the batch keeps
+        the results it already has, and a run of fifty does not start over
+        because one case was wrong.
         """
         target, replay = self.previousCorrectableStep()
         if target is None:
             logger.warning("Nothing correctable behind this step")
             return
 
+        flagged = self.review.flaggedPatients()
+        if not flagged:
+            logger.warning("No patient marked for rework")
+            return
+
         name = Review.describe(target.get("ReviewId", "")).get("label", target.get("Module"))
         logger.info(
-            f"Going back to '{name}'; {len(replay)} step(s) will run again afterwards"
+            f"Going back to '{name}' for {flagged}; "
+            f"{len(replay)} step(s) will run again for them"
         )
+
+        narrowed = []
+        for step in replay:
+            restricted, folders = Review.restrictStepToPatients(step, flagged)
+            self.review_temp_folders.extend(folders)
+            narrowed.append(restricted)
 
         self.review.reset()
         self.resetReviewUi()
 
-        # Everything between the two runs again, ahead of whatever was left.
-        self.list_Processes_Parameters[0:0] = replay
+        # The steps between the two run again, ahead of whatever was left.
+        self.list_Processes_Parameters[0:0] = narrowed
         self.review_step = target
+        self.review_flagged_carry = list(flagged)
         # beginReview guards against a pause cancelled between the callback and
         # the event loop; this one comes from a button, so it is armed here.
         self.review.pending = True
         self.beginReview()
 
-    def onReviewSkipRest(self):
-        """Accept the patients left at this step without looking at each one.
-
-        Whatever the user changed on the one in front of them is still saved:
-        they may well have corrected this patient and only then decided the
-        others were fine.
-        """
-        skipped = self.review.remaining
-        self.review.saveEdits()
-        logger.info(f"{skipped} patient(s) accepted without review at this step")
-
-        self.resetReviewUi()
-        self.review.reset()
-        self.advanceToNextProcess()
-
     def onReviewContinue(self):
-        """Save what changed, then move on to the next patient or step."""
-        self.review.saveEdits()
-        self.review.index += 1
+        """Leave this pause and carry on with the run.
 
-        if self.review.index < self.review.total and self.showReviewItem():
-            return
+        Moving between patients is what the navigation buttons are for, so this
+        one does the single thing its label promises: it ends the pause. What
+        the user changed on the patient in front of them is saved first, and
+        the patients they never opened keep the results they already have.
+        """
+        self.review.saveEdits()
+        seen = self.review.index + 1
+        total = self.review.total
+        if seen < total:
+            logger.info(f"{total - seen} patient(s) accepted without being opened")
 
         self.resetReviewUi()
         self.review.reset()
@@ -2155,14 +2212,27 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """Put the panel back the way it was before the pause."""
         self.ui.ReviewContinueButton.setVisible(False)
         self.ui.ReviewContinueButton.setText(self.CONTINUE_TEXT)
-        self.ui.ReviewSkipRestButton.setVisible(False)
         self.ui.ReviewGoBackButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
+        for name in ("ReviewPrevPatientButton", "ReviewNextPatientButton",
+                     "ReviewPatientLabel", "ReviewFlagButton"):
+            getattr(self.ui, name).setVisible(False)
         self.ui.ReviewMessageLabel.setText("")
+
+    def clearReviewTempFolders(self):
+        """Drop the link farms a rollback made. The scans they point at stay."""
+        import shutil
+        for folder in self.review_temp_folders:
+            try:
+                shutil.rmtree(folder, ignore_errors=True)
+            except Exception as e:
+                logger.warning(f"Could not remove {folder}: {e}")
+        self.review_temp_folders = []
 
     def OnEndProcess(self):
         self.resetReviewUi()
         self.review.reset()
+        self.clearReviewTempFolders()
         self.ui.LabelProgressPatient.setText(f"Patient : 0 / {self.nb_patient}")
         self.ui.LabelProgressExtension.setText(
             f"Extension : {self.nb_extension_did} / {self.nb_extension_launch}"

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1898,7 +1898,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         step = self.review_step or {}
         name = step.get("Module", "this step")
-        self.review.build(step)
+        # Output folders are reused between runs: without this the review walks
+        # patients this run never processed.
+        self.review.build(step, since=getattr(self, "startTime", None))
         if not self.review.total or not self.showReviewItem():
             logger.warning(
                 f"Nothing could be loaded to review after {name}, continuing"

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -43,6 +43,7 @@ from AREG_Method.CBCT import Semi_CBCT, Auto_CBCT, Or_Auto_CBCT
 from AREG_Method.IOSCBCT import Auto_IOSCBCT,Semi_IOSCBCT,Reg_IOSCBCT
 from AREG_Method.Method import Method
 from AREG_Method.Progress import Display
+from AREG_Method import Review
 
 from pathlib import Path
 import textwrap
@@ -350,6 +351,12 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.nb_patient = 0  # number of scans in the input folder
         self.time_log = 0  # time of the last log update
 
+        # Review pauses: which steps the user ticked, and the one on screen
+        self.module_name = ""
+        self.review = Review.ReviewSession()
+        self.review_checkboxes = {}
+        self.review_step = {}
+
     def setup(self):
         """
         Called when the user opens the module the first time and the widget is initiAREGzed.
@@ -475,6 +482,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         self.initRegistrationReference()
         self.HideComputeItems()
+        self.setupReviewUi()
         self.SwitchType()
         
         self.ui.label_11.setVisible(False)
@@ -1023,6 +1031,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.label_CBCTInputType.setVisible(False)
             self.isDCMInput = False
 
+        self.rebuildReviewSteps()
+
     def ClearAllLineEdits(self):
         """Function to clear all the line edits"""
         self.ui.lineEditScanT1LmPath.setText("")
@@ -1517,11 +1527,13 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 logger.error("list_Processes_Parameters is empty after calling ActualMeth.Process()")
                 return
 
+            self.markProcessesForReview()
+
             self.nb_extension_launch = len(self.list_Processes_Parameters)
             self.onProcessStarted()
 
             try:
-                self.module_name = self.list_Processes_Parameters[0]["Module"]
+                self.startStep(self.list_Processes_Parameters[0])
             except Exception:
                 logger.exception("Exception while accessing first process entry")
                 return
@@ -1536,7 +1548,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     None,
                     self.list_Processes_Parameters[0]["Parameter"],
                 )
-                self.module_name = self.list_Processes_Parameters[0]["Module"]
+                self.startStep(self.list_Processes_Parameters[0])
                 self.displayModule = self.list_Processes_Parameters[0]["Display"]
                 self.processObserver = self.process.AddObserver(
                     "ModifiedEvent", self.onProcessUpdate
@@ -1573,7 +1585,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                             None,
                             self.list_Processes_Parameters[0]["Parameter"],
                         )
-                        self.module_name = self.list_Processes_Parameters[0]["Module"]
+                        self.startStep(self.list_Processes_Parameters[0])
                         self.displayModule = self.list_Processes_Parameters[0]["Display"]
                         self.processObserver = self.process.AddObserver(
                             "ModifiedEvent", self.onProcessUpdate
@@ -1594,7 +1606,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     self.run_conda_tool("seg")
                     self.process = slicer.cli.run(
                     self.list_Processes_Parameters[0]["Process"],None,self.list_Processes_Parameters[0]["Parameter"],)
-                    self.module_name = self.list_Processes_Parameters[0]["Module"]
+                    self.startStep(self.list_Processes_Parameters[0])
                     self.displayModule = self.list_Processes_Parameters[0]["Display"]
                     self.processObserver = self.process.AddObserver(
                         "ModifiedEvent", self.onProcessUpdate
@@ -1606,7 +1618,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                         None,
                         self.list_Processes_Parameters[0]["Parameter"],
                     )
-                    self.module_name = self.list_Processes_Parameters[0]["Module"]
+                    self.startStep(self.list_Processes_Parameters[0])
                     self.displayModule = self.list_Processes_Parameters[0]["Display"]
                     self.processObserver = self.process.AddObserver(
                         "ModifiedEvent", self.onProcessUpdate
@@ -1702,34 +1714,265 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             else:
                 logger.info("========= PROCESS COMPLETED SUCCESSFULLY =========")
                 logger.info(self.process.GetOutputText())
-                try:
-                    logger.info(f"Process name: {self.list_Processes_Parameters[0]['Process']}")
-                    if self.list_Processes_Parameters[0]["Module"]=="AREG_IOS":
-                        self.nb_extension_did += 1
-                        self.run_conda_tool("areg")
-                    if self.list_Processes_Parameters[0]["Module"]=="CrownSegmentationcli":
-                        self.run_conda_tool("seg")
-                    if self.list_Processes_Parameters[0]["Module"]=="ALI_IOS":
-                        self.nb_extension_did += 1
-                        self.run_conda_tool("ali")
-                        
-                    self.ui.ButtonCancel.setEnabled(True)
-                    self.process = slicer.cli.run(
-                        self.list_Processes_Parameters[0]["Process"],
-                        None,
-                        self.list_Processes_Parameters[0]["Parameter"],
-                    )
-                    self.module_name = self.list_Processes_Parameters[0]["Module"]
-                    self.displayModule = self.list_Processes_Parameters[0]["Display"]
-                    self.processObserver = self.process.AddObserver(
-                        "ModifiedEvent", self.onProcessUpdate
-                    )
-                    del self.list_Processes_Parameters[0]
-                    # self.displayModule.progress = 0
-                except IndexError:
-                    self.OnEndProcess()
+                if self.enterReviewPause():
+                    return
+                self.advanceToNextProcess()
+
+    def advanceToNextProcess(self):
+        """Launch the next step of the run, or finish if there is none left."""
+        try:
+            logger.info(f"Process name: {self.list_Processes_Parameters[0]['Process']}")
+            # The conda tools run to completion right here rather than through
+            # the CLI observer, so their pause has to be taken on the way back
+            # out - otherwise no IOS step could ever stop the run.
+            if self.list_Processes_Parameters[0]["Module"]=="AREG_IOS":
+                self.nb_extension_did += 1
+                self.run_conda_tool("areg")
+                if self.enterReviewPause():
+                    return
+            if self.list_Processes_Parameters[0]["Module"]=="CrownSegmentationcli":
+                self.run_conda_tool("seg")
+                if self.enterReviewPause():
+                    return
+            if self.list_Processes_Parameters[0]["Module"]=="ALI_IOS":
+                self.nb_extension_did += 1
+                self.run_conda_tool("ali")
+                if self.enterReviewPause():
+                    return
+
+            self.ui.ButtonCancel.setEnabled(True)
+            self.process = slicer.cli.run(
+                self.list_Processes_Parameters[0]["Process"],
+                None,
+                self.list_Processes_Parameters[0]["Parameter"],
+            )
+            self.startStep(self.list_Processes_Parameters[0])
+            self.displayModule = self.list_Processes_Parameters[0]["Display"]
+            self.processObserver = self.process.AddObserver(
+                "ModifiedEvent", self.onProcessUpdate
+            )
+            del self.list_Processes_Parameters[0]
+            # self.displayModule.progress = 0
+        except IndexError:
+            self.OnEndProcess()
+
+    # ----------------------------------------------------------- review pauses
+
+    REVIEW_SETTINGS_KEY = "AREG/ReviewSteps"
+    CONTINUE_TEXT = "Continue"
+
+    def startStep(self, step):
+        """Remember the step being launched, so its pause is found when it ends."""
+        self.module_name = step["Module"]
+        self.review_step = step
+
+    def setupReviewUi(self):
+        """Wire the review section up. Called once, from setup()."""
+        self.ui.ReviewEnableCheckBox.connect("toggled(bool)", self.onReviewEnableToggled)
+        self.ui.ReviewSelectAllButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(True))
+        self.ui.ReviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
+        self.ui.ReviewContinueButton.connect("clicked(bool)", self.onReviewContinue)
+        self.ui.ReviewContinueButton.setVisible(False)
+        self.ui.ReviewMessageLabel.setVisible(False)
+        self.onReviewEnableToggled(self.ui.ReviewEnableCheckBox.isChecked())
+
+    def onReviewEnableToggled(self, enabled):
+        """Grey the list out when pausing is off, rather than hiding it."""
+        for widget in (self.ui.ReviewScrollArea, self.ui.ReviewSelectAllButton,
+                       self.ui.ReviewSelectNoneButton, self.ui.ReviewHelpLabel):
+            widget.setEnabled(enabled)
+
+    def rebuildReviewSteps(self):
+        """Rebuild the checkboxes for the mode now selected.
+
+        Modes do not share their steps - IOS has no CBCT landmarks, MGL swaps
+        the orientation for landmark placement - so the list is built from what
+        the current method says it offers, and what the user ticked before is
+        restored where the same step still exists.
+        """
+        contents = getattr(self.ui, "ReviewScrollContents", None)
+        layout = contents.layout() if contents is not None else None
+        if layout is None:
+            logger.warning("Review step list not found in the UI, no pause offered")
+            return
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+        self.review_checkboxes = {}
+
+        method = getattr(self, "ActualMeth", None)
+        if method is None:
+            return
+        try:
+            steps = method.getReviewSteps(
+                reg_type="MGL" if self.isMGLRegistration() else "Butterfly"
+            )
+        except Exception as e:
+            logger.warning(f"Could not list the reviewable steps: {e}")
+            return
+
+        remembered = self.loadReviewSelection()
+        group = None
+        for step in steps:
+            if step["group"] != group:
+                group = step["group"]
+                header = qt.QLabel(f"<b>{group}</b>")
+                layout.addWidget(header)
+
+            box = qt.QCheckBox(step["label"])
+            if step["kind"] == Review.VIEW:
+                box.setToolTip(f"Look only. {step['hint']}")
+            else:
+                box.setToolTip(f"You can correct this. {step['hint']}")
+                box.setText(step["label"] + "  (editable)")
+            box.setChecked(step["id"] in remembered)
+            box.connect("toggled(bool)", lambda _checked: self.saveReviewSelection())
+            layout.addWidget(box)
+            self.review_checkboxes[step["id"]] = box
+
+        layout.addStretch(1)
+
+    def setAllReviewSteps(self, checked):
+        """Tick or untick every step of the current mode."""
+        for box in self.review_checkboxes.values():
+            box.setChecked(checked)
+
+    def selectedReviewIds(self):
+        """Ids the user ticked, empty when pausing is switched off."""
+        if not self.ui.ReviewEnableCheckBox.isChecked():
+            return set()
+        return {i for i, box in self.review_checkboxes.items() if box.isChecked()}
+
+    def saveReviewSelection(self):
+        """Keep the ticked steps between sessions."""
+        chosen = [i for i, box in self.review_checkboxes.items() if box.isChecked()]
+        qt.QSettings().setValue(self.REVIEW_SETTINGS_KEY, ",".join(sorted(chosen)))
+
+    def loadReviewSelection(self):
+        """Steps ticked the last time, as a set of ids."""
+        stored = qt.QSettings().value(self.REVIEW_SETTINGS_KEY, "")
+        if not stored:
+            return set()
+        if isinstance(stored, (list, tuple)):
+            return set(stored)
+        return {i for i in str(stored).split(",") if i}
+
+    def markProcessesForReview(self):
+        """Flag the steps of this run the user asked to stop at."""
+        chosen = self.selectedReviewIds()
+        if not chosen:
+            return 0
+        marked = 0
+        for step in self.list_Processes_Parameters:
+            if step.get("ReviewId") in chosen:
+                step["ReviewPause"] = True
+                marked += 1
+        logger.info(f"{marked} step(s) will pause for review")
+        return marked
+
+    def enterReviewPause(self):
+        """Whether the step that just finished stops the run.
+
+        The loading itself waits for the event loop: this runs inside a VTK
+        observer callback, where Slicer cannot drain the pipe it captures its
+        own output into, and reading a scan there fills it with no reader left.
+        """
+        step = self.review_step or {}
+        if not step.get("ReviewPause"):
+            return False
+
+        self.review.pending = True
+        qt.QTimer.singleShot(0, self.beginReview)
+        return True
+
+    def beginReview(self):
+        """Load the finished step's result, once the event loop is turning."""
+        if not self.review.pending:
+            return          # cancelled between the callback returning and now
+        self.review.pending = False
+
+        step = self.review_step or {}
+        name = step.get("Module", "this step")
+        self.review.build(step)
+        if not self.review.total or not self.showReviewItem():
+            logger.warning(
+                f"Nothing could be loaded to review after {name}, continuing"
+            )
+            self.review.reset()
+            self.advanceToNextProcess()
+            return
+
+        self.ui.ReviewContinueButton.setVisible(True)
+        self.ui.ButtonCancel.setEnabled(True)
+        logger.info(f"Run paused after {name}")
+
+    def showReviewItem(self):
+        """Show the next patient that can be loaded. False if none can."""
+        while self.review.index < self.review.total:
+            if self.review.loadCurrent():
+                self.showReviewMessage()
+                return True
+            item = self.review.current
+            logger.warning(f"Nothing to load for {item['patient']}, skipping it")
+            self.review.index += 1
+        return False
+
+    def showReviewMessage(self):
+        """Say where the run is and what may be changed, in the module panel."""
+        item = self.review.current
+        step = self.review_step or {}
+        entry = Review.describe(step.get("ReviewId", ""))
+        title = entry.get("label") or step.get("Module", "Result")
+        hint = entry.get("hint", "")
+
+        position = ""
+        if self.review.total > 1:
+            position = f" - patient {self.review.index + 1} of {self.review.total}"
+
+        if item["editable"]:
+            action = "You can move the points"
+        elif item["adjustable"]:
+            action = "You can drag it into place"
+        else:
+            action = "Review only"
+
+        self.ui.ReviewMessageLabel.setText(
+            f"<b>Paused: {title}</b><br/>"
+            f"{item['patient']}{position} &nbsp;·&nbsp; <i>{action}</i><br/>{hint}"
+        )
+        self.ui.ReviewMessageLabel.setVisible(True)
+
+        remaining = self.review.remaining
+        self.ui.ReviewContinueButton.setText(
+            f"Continue - {remaining} more patient(s) here" if remaining
+            else self.CONTINUE_TEXT
+        )
+        logger.info(f"Review - {title} - {item['patient']}{position}")
+
+    def onReviewContinue(self):
+        """Save what changed, then move on to the next patient or step."""
+        self.review.saveEdits()
+        self.review.index += 1
+
+        if self.review.index < self.review.total and self.showReviewItem():
+            return
+
+        self.resetReviewUi()
+        self.review.reset()
+        self.advanceToNextProcess()
+
+    def resetReviewUi(self):
+        """Put the panel back the way it was before the pause."""
+        self.ui.ReviewContinueButton.setVisible(False)
+        self.ui.ReviewContinueButton.setText(self.CONTINUE_TEXT)
+        self.ui.ReviewMessageLabel.setVisible(False)
+        self.ui.ReviewMessageLabel.setText("")
 
     def OnEndProcess(self):
+        self.resetReviewUi()
+        self.review.reset()
         self.ui.LabelProgressPatient.setText(f"Patient : 0 / {self.nb_patient}")
         self.ui.LabelProgressExtension.setText(
             f"Extension : {self.nb_extension_did} / {self.nb_extension_launch}"
@@ -2064,9 +2307,11 @@ qMRMLNodeComboBox:focus {
             self.process.Cancel()
         except Exception as e:
             self.logic.cancel_process()
-            
+
         logger.warning("========= PROCESS CANCELED =========")
 
+        self.resetReviewUi()
+        self.review.reset()
         self.RunningUI(False)
 
     def RunningUI(self, run=False):
@@ -2117,7 +2362,7 @@ qMRMLNodeComboBox:focus {
             for i in range(nbr_run):
                 self.nb_extension_did += 1
                 args = self.list_Processes_Parameters[0]["Parameter"]
-                self.module_name = self.list_Processes_Parameters[0]["Module"]
+                self.startStep(self.list_Processes_Parameters[0])
                 logger.debug(f"Arguments: {args}")
                 conda_exe = self.logic.conda.getCondaExecutable()
                 command = [conda_exe, "run", "-n", self.logic.name_env, "python" ,"-m", f"CrownSegmentationcli"]
@@ -2165,7 +2410,7 @@ qMRMLNodeComboBox:focus {
             args = self.list_Processes_Parameters[0]["Parameter"]
             logger.info(f"Module: {self.list_Processes_Parameters[0]['Module']}")
             logger.debug(f"Arguments: {args}")
-            self.module_name = self.list_Processes_Parameters[0]["Module"]
+            self.startStep(self.list_Processes_Parameters[0])
             
             conda_exe = self.logic.conda.getCondaExecutable()
             command = [conda_exe, "run", "-n", self.logic.name_env, "python" ,"-m", f"AREG_IOS"]
@@ -2203,7 +2448,7 @@ qMRMLNodeComboBox:focus {
 
             del self.list_Processes_Parameters[0]
         elif type == "ali":
-            self.module_name = self.list_Processes_Parameters[0]["Module"]
+            self.startStep(self.list_Processes_Parameters[0])
             args = self.list_Processes_Parameters[0]["Parameter"]
             logger.debug(f"Processing arguments: {args}")
             conda_exe = self.logic.conda.getCondaExecutable()

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1798,7 +1798,9 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.ReviewSelectAllButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(True))
         self.ui.ReviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
         self.ui.ReviewContinueButton.connect("clicked(bool)", self.onReviewContinue)
+        self.ui.ReviewSkipRestButton.connect("clicked(bool)", self.onReviewSkipRest)
         self.ui.ReviewContinueButton.setVisible(False)
+        self.ui.ReviewSkipRestButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
         self.onReviewEnableToggled(self.ui.ReviewEnableCheckBox.isChecked())
 
@@ -1977,7 +1979,29 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             f"Continue - {remaining} more patient(s) here" if remaining
             else self.CONTINUE_TEXT
         )
+        # On a large batch, stepping through every patient of every step is the
+        # thing that stops people using the pauses at all. Two or three are
+        # usually enough to tell whether the whole batch went the same way.
+        self.ui.ReviewSkipRestButton.setVisible(remaining > 0)
+        self.ui.ReviewSkipRestButton.setText(
+            f"The rest is fine - skip {remaining} patient(s)"
+        )
         logger.info(f"Review - {title} - {item['patient']}{position}")
+
+    def onReviewSkipRest(self):
+        """Accept the patients left at this step without looking at each one.
+
+        Whatever the user changed on the one in front of them is still saved:
+        they may well have corrected this patient and only then decided the
+        others were fine.
+        """
+        skipped = self.review.remaining
+        self.review.saveEdits()
+        logger.info(f"{skipped} patient(s) accepted without review at this step")
+
+        self.resetReviewUi()
+        self.review.reset()
+        self.advanceToNextProcess()
 
     def onReviewContinue(self):
         """Save what changed, then move on to the next patient or step."""
@@ -2007,6 +2031,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """Put the panel back the way it was before the pause."""
         self.ui.ReviewContinueButton.setVisible(False)
         self.ui.ReviewContinueButton.setText(self.CONTINUE_TEXT)
+        self.ui.ReviewSkipRestButton.setVisible(False)
         self.ui.ReviewMessageLabel.setVisible(False)
         self.ui.ReviewMessageLabel.setText("")
 

--- a/AREG/AREG.py
+++ b/AREG/AREG.py
@@ -1671,6 +1671,13 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 self.ui.progressBar.setFormat(f"{progress_bar_value:.2f}%")
 
     def onProcessUpdate(self, caller, event):
+        # Observers are never removed, and self.process becomes a plain Thread
+        # while a conda tool runs. So a finished node can wake this up long
+        # after its turn, with self.process pointing at something else - and a
+        # stale Completed event would launch the next step out of order.
+        if self.process is not caller:
+            return
+
         currentTime = time.time() - self.startTime
         if currentTime < 60:
             timer = f"Time : {int(currentTime)}s"
@@ -1708,8 +1715,8 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if caller.GetStatus() & caller.Completed:
             if caller.GetStatus() & caller.ErrorsMask:
                 # error
-                out = self._briefCliOutput(self.process.GetOutputText())
-                err = self._briefCliOutput(self.process.GetErrorText())
+                out = self._briefCliOutput(caller.GetOutputText())
+                err = self._briefCliOutput(caller.GetErrorText())
                 qt.QTimer.singleShot(0, lambda: logger.error(
                     "========= PROCESS COMPLETED WITH ERRORS =========\n"
                     f"{out}\n========= ERROR DETAILS =========\n{err}"
@@ -1723,7 +1730,7 @@ class AREGWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 # Writing a whole CLI's output here fills the pipe with no reader
                 # left and the main thread blocks in write() for ever - a batch of
                 # three patients through ALI is already enough to do it.
-                cli_output = self._briefCliOutput(self.process.GetOutputText())
+                cli_output = self._briefCliOutput(caller.GetOutputText())
                 qt.QTimer.singleShot(0, lambda: logger.info(
                     f"========= PROCESS COMPLETED SUCCESSFULLY =========\n{cli_output}"
                 ))

--- a/AREG/AREG_Method/CBCT.py
+++ b/AREG/AREG_Method/CBCT.py
@@ -1,4 +1,5 @@
 from AREG_Method.Method import Method
+from AREG_Method import Review
 from AREG_Method.Progress import (
     DisplayAREGCBCT,
     DisplayAMASSS,
@@ -254,6 +255,14 @@ class Semi_CBCT(Method):
             "https://github.com/lucanchling/Areg_CBCT/releases/download/TestFiles/SemiAuto.zip",
         )
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "cbct_centered_t2",
+            "cbct_registration",
+            "cbct_segmentation",
+        ])
+
     def Process(self, **kwargs):
         list_struct = self.CheckboxisChecked(kwargs["dic_checkbox"])
         full_reg_struct, full_seg_struct = (
@@ -286,6 +295,8 @@ class Semi_CBCT(Method):
                 "Process": PreOrientProcess,
                 "Parameter": parameter_pre_aso,
                 "Module": "Centering T2",
+                "ReviewId": "cbct_centered_t2",
+                "ReviewFolder": centered_T2,
                 "Display": DisplayASOCBCT(nb_scan),
             }
         ]
@@ -311,6 +322,9 @@ class Semi_CBCT(Method):
                     "Process": AREGProcess,
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
+                    "ReviewId": "cbct_registration",
+                    "ReviewFolder": kwargs["folder_output"],
+                    "ReviewReferenceFolder": kwargs["input_t1_folder"],
                     "Display": DisplayAREGCBCT(nb_scan),
                 }
             )
@@ -362,6 +376,8 @@ class Semi_CBCT(Method):
                     "Process": AMASSSProcess,
                     "Parameter": parameter_amasss_seg_t2,
                     "Module": "AMASSS_CBCT Segmentation of T2",
+                    "ReviewId": "cbct_segmentation",
+                    "ReviewFolder": kwargs["folder_output"],
                     "Display": DisplayAMASSS(
                         nb_scan, len(full_seg_struct), len(full_reg_struct)
                     ),
@@ -411,6 +427,15 @@ class Auto_CBCT(Semi_CBCT):
         return out
 
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "cbct_masks",
+            "cbct_centered_t2",
+            "cbct_registration",
+            "cbct_segmentation",
+        ])
+
     def Process(self, **kwargs):
 
         list_struct = self.CheckboxisChecked(kwargs["dic_checkbox"])
@@ -441,6 +466,8 @@ class Auto_CBCT(Semi_CBCT):
                 "Process": AMASSSProcess,
                 "Parameter": parameter_amasss_mask_t1,
                 "Module": "AMASSS_CBCT - Masks Generation for T1",
+                "ReviewId": "cbct_masks",
+                "ReviewFolder": kwargs["input_t1_folder"],
                 "Display": DisplayAMASSS(
                     nb_scan, len(full_reg_struct)
                 ),
@@ -466,6 +493,8 @@ class Auto_CBCT(Semi_CBCT):
                 "Process": PreOrientProcess,
                 "Parameter": parameter_pre_aso,
                 "Module": "Centering T2",
+                "ReviewId": "cbct_centered_t2",
+                "ReviewFolder": centered_T2,
                 "Display": DisplayASOCBCT(
                     nb_scan
                 ),
@@ -496,6 +525,9 @@ class Auto_CBCT(Semi_CBCT):
                     "Process": AREGProcess,
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
+                    "ReviewId": "cbct_registration",
+                    "ReviewFolder": kwargs["folder_output"],
+                    "ReviewReferenceFolder": kwargs["input_t1_folder"],
                     "Display": DisplayAREGCBCT(
                         nb_scan
                     ),
@@ -554,6 +586,8 @@ class Auto_CBCT(Semi_CBCT):
                     "Process": AMASSSProcess,
                     "Parameter": parameter_amasss_seg_t2,
                     "Module": "AMASSS_CBCT Segmentation for T2",
+                    "ReviewId": "cbct_segmentation",
+                    "ReviewFolder": kwargs["folder_output"],
                     "Display": DisplayAMASSS(
                         nb_scan, len(full_seg_struct), len(full_reg_struct)
                     ),
@@ -669,6 +703,17 @@ class Or_Auto_CBCT(Semi_CBCT):
         lms = lm_str.strip().split()
         return ", ".join(f"'{lm}'" for lm in lms)
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "cbct_landmarks_orientation",
+            "cbct_oriented",
+            "cbct_masks",
+            "cbct_centered_t2",
+            "cbct_registration",
+            "cbct_segmentation",
+        ])
+
     def Process(self, **kwargs):
 
         # ====================== ASO Process ======================
@@ -741,12 +786,17 @@ class Or_Auto_CBCT(Semi_CBCT):
                 "Process": ALIProcess,
                 "Parameter": parameter_ali,
                 "Module": "ALI_CBCT",
+                "ReviewId": "cbct_landmarks_orientation",
+                "ReviewFolder": temp_folder,
+                "ReviewReferenceFolder": temp_folder,
                 "Display": DisplayALICBCT(nb_landmark, nb_scan),
             },
             {
                 "Process": OrientProcess,
                 "Parameter": parameter_semi_aso,
                 "Module": "SEMI_ASO_CBCT",
+                "ReviewId": "cbct_oriented",
+                "ReviewFolder": ASO_T1_Oriented,
                 "Display": DisplayASOCBCT(nb_scan),
             },
         ]
@@ -779,6 +829,8 @@ class Or_Auto_CBCT(Semi_CBCT):
                 "Process": AMASSSProcess,
                 "Parameter": parameter_amasss_mask_t1,
                 "Module": "AMASSS_CBCT - Masks Generation for T1",
+                "ReviewId": "cbct_masks",
+                "ReviewFolder": ASO_T1_Oriented,
                 "Display": DisplayAMASSS(nb_scan, len(full_reg_struct)),
             }
         ]
@@ -800,6 +852,8 @@ class Or_Auto_CBCT(Semi_CBCT):
                 "Process": PreOrientProcess,
                 "Parameter": parameter_pre_aso,
                 "Module": "Centering T2",
+                "ReviewId": "cbct_centered_t2",
+                "ReviewFolder": centered_T2,
                 "Display": DisplayASOCBCT(nb_scan),
             }
         )
@@ -828,6 +882,9 @@ class Or_Auto_CBCT(Semi_CBCT):
                     "Process": AREGProcess,
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
+                    "ReviewId": "cbct_registration",
+                    "ReviewFolder": kwargs["folder_output"],
+                    "ReviewReferenceFolder": ASO_T1_Oriented,
                     "Display": DisplayAREGCBCT(nb_scan),
                 }
             )
@@ -882,6 +939,8 @@ class Or_Auto_CBCT(Semi_CBCT):
                     "Process": AMASSSProcess,
                     "Parameter": parameter_amasss_seg_t2,
                     "Module": "AMASSS_CBCT Segmentation for T2",
+                    "ReviewId": "cbct_segmentation",
+                    "ReviewFolder": kwargs["folder_output"],
                     "Display": DisplayAMASSS(
                         nb_scan, len(full_seg_struct), len(full_reg_struct)
                     ),

--- a/AREG/AREG_Method/CBCT.py
+++ b/AREG/AREG_Method/CBCT.py
@@ -323,7 +323,14 @@ class Semi_CBCT(Method):
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
                     "ReviewId": "cbct_registration",
-                    "ReviewFolder": kwargs["folder_output"],
+                    # Scoped to the structure this run of AREG just wrote.
+                    # The whole output folder accumulates every structure, so
+                    # the mandible pause showed the cranial base and maxilla
+                    # too - and the displacement the user drags would be folded
+                    # into whichever matrix turned up first, not this one's.
+                    "ReviewFolder": os.path.join(
+                        kwargs["folder_output"], full_reg_struct[i]
+                    ),
                     "ReviewReferenceFolder": kwargs["input_t1_folder"],
                     "Display": DisplayAREGCBCT(nb_scan),
                 }
@@ -526,7 +533,14 @@ class Auto_CBCT(Semi_CBCT):
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
                     "ReviewId": "cbct_registration",
-                    "ReviewFolder": kwargs["folder_output"],
+                    # Scoped to the structure this run of AREG just wrote.
+                    # The whole output folder accumulates every structure, so
+                    # the mandible pause showed the cranial base and maxilla
+                    # too - and the displacement the user drags would be folded
+                    # into whichever matrix turned up first, not this one's.
+                    "ReviewFolder": os.path.join(
+                        kwargs["folder_output"], full_reg_struct[i]
+                    ),
                     "ReviewReferenceFolder": kwargs["input_t1_folder"],
                     "Display": DisplayAREGCBCT(
                         nb_scan
@@ -883,7 +897,14 @@ class Or_Auto_CBCT(Semi_CBCT):
                     "Parameter": parameter_areg_cbct,
                     "Module": "AREG_CBCT for {}".format(full_reg_struct[i]),
                     "ReviewId": "cbct_registration",
-                    "ReviewFolder": kwargs["folder_output"],
+                    # Scoped to the structure this run of AREG just wrote.
+                    # The whole output folder accumulates every structure, so
+                    # the mandible pause showed the cranial base and maxilla
+                    # too - and the displacement the user drags would be folded
+                    # into whichever matrix turned up first, not this one's.
+                    "ReviewFolder": os.path.join(
+                        kwargs["folder_output"], full_reg_struct[i]
+                    ),
                     "ReviewReferenceFolder": ASO_T1_Oriented,
                     "Display": DisplayAREGCBCT(nb_scan),
                 }

--- a/AREG/AREG_Method/IOS.py
+++ b/AREG/AREG_Method/IOS.py
@@ -1,4 +1,5 @@
 from AREG_Method.Method import Method
+from AREG_Method import Review
 from AREG_Method.Progress import DisplayAREGIOS, DisplayCrownSeg, DisplayASOIOS, DisplayALIIOS
 import slicer
 import webbrowser
@@ -77,6 +78,9 @@ def MGLProcess(method, numberscan, areg_mode, **kwargs):
                 "Process": slicer.modules.ali_ios,
                 "Parameter": parameter_ali,
                 "Module": f"ALI_IOS {time}",
+                "ReviewId": f"ios_landmarks_{time.lower()}",
+                "ReviewFolder": landmarks_folder,
+                "ReviewReferenceFolder": kwargs[f"input_{time.lower()}_folder"],
                 "Display": DisplayALIIOS(13, numberscan),
             })
 
@@ -99,6 +103,9 @@ def MGLProcess(method, numberscan, areg_mode, **kwargs):
         "Process": slicer.modules.areg_ios,
         "Parameter": parameter_reg,
         "Module": "AREG_IOS",
+        "ReviewId": "ios_registration",
+        "ReviewFolder": kwargs["folder_output"],
+        "ReviewReferenceFolder": kwargs["input_t1_folder"],
         "Display": DisplayAREGIOS(numberscan, kwargs["logPath"]),
     })
 
@@ -560,10 +567,29 @@ class Auto_IOS(Method):
             "Process": SegProcess,
             "Parameter": parameter,
             "Module": f"CrownSegmentationcli {timepoint}",
+            "ReviewId": "ios_segmented",
+            "ReviewFolder": parameter["out"],
             "Display": DisplayCrownSeg(number, kwargs["logPath"], f"{timepoint} Scan"),
         } for timepoint, number, parameter in to_segment]
 
         return processes, path_tmp, path_seg_T1, path_seg_T2
+
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        if kwargs.get("reg_type") == "MGL":
+            # MGL places landmarks instead of orienting the palate
+            return Review.stepsFor([
+                "ios_segmented",
+                "ios_landmarks_t1",
+                "ios_landmarks_t2",
+                "ios_registration",
+            ])
+        return Review.stepsFor([
+            "ios_segmented",
+            "ios_oriented_t1",
+            "ios_oriented_t2",
+            "ios_registration",
+        ])
 
     def Process(self, **kwargs):
 
@@ -641,18 +667,25 @@ class Auto_IOS(Method):
                 "Process": PreOrientProcess,
                 "Parameter": parameter_pre_aso_T1,
                 "Module": "PRE_ASO_IOS T1",
+                "ReviewId": "ios_oriented_t1",
+                "ReviewFolder": path_or_T1,
                 "Display": DisplayASOIOS(numberscan, kwargs["logPath"], "T1 Patient"),
             },
             {
                 "Process": PreOrientProcess,
                 "Parameter": parameter_pre_aso_T2,
                 "Module": "PRE_ASO_IOS T2",
+                "ReviewId": "ios_oriented_t2",
+                "ReviewFolder": path_or_T2,
                 "Display": DisplayASOIOS(numberscan, kwargs["logPath"], "T2 Patient"),
             },
             {
                 "Process": RegProcess,
                 "Parameter": parameter_reg,
                 "Module": "AREG_IOS",
+                "ReviewId": "ios_registration",
+                "ReviewFolder": kwargs["folder_output"],
+                "ReviewReferenceFolder": path_or_T1,
                 "Display": DisplayAREGIOS(numberscan, kwargs["logPath"]),
             },
         ]
@@ -697,6 +730,16 @@ class Semi_IOS(Auto_IOS):
 
         return out
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        if kwargs.get("reg_type") == "MGL":
+            return Review.stepsFor([
+                "ios_landmarks_t1",
+                "ios_landmarks_t2",
+                "ios_registration",
+            ])
+        return Review.stepsFor(["ios_registration"])
+
     def Process(self, **kwargs):
 
         numberscan = self.NumberScan(
@@ -735,6 +778,9 @@ class Semi_IOS(Auto_IOS):
                 "Process": RegProcess,
                 "Parameter": parameter_reg,
                 "Module": "AREG_IOS",
+                "ReviewId": "ios_registration",
+                "ReviewFolder": kwargs["folder_output"],
+                "ReviewReferenceFolder": kwargs["input_t1_folder"],
                 "Display": DisplayAREGIOS(numberscan, kwargs["logPath"]),
             }
         ]

--- a/AREG/AREG_Method/IOSCBCT.py
+++ b/AREG/AREG_Method/IOSCBCT.py
@@ -1,4 +1,5 @@
 from AREG_Method.Method import Method
+from AREG_Method import Review
 from AREG_Method.Progress import DisplayAREGIOSCBCT, DisplayALICBCT,DisplayASOIOS,DisplayASOCBCT,DisplayCrownSeg,DisplayALIIOS
 import webbrowser
 import os
@@ -232,6 +233,15 @@ class Semi_IOSCBCT(IOSCBCT):
                             writer.writerow([self.windows_to_linux_path(norm_file_path)])
         return csv_file
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "ios_segmented",
+            "cbct_landmarks_registration",
+            "ios_landmarks",
+            "ioscbct_registration",
+        ])
+
     def Process(self, **kwargs):
 
         nb_scan = self.NumberScan(kwargs["input_t1_folder"],kwargs["input_t2_folder"])
@@ -276,6 +286,8 @@ class Semi_IOSCBCT(IOSCBCT):
                 "Process": SegProcess_IOS,
                 "Parameter": parameter_seg,
                 "Module": "CrownSegmentationcli",
+                "ReviewId": "ios_segmented",
+                "ReviewFolder": seg_ios_folder_path,
                 "Display": DisplayCrownSeg(
                     nb_scan, kwargs["logPath"],"Segmentation Patient"
                 ),
@@ -306,6 +318,9 @@ class Semi_IOSCBCT(IOSCBCT):
                 "Process": ALIProcess_CBCT,
                 "Parameter": parameter_ali_cbct,
                 "Module": "ALI_CBCT",
+                "ReviewId": "cbct_landmarks_registration",
+                "ReviewFolder": cbct_landmarks_folder_path,
+                "ReviewReferenceFolder": kwargs["input_t2_folder"],
                 "Display": DisplayALICBCT(
                     12, nb_scan
                 ),
@@ -338,6 +353,9 @@ class Semi_IOSCBCT(IOSCBCT):
                 "Process": ALIProcess_IOS,
                 "Parameter": parameter_ali_ios,
                 "Module": "ALI_IOS",
+                "ReviewId": "ios_landmarks",
+                "ReviewFolder": ios_landmarks_folder_path,
+                "ReviewReferenceFolder": seg_ios_folder_path,
                 "Display": DisplayALIIOS(
                     12, nb_scan
                 ),
@@ -362,6 +380,9 @@ class Semi_IOSCBCT(IOSCBCT):
                 "Process": AREGProcess,
                 "Parameter": parameter_areg_IOSCBCT,
                 "Module": "AREG IOSCBCT",
+                "ReviewId": "ioscbct_registration",
+                "ReviewFolder": registered_ios_folder_path,
+                "ReviewReferenceFolder": kwargs["input_t2_folder"],
                 "Display": DisplayAREGIOSCBCT(0),
             }
         )
@@ -413,6 +434,12 @@ class Reg_IOSCBCT(IOSCBCT):
     def getReferenceList(self):
         return None
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "ioscbct_registration",
+        ])
+
     def Process(self, **kwargs):
 
         parameter_areg_IOSCBCT = {
@@ -431,6 +458,8 @@ class Reg_IOSCBCT(IOSCBCT):
                 "Process": AREGProcess,
                 "Parameter": parameter_areg_IOSCBCT,
                 "Module": "AREG IOSCBCT",
+                "ReviewId": "ioscbct_registration",
+                "ReviewFolder": kwargs["folder_output"],
                 "Display": DisplayAREGIOSCBCT(0),
             }
         ]
@@ -560,6 +589,19 @@ class Auto_IOSCBCT(IOSCBCT):
                             writer.writerow([self.windows_to_linux_path(norm_file_path)])
         return csv_file
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them."""
+        return Review.stepsFor([
+            "cbct_resampled",
+            "cbct_landmarks_orientation",
+            "cbct_oriented",
+            "ios_segmented",
+            "ios_oriented",
+            "cbct_landmarks_registration",
+            "ios_landmarks",
+            "ioscbct_registration",
+        ])
+
     def Process(self, **kwargs):
 
         nb_scan = self.NumberScan(kwargs["input_t1_folder"],kwargs["input_t2_folder"])
@@ -590,6 +632,8 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": ResampleProcess_CBCT,
                 "Parameter": parameter_resample_cbct,
                 "Module": "CBCT Resampling",
+                "ReviewId": "cbct_resampled",
+                "ReviewFolder": resample_folder_path,
                 "Display": DisplayASOCBCT(
                     nb_scan
                 ),
@@ -657,6 +701,9 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": ALIProcess_CBCT,
                 "Parameter": parameter_ali_cbct,
                 "Module": "ALI_CBCT",
+                "ReviewId": "cbct_landmarks_orientation",
+                "ReviewFolder": pre_aso_cbct_folder_path,
+                "ReviewReferenceFolder": pre_aso_cbct_folder_path,
                 "Display": DisplayALICBCT(
                     nb_landmark, nb_scan
                 ),
@@ -665,6 +712,8 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": OrientProcess_CBCT,
                 "Parameter": parameter_semi_aso_cbct,
                 "Module": "SEMI_ASO_CBCT",
+                "ReviewId": "cbct_oriented",
+                "ReviewFolder": oriented_cbct_folder_path,
                 "Display": DisplayASOCBCT(
                     nb_scan
                 ),
@@ -732,6 +781,8 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": SegProcess_IOS,
                 "Parameter": parameter_seg,
                 "Module": "CrownSegmentationcli",
+                "ReviewId": "ios_segmented",
+                "ReviewFolder": seg_ios_folder_path,
                 "Display": DisplayCrownSeg(
                     nb_scan, kwargs["logPath"],"Segmentation Patient"
                 ),
@@ -740,6 +791,8 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": PreOrientProcess_IOS,
                 "Parameter": parameter_pre_aso_ios,
                 "Module": "PRE_ASO_IOS",
+                "ReviewId": "ios_oriented",
+                "ReviewFolder": pre_aso_ios_folder_path,
                 "Display": DisplayASOIOS(
                     nb_scan, kwargs["logPath"],"Orient IOS Patient"
                 ),
@@ -769,6 +822,9 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": ALIProcess_CBCT,
                 "Parameter": parameter_ali_cbct_2,
                 "Module": "ALI_CBCT",
+                "ReviewId": "cbct_landmarks_registration",
+                "ReviewFolder": cbct_landmarks_folder_path,
+                "ReviewReferenceFolder": oriented_cbct_folder_path,
                 "Display": DisplayALICBCT(
                     12, nb_scan
                 ),
@@ -801,6 +857,9 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": ALIProcess_IOS,
                 "Parameter": parameter_ali_ios,
                 "Module": "ALI_IOS",
+                "ReviewId": "ios_landmarks",
+                "ReviewFolder": ios_landmarks_folder_path,
+                "ReviewReferenceFolder": pre_aso_ios_folder_path,
                 "Display": DisplayALIIOS(
                     12, nb_scan
                 ),
@@ -825,6 +884,9 @@ class Auto_IOSCBCT(IOSCBCT):
                 "Process": AREGProcess,
                 "Parameter": parameter_areg_IOSCBCT,
                 "Module": "AREG IOSCBCT",
+                "ReviewId": "ioscbct_registration",
+                "ReviewFolder": registered_ios_folder_path,
+                "ReviewReferenceFolder": oriented_cbct_folder_path,
                 "Display": DisplayAREGIOSCBCT(0),
             }
         )

--- a/AREG/AREG_Method/Method.py
+++ b/AREG/AREG_Method/Method.py
@@ -168,6 +168,18 @@ class Method(ABC):
         """
         pass
 
+    def getReviewSteps(self, **kwargs) -> list:
+        """Pauses this mode can offer, in the order the run reaches them.
+
+        Declared without running Process(): the widget needs the list to build
+        its checkboxes long before anything is computed, and Process() creates
+        folders on the way.
+
+        Returns:
+            list: catalogue entries, each carrying its id
+        """
+        return []
+
     def getcheckbox(self):
         return self.diccheckbox
 

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -122,7 +122,7 @@ class ReviewSession:
 
         # Landmarks mean nothing without the scan they were placed on, and a
         # registration can only be judged against what it was registered to.
-        references = self._index(step.get("ReviewReferenceFolder"), VOLUME_EXT + MODEL_EXT)
+        references = self._indexAll(step.get("ReviewReferenceFolder"), VOLUME_EXT + MODEL_EXT)
 
         # An adjusted registration is only worth saving if its matrix can be
         # updated with it: what comes after follows the matrix, not the voxels.
@@ -141,13 +141,13 @@ class ReviewSession:
                 logger.warning(
                     f"No matrix for {patient}: its registration can be looked at, not moved"
                 )
-            reference = references.get(patient) or self._matchAcrossNaming(
+            found = references.get(patient) or self._matchAcrossNaming(
                 patient, references
             )
             queue.append({
                 "patient": patient,
                 "files": by_patient[patient],
-                "reference": reference,
+                "references": list(found or []),
                 "kind": kind,
                 "editable": kind == LANDMARKS,
                 "adjustable": adjustable,
@@ -196,12 +196,26 @@ class ReviewSession:
     def _index(folder, extensions):
         """First file of each patient in a folder, by patient id."""
         found = {}
+        for patient, paths in ReviewSession._indexAll(folder, extensions).items():
+            found[patient] = paths[0]
+        return found
+
+    @staticmethod
+    def _indexAll(folder, extensions):
+        """Every file of each patient in a folder, by patient id.
+
+        An IOS is two files, one arch each, and keeping only the first left the
+        upper arch off the screen while its landmarks were shown on it.
+        """
+        found = {}
         if not folder or not os.path.isdir(folder):
             return found
         for root, _, files in os.walk(folder):
             for name in sorted(files):
                 if name.endswith(extensions):
-                    found.setdefault(patientIdFromFileName(name), os.path.join(root, name))
+                    found.setdefault(patientIdFromFileName(name), []).append(
+                        os.path.join(root, name)
+                    )
         return found
 
     # ---------------------------------------------------------------- loading
@@ -214,11 +228,12 @@ class ReviewSession:
 
         self.clearNodes()
         loaded = False
-        reference = None
 
-        if item.get("reference"):
-            reference = self._load(item["reference"])
-            if reference is not None:
+        loaded_references = []
+        for path in item.get("references", []):
+            node = self._load(path)
+            if node is not None:
+                loaded_references.append(node)
                 loaded = True
 
         moving = None
@@ -230,6 +245,13 @@ class ReviewSession:
 
         if not loaded:
             return False
+
+        # A volume is what the slice views can show behind everything else; an
+        # IOS reference is a pair of surfaces and has no such role.
+        reference = next(
+            (n for n in loaded_references if n.IsA("vtkMRMLScalarVolumeNode")),
+            loaded_references[0] if loaded_references else None,
+        )
 
         if item["adjustable"] and moving is not None:
             self._setUpAdjustment(item, reference, moving)
@@ -327,9 +349,11 @@ class ReviewSession:
         manager = slicer.app.layoutManager()
         if manager is None:
             return
-        paths = list(item["files"]) + ([item["reference"]] if item.get("reference") else [])
-        surfaces_only = paths and all(p.endswith(MODEL_EXT) for p in paths)
-        if surfaces_only:
+        paths = list(item["files"]) + list(item.get("references", []))
+        # Landmarks sitting on a pair of surfaces belong in the 3D view: the
+        # slice views have no volume to draw them against.
+        no_volume = paths and not any(p.endswith(VOLUME_EXT) for p in paths)
+        if no_volume:
             manager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
             widget = manager.threeDWidget(0)
             if widget:

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -751,20 +751,29 @@ def restrictStepToPatients(step, patients, tempdir_factory=None):
 
         linked = make_temp()
         kept = 0
-        for name in sorted(os.listdir(folder)):
-            source = os.path.join(folder, name)
-            if not os.path.isfile(source):
-                continue
-            if ReviewSession._normalisedId(patientIdFromFileName(name)) not in wanted:
-                continue
-            try:
-                os.symlink(source, os.path.join(linked, name))
-                kept += 1
-            except OSError as e:
-                # A filesystem without links is no reason to lose the replay.
-                logger.warning(f"Could not link {name}, copying instead: {e}")
-                shutil.copy(source, os.path.join(linked, name))
-                kept += 1
+        # Walked, and the tree kept: AREG writes its registered scans to
+        # <Region>/<patient>_OutReg/, and AMASSS walks sub-directories to find
+        # them. A flat listing of that folder sees only the segmentations left
+        # at the top from an earlier pass - which AMASSS then skips as its own
+        # output, leaving it with nothing to segment.
+        for root, _, names in os.walk(folder):
+            for name in sorted(names):
+                source = os.path.join(root, name)
+                if not os.path.isfile(source):
+                    continue
+                if ReviewSession._normalisedId(patientIdFromFileName(name)) not in wanted:
+                    continue
+                relative = os.path.relpath(source, folder)
+                target = os.path.join(linked, relative)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                try:
+                    os.symlink(source, target)
+                    kept += 1
+                except OSError as e:
+                    # A filesystem without links is no reason to lose the replay.
+                    logger.warning(f"Could not link {relative}, copying instead: {e}")
+                    shutil.copy(source, target)
+                    kept += 1
 
         if kept == 0:
             logger.warning(

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -8,6 +8,7 @@ interface.
 
 import logging
 import os
+import re
 
 import slicer
 import vtk
@@ -127,28 +128,69 @@ class ReviewSession:
         # updated with it: what comes after follows the matrix, not the voxels.
         matrices = self._index(step.get("ReviewMatrixFolder") or folder, (".tfm",))
 
+        def matrixFor(patient):
+            return matrices.get(patient) or self._matchAcrossNaming(patient, matrices)
+
         queue = []
         for patient in sorted(by_patient):
             if kind == LANDMARKS and patient not in references:
                 logger.warning(f"No scan found for {patient}, its landmarks lose their context")
-            adjustable = kind == REGISTRATION and patient in matrices
+            matrix = matrixFor(patient)
+            adjustable = kind == REGISTRATION and matrix is not None
             if kind == REGISTRATION and not adjustable:
                 logger.warning(
                     f"No matrix for {patient}: its registration can be looked at, not moved"
                 )
+            reference = references.get(patient) or self._matchAcrossNaming(
+                patient, references
+            )
             queue.append({
                 "patient": patient,
                 "files": by_patient[patient],
-                "reference": references.get(patient),
+                "reference": reference,
                 "kind": kind,
                 "editable": kind == LANDMARKS,
                 "adjustable": adjustable,
-                "matrix": matrices.get(patient),
+                "matrix": matrix,
             })
 
         self.queue = queue
         self.index = 0
         return queue
+
+    @staticmethod
+    def _normalisedId(patient_id):
+        """The id AREG_IOSCBCT reduces a patient to when it pairs the modalities.
+
+        Underscores go, then leading zeros, so P_0001, P001 and P1 all land on
+        the same patient.
+        """
+        compact = (patient_id or "").replace("_", "")
+        match = re.match(r"([A-Za-z]*)([0-9]*)", compact)
+        if not match:
+            return compact
+        letters, digits = match.group(1), match.group(2)
+        if digits:
+            digits = str(int(digits))
+        return letters + digits
+
+    @classmethod
+    def _matchAcrossNaming(cls, patient, index):
+        """Find this patient's file when the two sides name it differently.
+
+        A CBCT keeps the name its dataset gave it while the registered IOS
+        carries the id AREG_IOSCBCT normalised, so P1_T2_Reg_U.vtk and
+        P_0001_T2_Or.nii.gz never match as strings even though they are the
+        same patient - and the review would show the IOS alone, with nothing
+        to judge it against.
+        """
+        target = cls._normalisedId(patient)
+        if not target:
+            return None
+        for other, path in index.items():
+            if cls._normalisedId(other) == target:
+                return path
+        return None
 
     @staticmethod
     def _index(folder, extensions):

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -9,6 +9,7 @@ interface.
 import logging
 import os
 import re
+import shutil
 
 import slicer
 import vtk
@@ -54,6 +55,7 @@ class ReviewSession:
         self.index = 0
         self.pending = False
         self.step = {}
+        self.flagged = set()
 
     def clearNodes(self):
         """Take the previous patient's nodes back out of the scene."""
@@ -81,6 +83,31 @@ class ReviewSession:
     @property
     def remaining(self):
         return max(0, len(self.queue) - (self.index + 1))
+
+    @property
+    def currentPatient(self):
+        item = self.current
+        return item["patient"] if item else None
+
+    def isFlagged(self, patient=None):
+        """Whether this patient is marked for rework."""
+        patient = patient or self.currentPatient
+        return patient in self.flagged
+
+    def toggleFlag(self, patient=None):
+        """Mark or unmark a patient for rework, and say which it now is."""
+        patient = patient or self.currentPatient
+        if patient is None:
+            return False
+        if patient in self.flagged:
+            self.flagged.discard(patient)
+        else:
+            self.flagged.add(patient)
+        return patient in self.flagged
+
+    def flaggedPatients(self):
+        """The patients marked for rework, in the order they were queued."""
+        return [i["patient"] for i in self.queue if i["patient"] in self.flagged]
 
     # --------------------------------------------------------------- building
 
@@ -172,6 +199,7 @@ class ReviewSession:
 
         self.queue = queue
         self.index = 0
+        self.flagged = set()
         return queue
 
     @staticmethod
@@ -670,3 +698,87 @@ def stepsFor(ids) -> list:
             continue
         steps.append(dict(entry, id=review_id))
     return steps
+
+
+# ---------------------------------------------------------------------------
+# Replaying a step for a few patients rather than all of them.
+#
+# Every step reads a folder, so restricting it means handing it a folder that
+# holds only the patients wanted. The files are linked, never copied: a CBCT is
+# 200 MB and a run can hold fifty of them. Their names are kept, because the
+# tools derive their output names from the input ones.
+# ---------------------------------------------------------------------------
+
+# Which parameter of a step names the folder it reads.
+INPUT_KEYS = (
+    "input",              # ALI, PRE_ASO, SEMI_ASO, Centering
+    "inputVolume",        # AMASSS
+    "t1_folder", "t2_folder",        # AREG_CBCT
+    "T1", "T2",                      # AREG_IOS
+    "IOS_folder", "CBCT_folder",     # AREG IOSCBCT
+    "input_folder_CBCT",             # resampling
+)
+
+
+def restrictStepToPatients(step, patients, tempdir_factory=None):
+    """A copy of this step that only reads the patients given.
+
+    Args:
+        step: the step dictionary to narrow
+        patients: patient ids to keep
+        tempdir_factory: callable returning a fresh empty directory, so a
+            caller can control where the links go
+
+    Returns:
+        tuple: (narrowed step, folders created). The step is returned unchanged
+            when nothing can be narrowed, which is the safe outcome: replaying
+            every patient wastes time, replaying none loses work.
+    """
+    wanted = {ReviewSession._normalisedId(p) for p in patients}
+    if not wanted:
+        return step, []
+
+    make_temp = tempdir_factory or slicer.util.tempDirectory
+    narrowed = dict(step)
+    parameters = dict(step.get("Parameter") or {})
+    created = []
+    changed = False
+
+    for key in INPUT_KEYS:
+        folder = parameters.get(key)
+        if not isinstance(folder, str) or not os.path.isdir(folder):
+            continue
+
+        linked = make_temp()
+        kept = 0
+        for name in sorted(os.listdir(folder)):
+            source = os.path.join(folder, name)
+            if not os.path.isfile(source):
+                continue
+            if ReviewSession._normalisedId(patientIdFromFileName(name)) not in wanted:
+                continue
+            try:
+                os.symlink(source, os.path.join(linked, name))
+                kept += 1
+            except OSError as e:
+                # A filesystem without links is no reason to lose the replay.
+                logger.warning(f"Could not link {name}, copying instead: {e}")
+                shutil.copy(source, os.path.join(linked, name))
+                kept += 1
+
+        if kept == 0:
+            logger.warning(
+                f"None of {sorted(patients)} found in {folder}; leaving '{key}' as it was"
+            )
+            continue
+
+        parameters[key] = linked
+        created.append(linked)
+        changed = True
+        logger.info(f"'{key}' narrowed to {kept} file(s) for {sorted(patients)}")
+
+    if not changed:
+        return step, []
+
+    narrowed["Parameter"] = parameters
+    return narrowed, created

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -174,6 +174,11 @@ class ReviewSession:
 
         A missing or unreadable timestamp counts as recent: leaving a file out
         of the review is worse than showing one extra.
+
+        This rests on the pipeline copying with shutil.copy, which stamps the
+        copy with the current time. shutil.copy2 keeps the original date, and
+        an already-segmented scan copied that way would silently vanish from
+        the review.
         """
         try:
             return os.path.getmtime(path) >= since

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -84,11 +84,15 @@ class ReviewSession:
 
     # --------------------------------------------------------------- building
 
-    def build(self, step: dict) -> list:
+    def build(self, step: dict, since=None) -> list:
         """One review item per patient for the step that just finished.
 
         Args:
             step: the finished step's dictionary, carrying its Review* keys
+            since: only review files written after this timestamp. Output
+                folders get reused between runs, and without this the review
+                walks patients the run never touched - "patient 1 of 5" on a
+                batch of two.
 
         Returns:
             list: the items, which is also kept as this session's queue
@@ -113,12 +117,18 @@ class ReviewSession:
             wanted = VOLUME_EXT + MODEL_EXT
 
         by_patient = {}
+        skipped = 0
         for root, _, files in os.walk(folder):
             for name in sorted(files):
-                if name.endswith(wanted):
-                    by_patient.setdefault(patientIdFromFileName(name), []).append(
-                        os.path.join(root, name)
-                    )
+                if not name.endswith(wanted):
+                    continue
+                path = os.path.join(root, name)
+                if since is not None and not self._writtenSince(path, since):
+                    skipped += 1
+                    continue
+                by_patient.setdefault(patientIdFromFileName(name), []).append(path)
+        if skipped:
+            logger.info(f"{skipped} file(s) from an earlier run left out of the review")
 
         # Landmarks mean nothing without the scan they were placed on, and a
         # registration can only be judged against what it was registered to.
@@ -159,6 +169,18 @@ class ReviewSession:
         return queue
 
     @staticmethod
+    def _writtenSince(path, since):
+        """Whether this run produced the file, rather than an earlier one.
+
+        A missing or unreadable timestamp counts as recent: leaving a file out
+        of the review is worse than showing one extra.
+        """
+        try:
+            return os.path.getmtime(path) >= since
+        except OSError:
+            return True
+
+    @staticmethod
     def _normalisedId(patient_id):
         """The id AREG_IOSCBCT reduces a patient to when it pairs the modalities.
 
@@ -187,10 +209,19 @@ class ReviewSession:
         target = cls._normalisedId(patient)
         if not target:
             return None
-        for other, path in index.items():
-            if cls._normalisedId(other) == target:
-                return path
-        return None
+        matches = [path for other, path in index.items()
+                   if cls._normalisedId(other) == target]
+        if not matches:
+            return None
+        if len(matches) > 1:
+            # Two patients whose ids collide once normalised. Which one belongs
+            # to this scan is not recoverable here, so say so rather than pick
+            # one quietly and show the wrong anatomy underneath.
+            logger.warning(
+                f"{patient}: several candidates match once the id is normalised "
+                f"({[os.path.basename(str(m)) for m in matches]}), taking the first"
+            )
+        return matches[0]
 
     @staticmethod
     def _index(folder, extensions):

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -1,0 +1,581 @@
+"""Pausing a run so a clinician can look at a step's result, and fix it.
+
+A step declares what it produced and whether the user may change it; this
+module turns that into nodes on screen, and writes back only what actually
+moved. The widget owns the buttons and the wording, nothing here touches the
+interface.
+"""
+
+import logging
+import os
+
+import slicer
+import vtk
+
+logger = logging.getLogger(__name__)
+
+VOLUME_EXT = (".nrrd", ".nii.gz", ".nii", ".nrrd.gz", ".gipl.gz", ".gipl")
+MODEL_EXT = (".vtk", ".vtp", ".stl")
+
+# What a step lets the user do with its result.
+VIEW = "view"                # look only
+LANDMARKS = "landmarks"      # drag the points, saved back to their file
+REGISTRATION = "registration"  # drag the scan, folded into its matrix
+
+
+def patientIdFromFileName(basename: str) -> str:
+    """Patient id shared by a scan, its landmarks and its matrix.
+
+    Every module of the pipeline appends its own marker to the scan name, so
+    the id is what is left once those are stripped. The order matters: the
+    longest markers have to go first or a shorter one cuts inside them.
+    """
+    for token in ["_SegOr", "_Scan", "_scan", "_Or", "_OR", "_MAND", "_MD",
+                  "_MAX", "_MX", "_CB", "_lm", "_Pred", "_T1", "_T2", "_Cl",
+                  "_Center", "_left", "_Left", "_right", "_Right", "_U", "_L",
+                  "."]:
+        basename = basename.split(token)[0]
+    return basename
+
+
+class ReviewSession:
+    """The patients waiting to be reviewed for one finished step."""
+
+    def __init__(self):
+        self.reset()
+
+    # ------------------------------------------------------------------ state
+
+    def reset(self):
+        """Forget the review in progress, scene included."""
+        self.clearNodes()
+        self.queue = []
+        self.index = 0
+        self.pending = False
+        self.step = {}
+
+    def clearNodes(self):
+        """Take the previous patient's nodes back out of the scene."""
+        for node in getattr(self, "nodes", []):
+            try:
+                slicer.mrmlScene.RemoveNode(node)
+            except Exception as e:
+                logger.warning(f"Could not remove a reviewed node: {e}")
+        self.nodes = []
+        self.markups_nodes = []
+        self.markups_start = {}
+        self.transform = None
+        self.transform_item = None
+
+    @property
+    def total(self):
+        return len(self.queue)
+
+    @property
+    def current(self):
+        if 0 <= self.index < len(self.queue):
+            return self.queue[self.index]
+        return None
+
+    @property
+    def remaining(self):
+        return max(0, len(self.queue) - (self.index + 1))
+
+    # --------------------------------------------------------------- building
+
+    def build(self, step: dict) -> list:
+        """One review item per patient for the step that just finished.
+
+        Args:
+            step: the finished step's dictionary, carrying its Review* keys
+
+        Returns:
+            list: the items, which is also kept as this session's queue
+        """
+        self.step = step
+        folder = step.get("ReviewFolder")
+        if not folder or not os.path.isdir(folder):
+            logger.warning(f"Nothing to review: {folder} not found")
+            self.queue = []
+            return []
+
+        # A step carries its id; what that id lets the user do is the
+        # catalogue's business, so a mode never has to repeat it.
+        kind = step.get("ReviewKind") or CATALOGUE.get(
+            step.get("ReviewId", ""), {}
+        ).get("kind", VIEW)
+        if kind == LANDMARKS:
+            wanted = (".json",)
+        elif kind == REGISTRATION:
+            wanted = VOLUME_EXT + MODEL_EXT
+        else:
+            wanted = VOLUME_EXT + MODEL_EXT
+
+        by_patient = {}
+        for root, _, files in os.walk(folder):
+            for name in sorted(files):
+                if name.endswith(wanted):
+                    by_patient.setdefault(patientIdFromFileName(name), []).append(
+                        os.path.join(root, name)
+                    )
+
+        # Landmarks mean nothing without the scan they were placed on, and a
+        # registration can only be judged against what it was registered to.
+        references = self._index(step.get("ReviewReferenceFolder"), VOLUME_EXT + MODEL_EXT)
+
+        # An adjusted registration is only worth saving if its matrix can be
+        # updated with it: what comes after follows the matrix, not the voxels.
+        matrices = self._index(step.get("ReviewMatrixFolder") or folder, (".tfm",))
+
+        queue = []
+        for patient in sorted(by_patient):
+            if kind == LANDMARKS and patient not in references:
+                logger.warning(f"No scan found for {patient}, its landmarks lose their context")
+            adjustable = kind == REGISTRATION and patient in matrices
+            if kind == REGISTRATION and not adjustable:
+                logger.warning(
+                    f"No matrix for {patient}: its registration can be looked at, not moved"
+                )
+            queue.append({
+                "patient": patient,
+                "files": by_patient[patient],
+                "reference": references.get(patient),
+                "kind": kind,
+                "editable": kind == LANDMARKS,
+                "adjustable": adjustable,
+                "matrix": matrices.get(patient),
+            })
+
+        self.queue = queue
+        self.index = 0
+        return queue
+
+    @staticmethod
+    def _index(folder, extensions):
+        """First file of each patient in a folder, by patient id."""
+        found = {}
+        if not folder or not os.path.isdir(folder):
+            return found
+        for root, _, files in os.walk(folder):
+            for name in sorted(files):
+                if name.endswith(extensions):
+                    found.setdefault(patientIdFromFileName(name), os.path.join(root, name))
+        return found
+
+    # ---------------------------------------------------------------- loading
+
+    def loadCurrent(self) -> bool:
+        """Put the current patient on screen. True if anything could be shown."""
+        item = self.current
+        if item is None:
+            return False
+
+        self.clearNodes()
+        loaded = False
+        reference = None
+
+        if item.get("reference"):
+            reference = self._load(item["reference"])
+            if reference is not None:
+                loaded = True
+
+        moving = None
+        for path in item["files"]:
+            node = self._load(path)
+            if node is not None:
+                moving = node
+                loaded = True
+
+        if not loaded:
+            return False
+
+        if item["adjustable"] and moving is not None:
+            self._setUpAdjustment(item, reference, moving)
+        else:
+            self._showTogether(reference, moving)
+
+        self._layout(item)
+        return True
+
+    def _load(self, path):
+        """Load one file, dispatching on what it is."""
+        try:
+            if path.endswith(".json"):
+                node = self._loadEditableMarkups(path)
+            elif path.endswith(MODEL_EXT):
+                node = slicer.util.loadModel(path)
+            else:
+                node = slicer.util.loadVolume(path)
+        except Exception as e:
+            logger.error(f"Could not load {path}: {e}")
+            return None
+
+        if node is None:
+            logger.warning(f"Nothing loaded from {path}")
+            return None
+
+        self.nodes.append(node)
+        return node
+
+    def _loadEditableMarkups(self, path):
+        """Load landmarks so their points can actually be dragged.
+
+        ALI writes every control point with "locked": true and the display
+        hidden, so loading one as it comes shows an empty view holding points
+        that refuse to move. Both are forced on the node only: the file keeps
+        its own flags unless a position really changes.
+        """
+        node = slicer.util.loadMarkups(path)
+        if node is None:
+            return None
+
+        node.SetLocked(False)
+        for i in range(node.GetNumberOfControlPoints()):
+            node.SetNthControlPointLocked(i, False)
+
+        display = node.GetDisplayNode()
+        if display:
+            display.SetVisibility(True)
+            display.SetPointLabelsVisibility(True)
+
+        self.markups_nodes.append(node)
+        self.markups_start[node.GetID()] = self.markupsPositions(node)
+        return node
+
+    def _setUpAdjustment(self, item, reference, moving):
+        """Let the user drag the registered scan onto the one it targets.
+
+        The displacement is held in a transform node, and read back on
+        Continue. Nothing is asked of the user beyond moving the image.
+        """
+        transform = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLLinearTransformNode", f"{item['patient']} manual adjustment"
+        )
+        moving.SetAndObserveTransformNodeID(transform.GetID())
+        self.nodes.append(transform)
+        self.transform = transform
+        self.transform_item = item
+
+        self._showTogether(reference, moving)
+        try:
+            display = transform.GetDisplayNode()
+            if display is None:
+                transform.CreateDefaultDisplayNodes()
+                display = transform.GetDisplayNode()
+            if display is not None:
+                display.SetEditorVisibility(True)
+        except Exception as e:
+            logger.warning(f"Could not show the interaction handles: {e}")
+
+    @staticmethod
+    def _showTogether(reference, moving):
+        """Half-opaque over the reference is what makes a misalignment visible."""
+        if reference is not None and reference.IsA("vtkMRMLScalarVolumeNode"):
+            if moving is not None and moving.IsA("vtkMRMLScalarVolumeNode"):
+                slicer.util.setSliceViewerLayers(
+                    background=reference, foreground=moving, foregroundOpacity=0.5
+                )
+            else:
+                slicer.util.setSliceViewerLayers(background=reference)
+        elif moving is not None and moving.IsA("vtkMRMLScalarVolumeNode"):
+            slicer.util.setSliceViewerLayers(background=moving)
+
+    def _layout(self, item):
+        """A layout suited to what is on screen."""
+        manager = slicer.app.layoutManager()
+        if manager is None:
+            return
+        paths = list(item["files"]) + ([item["reference"]] if item.get("reference") else [])
+        surfaces_only = paths and all(p.endswith(MODEL_EXT) for p in paths)
+        if surfaces_only:
+            manager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
+            widget = manager.threeDWidget(0)
+            if widget:
+                widget.threeDView().resetFocalPoint()
+        else:
+            manager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
+            slicer.util.resetSliceViews()
+
+    # ----------------------------------------------------------------- saving
+
+    def saveEdits(self) -> None:
+        """Write back whatever the user actually changed, and nothing else."""
+        self._saveMarkups()
+        self._saveAdjustment()
+
+    def _saveMarkups(self):
+        """Rewrite the landmark files whose points moved.
+
+        A file left untouched is not rewritten, so a run where the user only
+        looked leaves ALI's output byte for byte as it was.
+        """
+        for node in self.markups_nodes:
+            storage = node.GetStorageNode()
+            path = storage.GetFileName() if storage else None
+            if not path:
+                logger.warning(f"No file to save {node.GetName()} back to")
+                continue
+
+            before = self.markups_start.get(node.GetID())
+            after = self.markupsPositions(node)
+            if before == after:
+                logger.info(f"{os.path.basename(path)} unchanged, not rewritten")
+                continue
+
+            moved = sum(1 for a, b in zip(before, after) if a != b)
+            try:
+                if slicer.util.saveNode(node, path):
+                    logger.info(f"{moved} landmark(s) adjusted, saved to {path}")
+                else:
+                    logger.error(f"Could not save adjusted landmarks to {path}")
+            except Exception as e:
+                logger.error(f"Could not save adjusted landmarks to {path}: {e}")
+
+    def _saveAdjustment(self):
+        """Fold the user's displacement into the matrix it corrects.
+
+        What runs after a registration applies one matrix per patient and
+        cannot chain two, so composing here keeps that contract: the file it
+        already reads carries the registration and the correction together, and
+        nothing downstream has to know an adjustment happened.
+        """
+        transform = self.transform
+        item = self.transform_item
+        if transform is None or not item or not item.get("matrix"):
+            return
+
+        matrix = vtk.vtkMatrix4x4()
+        transform.GetMatrixTransformToParent(matrix)
+        if self.isIdentityMatrix(matrix):
+            logger.info(f"{item['patient']}: registration left as it was produced")
+            return
+
+        import numpy as np
+        import SimpleITK as sitk
+
+        path = item["matrix"]
+        try:
+            original = sitk.ReadTransform(path)
+        except Exception as e:
+            logger.error(f"Could not read {os.path.basename(path)}: {e}")
+            return
+
+        ras = np.array([[matrix.GetElement(r, c) for c in range(4)] for r in range(4)])
+        # Slicer holds the displacement in RAS; a .tfm is LPS, and the two
+        # differ by a flip of the first two axes.
+        flip = np.diag([-1.0, -1.0, 1.0, 1.0])
+        lps = flip @ ras @ flip
+
+        nudge = sitk.AffineTransform(3)
+        nudge.SetMatrix(lps[:3, :3].flatten().tolist())
+        nudge.SetTranslation(lps[:3, 3].tolist())
+
+        # A transform maps the output point back to the input, so the
+        # correction goes in inverted for the pair to read as "register, then
+        # nudge" when it is applied.
+        composed = sitk.CompositeTransform([original, nudge.GetInverse()])
+
+        try:
+            sitk.WriteTransform(composed, path)
+            logger.info(f"{item['patient']}: adjustment folded into {os.path.basename(path)}")
+        except Exception as e:
+            logger.error(f"Could not write the adjusted matrix to {path}: {e}")
+            return
+
+        self._saveAdjustedScan(item, transform)
+
+    def _saveAdjustedScan(self, item, transform):
+        """Write the moved scan back, so the file matches its matrix."""
+        for node in self.nodes:
+            if node.GetTransformNodeID() != transform.GetID():
+                continue
+            storage = node.GetStorageNode()
+            path = storage.GetFileName() if storage else None
+            if not path:
+                continue
+            try:
+                node.HardenTransform()
+                if slicer.util.saveNode(node, path):
+                    logger.info(
+                        f"{item['patient']}: adjusted scan saved to {os.path.basename(path)}"
+                    )
+                else:
+                    logger.error(f"Could not save the adjusted scan to {path}")
+            except Exception as e:
+                logger.error(f"Could not save the adjusted scan to {path}: {e}")
+            return
+
+    # ------------------------------------------------------------------ utils
+
+    @staticmethod
+    def markupsPositions(node) -> list:
+        """Control point positions of a markups node, in order."""
+        positions = []
+        for i in range(node.GetNumberOfControlPoints()):
+            position = [0.0, 0.0, 0.0]
+            node.GetNthControlPointPosition(i, position)
+            positions.append(tuple(position))
+        return positions
+
+    @staticmethod
+    def isIdentityMatrix(matrix, tolerance: float = 1e-9) -> bool:
+        """Whether a 4x4 holds no displacement at all."""
+        for row in range(4):
+            for col in range(4):
+                expected = 1.0 if row == col else 0.0
+                if abs(matrix.GetElement(row, col) - expected) > tolerance:
+                    return False
+        return True
+
+
+# ---------------------------------------------------------------------------
+# What each mode can offer to review.
+#
+# Ids are what the widget stores and what a step carries, so they outlive any
+# change of wording. Several modes run the same kind of step - a mode lists the
+# ids it offers and the wording stays identical everywhere.
+# ---------------------------------------------------------------------------
+
+CBCT = "CBCT"
+IOS = "IOS"
+REG = "Registration"
+
+LOOK = "Nothing to edit here - look at the result, then continue."
+
+CATALOGUE = {
+    "cbct_resampled": {
+        "label": "Resampled CBCT",
+        "group": CBCT,
+        "kind": VIEW,
+        "hint": "Check the CBCT came through resampling intact. " + LOOK,
+    },
+    "cbct_landmarks_orientation": {
+        "label": "CBCT landmarks - orientation",
+        "group": CBCT,
+        "kind": LANDMARKS,
+        "hint": "These points decide how the CBCT is oriented. Drag any that sits "
+                "off its anatomy. Your changes are saved when you continue - you "
+                "do not need to save in Slicer.",
+    },
+    "cbct_oriented": {
+        "label": "Oriented CBCT",
+        "group": CBCT,
+        "kind": VIEW,
+        "hint": "Check the scan is oriented on the reference planes. " + LOOK,
+    },
+    "cbct_masks": {
+        "label": "Registration masks",
+        "group": CBCT,
+        "kind": VIEW,
+        "hint": "These masks decide what the registration matches on. Check they "
+                "follow the bone. " + LOOK,
+    },
+    "cbct_centered_t2": {
+        "label": "Centered T2",
+        "group": CBCT,
+        "kind": VIEW,
+        "hint": "Check the T2 scan is centered before it is registered. " + LOOK,
+    },
+    "cbct_landmarks_registration": {
+        "label": "CBCT landmarks - registration",
+        "group": CBCT,
+        "kind": LANDMARKS,
+        "hint": "These points are what the IOS is registered onto. Drag any that "
+                "sits off its tooth. Your changes are saved when you continue - "
+                "you do not need to save in Slicer.",
+    },
+    "cbct_segmentation": {
+        "label": "Final CBCT segmentations",
+        "group": CBCT,
+        "kind": VIEW,
+        "hint": "Check the segmentations produced at the end of the run. " + LOOK,
+    },
+    "ios_segmented": {
+        "label": "Segmented teeth",
+        "group": IOS,
+        "kind": VIEW,
+        "hint": "Check every tooth carries its label. " + LOOK,
+    },
+    "ios_oriented": {
+        "label": "Oriented IOS",
+        "group": IOS,
+        "kind": VIEW,
+        "hint": "Check the scan is oriented before registration. " + LOOK,
+    },
+    "ios_oriented_t1": {
+        "label": "Oriented IOS - T1",
+        "group": IOS,
+        "kind": VIEW,
+        "hint": "Check the T1 scan is oriented before registration. " + LOOK,
+    },
+    "ios_oriented_t2": {
+        "label": "Oriented IOS - T2",
+        "group": IOS,
+        "kind": VIEW,
+        "hint": "Check the T2 scan is oriented before registration. " + LOOK,
+    },
+    "ios_landmarks": {
+        "label": "IOS landmarks",
+        "group": IOS,
+        "kind": LANDMARKS,
+        "hint": "These points are what the IOS is registered by. Drag any that "
+                "sits off its tooth. Your changes are saved when you continue - "
+                "you do not need to save in Slicer.",
+    },
+    "ios_landmarks_t1": {
+        "label": "IOS landmarks - T1",
+        "group": IOS,
+        "kind": LANDMARKS,
+        "hint": "Drag any point that sits off its tooth on the T1 scan. Your "
+                "changes are saved when you continue.",
+    },
+    "ios_landmarks_t2": {
+        "label": "IOS landmarks - T2",
+        "group": IOS,
+        "kind": LANDMARKS,
+        "hint": "Drag any point that sits off its tooth on the T2 scan. Your "
+                "changes are saved when you continue.",
+    },
+    "cbct_registration": {
+        "label": "Registered CBCT",
+        "group": REG,
+        "kind": REGISTRATION,
+        "hint": "The registered scan is shown over the one it targets. Drag it "
+                "into place if it is off; the correction is folded into its "
+                "matrix when you continue. Leave it alone to keep the result "
+                "as computed.",
+    },
+    "ios_registration": {
+        "label": "Registered IOS",
+        "group": REG,
+        "kind": REGISTRATION,
+        "hint": "The registered scan is shown over the one it targets. Drag it "
+                "into place if it is off; the correction is folded into its "
+                "matrix when you continue. Leave it alone to keep the result "
+                "as computed.",
+    },
+    "ioscbct_registration": {
+        "label": "Registered IOS on CBCT",
+        "group": REG,
+        "kind": VIEW,
+        "hint": "Check the IOS sits correctly in the CBCT. This step writes no "
+                "matrix, so the result cannot be moved here. " + LOOK,
+    },
+}
+
+
+def describe(review_id: str) -> dict:
+    """Catalogue entry of a pause, or an empty dict if the id is unknown."""
+    return CATALOGUE.get(review_id, {})
+
+
+def stepsFor(ids) -> list:
+    """Catalogue entries for the ids a mode offers, in the order given."""
+    steps = []
+    for review_id in ids:
+        entry = CATALOGUE.get(review_id)
+        if entry is None:
+            logger.warning(f"Unknown review step '{review_id}', ignored")
+            continue
+        steps.append(dict(entry, id=review_id))
+    return steps

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -84,19 +84,22 @@ class ReviewSession:
 
     # --------------------------------------------------------------- building
 
-    def build(self, step: dict, since=None) -> list:
+    def build(self, step: dict, expected=None) -> list:
         """One review item per patient for the step that just finished.
 
         Args:
             step: the finished step's dictionary, carrying its Review* keys
-            since: only review files written after this timestamp. Output
-                folders get reused between runs, and without this the review
-                walks patients the run never touched - "patient 1 of 5" on a
-                batch of two.
+            expected: patient ids this run is about. Output folders are reused
+                between runs, so without it the review walks patients the run
+                never touched. Identity rather than file date: a module that
+                skips a patient whose output is already there leaves a file
+                weeks old, and dating the file drops a patient that really is
+                part of the run.
 
         Returns:
             list: the items, which is also kept as this session's queue
         """
+        wanted_ids = {self._normalisedId(p) for p in (expected or ())} or None
         self.step = step
         folder = step.get("ReviewFolder")
         if not folder or not os.path.isdir(folder):
@@ -117,18 +120,21 @@ class ReviewSession:
             wanted = VOLUME_EXT + MODEL_EXT
 
         by_patient = {}
-        skipped = 0
+        skipped = set()
         for root, _, files in os.walk(folder):
             for name in sorted(files):
                 if not name.endswith(wanted):
                     continue
-                path = os.path.join(root, name)
-                if since is not None and not self._writtenSince(path, since):
-                    skipped += 1
+                patient = patientIdFromFileName(name)
+                if wanted_ids is not None and self._normalisedId(patient) not in wanted_ids:
+                    skipped.add(patient)
                     continue
-                by_patient.setdefault(patientIdFromFileName(name), []).append(path)
+                by_patient.setdefault(patient, []).append(os.path.join(root, name))
         if skipped:
-            logger.info(f"{skipped} file(s) from an earlier run left out of the review")
+            logger.info(
+                f"{len(skipped)} patient(s) left out of the review, not part of this "
+                f"run: {sorted(skipped)}"
+            )
 
         # Landmarks mean nothing without the scan they were placed on, and a
         # registration can only be judged against what it was registered to.
@@ -167,23 +173,6 @@ class ReviewSession:
         self.queue = queue
         self.index = 0
         return queue
-
-    @staticmethod
-    def _writtenSince(path, since):
-        """Whether this run produced the file, rather than an earlier one.
-
-        A missing or unreadable timestamp counts as recent: leaving a file out
-        of the review is worse than showing one extra.
-
-        This rests on the pipeline copying with shutil.copy, which stamps the
-        copy with the current time. shutil.copy2 keeps the original date, and
-        an already-segmented scan copied that way would silently vanish from
-        the review.
-        """
-        try:
-            return os.path.getmtime(path) >= since
-        except OSError:
-            return True
 
     @staticmethod
     def _normalisedId(patient_id):

--- a/AREG/Resources/UI/AREG.ui
+++ b/AREG/Resources/UI/AREG.ui
@@ -723,6 +723,17 @@ qMRMLNodeComboBox:focus {
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="ReviewSkipRestButton">
+          <property name="visible"><bool>false</bool></property>
+          <property name="toolTip">
+           <string>Accept the remaining patients of this step without looking at each one, and carry on with the run</string>
+          </property>
+          <property name="text">
+           <string>The rest is fine</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QLabel" name="LabelNameExtension">
           <property name="text">
            <string />

--- a/AREG/Resources/UI/AREG.ui
+++ b/AREG/Resources/UI/AREG.ui
@@ -723,6 +723,45 @@ qMRMLNodeComboBox:focus {
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_ReviewNav">
+          <item>
+           <widget class="QPushButton" name="ReviewPrevPatientButton">
+            <property name="visible"><bool>false</bool></property>
+            <property name="toolTip">
+             <string>Go back to the patient before this one, to look again or change something</string>
+            </property>
+            <property name="text"><string>&#9664; Previous patient</string></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="ReviewPatientLabel">
+            <property name="visible"><bool>false</bool></property>
+            <property name="alignment"><set>Qt::AlignCenter</set></property>
+            <property name="textFormat"><enum>Qt::RichText</enum></property>
+            <property name="text"><string/></property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="ReviewNextPatientButton">
+            <property name="visible"><bool>false</bool></property>
+            <property name="toolTip">
+             <string>Move on to the next patient of this step</string>
+            </property>
+            <property name="text"><string>Next patient &#9654;</string></property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="ReviewFlagButton">
+          <property name="visible"><bool>false</bool></property>
+          <property name="toolTip">
+           <string>Mark this patient as one to redo: going back will replay the steps for it alone</string>
+          </property>
+          <property name="text"><string>Go back and edit this patient</string></property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="ReviewGoBackButton">
           <property name="visible"><bool>false</bool></property>
           <property name="toolTip">
@@ -730,17 +769,6 @@ qMRMLNodeComboBox:focus {
           </property>
           <property name="text">
            <string>Go back and fix</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="ReviewSkipRestButton">
-          <property name="visible"><bool>false</bool></property>
-          <property name="toolTip">
-           <string>Accept the remaining patients of this step without looking at each one, and carry on with the run</string>
-          </property>
-          <property name="text">
-           <string>The rest is fine</string>
           </property>
          </widget>
         </item>

--- a/AREG/Resources/UI/AREG.ui
+++ b/AREG/Resources/UI/AREG.ui
@@ -723,6 +723,17 @@ qMRMLNodeComboBox:focus {
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="ReviewGoBackButton">
+          <property name="visible"><bool>false</bool></property>
+          <property name="toolTip">
+           <string>Go back to the last step you can correct, fix it there, and replay everything since</string>
+          </property>
+          <property name="text">
+           <string>Go back and fix</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="ReviewSkipRestButton">
           <property name="visible"><bool>false</bool></property>
           <property name="toolTip">

--- a/AREG/Resources/UI/AREG.ui
+++ b/AREG/Resources/UI/AREG.ui
@@ -608,6 +608,67 @@ qMRMLNodeComboBox:focus {
     </widget>
    </item>
    <item>
+    <widget class="ctkCollapsibleButton" name="reviewCollapsibleButton">
+     <property name="text">
+      <string>Review and manual adjustment</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_Review">
+      <property name="spacing"><number>6</number></property>
+      <item>
+       <widget class="QCheckBox" name="ReviewEnableCheckBox">
+        <property name="toolTip">
+         <string>Stop after the steps ticked below so you can look at the result, and correct it where the run allows it</string>
+        </property>
+        <property name="text">
+         <string>Pause during the run to check the results</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="ReviewHelpLabel">
+        <property name="wordWrap"><bool>true</bool></property>
+        <property name="text">
+         <string>Tick the steps you want to stop at. The run waits for you there, and continues when you say so.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_Review">
+        <item>
+         <widget class="QPushButton" name="ReviewSelectAllButton">
+          <property name="text"><string>Select all</string></property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="ReviewSelectNoneButton">
+          <property name="text"><string>Select none</string></property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="ReviewScrollArea">
+        <property name="widgetResizable"><bool>true</bool></property>
+        <property name="minimumSize">
+         <size><width>0</width><height>140</height></size>
+        </property>
+        <property name="maximumSize">
+         <size><width>16777215</width><height>260</height></size>
+        </property>
+        <widget class="QWidget" name="ReviewScrollContents">
+         <layout class="QVBoxLayout" name="ReviewStepsLayout">
+          <property name="spacing"><number>4</number></property>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="computeCollapsibleButton">
      <property name="text">
       <string>Compute</string>
@@ -639,6 +700,25 @@ qMRMLNodeComboBox:focus {
           </property>
           <property name="text">
            <string>Cancel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="ReviewMessageLabel">
+          <property name="visible"><bool>false</bool></property>
+          <property name="wordWrap"><bool>true</bool></property>
+          <property name="textFormat"><enum>Qt::RichText</enum></property>
+          <property name="text"><string /></property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="ReviewContinueButton">
+          <property name="visible"><bool>false</bool></property>
+          <property name="toolTip">
+           <string>Save anything you changed and carry on with the run</string>
+          </property>
+          <property name="text">
+           <string>Continue</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
## Why

AREG chains a lot of modules together and, until now, a clinician only saw the
result at the very end. When ALI misplaced a landmark, AMASSS produced a poor
mask or ASO mis-oriented a scan, the registration came out wrong and the whole
run had to be redone from the beginning - with no way to say where it went
wrong or to fix it in place.

This adds an optional review mode: the run pauses after the steps the clinician
picked, loads what was just produced into Slicer, lets them correct it, and
carries the correction forward.

## Picking the pauses

A collapsible "Review and manual adjustment" section lists the steps that can
pause, rebuilt from the mode actually selected - the CBCT/CBCT, IOS/IOS and
IOS/CBCT paths each offer their own. Every step is a checkbox, with Select
all / none, so a clinician who only cares about orientation ticks that one step
and the rest runs unattended.

The list is not hardcoded in the UI: each of the 8 Method subclasses declares
its reviewable steps through `getReviewSteps()`, and `Review.py` holds the
catalogue that maps a step id to its title, hint and what can be edited.

## What can be corrected

Three kinds of pause, and the message says which one you are looking at:

- **Landmarks** - the `.json` is loaded unlocked and visible; points are dragged
  in Slicer and saved back to the same file on Continue.
- **Registration** - the scan is loaded with a transform; dragging it into place
  is folded into the registration matrix itself, so no second matrix has to be
  produced or fed back in.
- **Review only** - visual check, nothing to edit.

## Batches

With more than one patient the pause walks the batch instead of stopping once:

- Previous / Next patient, with the current patient's name shown
- a flag toggle per patient
- "Next step" to accept the rest as they are
- "Go back", which returns to the nearest step that can actually be corrected
  and replays from there - **for the flagged patients only**. The step is
  narrowed to those patients by symlinking their files into a temporary tree
  (falling back to a copy if the filesystem refuses), so the other patients'
  results are left untouched.

## Fixes that came out of testing this

Several of these are pre-existing bugs that the review mode made reachable:

- Slicer froze when a step loaded a large volume from inside a VTK callback -
  writing to stdout from there fills the 64 KB pipe that only the Qt event loop
  drains. Loading is now deferred to the event loop, and CLI output is trimmed.
- A finished run could lock Slicer behind an unmapped modal dialog that had no
  parent. Dialogs are now parented to the main window.
- A traceback raised inside the process callback froze Slicer for the same pipe
  reason; errors are now reported after the callback returns.
- A CLI event arriving after something else took over the run was acted on,
  hitting a `threading.Thread` where a CLI node was expected. Stale events are
  ignored.
- The review picked its patients by file date, which silently dropped a patient
  whose output already existed from an earlier run. It now filters by identity.
- IOS and CBCT files for the same patient were never paired when the two
  modules named them differently (`P1` vs `P_0001`).
- Only the first IOS arch was loaded; both are now shown.
- A registration pause showed every structure instead of the one just
  registered, and the drag could fold into the wrong matrix.

## AMASSS

One commit here (`109e1ed`) is separable from the rest: it ports AMASSS to the
nnUNet Python API with GPU resampling, which is what the cloud version already
did. Measured 2.7x faster - about 60 s down to 22 s per structure. It is in this
branch because the review mode made the wait obvious, but it can be split into
its own PR if preferred.

## Testing

20 scripted suites run inside Slicer cover the catalogue against all 24 mode
configurations, the pause/continue flow, batch navigation and flagging, the
selective replay's folder narrowing, the pairing and arch-loading fixes, and
regression tests for each freeze.

Manually exercised end to end on CBCT/CBCT and IOS/CBCT batches.
