### PR TITLE
VFACE: pause for review at chosen steps, and stop losing failures in silence

### DIFF
--- a/AREG/AREG_Method/CBCT.py
+++ b/AREG/AREG_Method/CBCT.py
@@ -1006,6 +1006,9 @@ def GetPatients(folder_path, time_point="T1", segmentationType=None, folder_mask
     
     patients = {}
 
+    # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+    # patient pairing. See the full note above GetPatients in
+    # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
     for file in all_files:
         basename = os.path.basename(file)
         patient = (

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -770,6 +770,13 @@ def restrictStepToPatients(step, patients, tempdir_factory=None):
                 relative = os.path.relpath(source, folder)
                 target = os.path.join(linked, relative)
                 os.makedirs(os.path.dirname(target), exist_ok=True)
+                # slicer.util.tempDirectory() names its folder to the millisecond,
+                # so two narrowings close together can be handed the same one. The
+                # file is then already linked, and copying onto a link that points
+                # at its own source raises SameFileError.
+                if os.path.lexists(target):
+                    kept += 1
+                    continue
                 try:
                     os.symlink(source, target)
                     kept += 1

--- a/AREG/AREG_Method/Review.py
+++ b/AREG/AREG_Method/Review.py
@@ -32,6 +32,10 @@ def patientIdFromFileName(basename: str) -> str:
     the id is what is left once those are stripped. The order matters: the
     longest markers have to go first or a shorter one cuts inside them.
     """
+    # TIMEPOINT-SUFFIX: this list mirrors the split chains used across the
+    # pipeline and carries the same limit - only _T1/_T2 are stripped, so _T3/_T4
+    # inputs break pairing. See the full note above GetPatients in
+    # AREG_CBCT/AREG_CBCT_utils/utils.py.
     for token in ["_SegOr", "_Scan", "_scan", "_Or", "_OR", "_MAND", "_MD",
                   "_MAX", "_MX", "_CB", "_lm", "_Pred", "_T1", "_T2", "_Cl",
                   "_Center", "_left", "_Left", "_right", "_Right", "_U", "_L",

--- a/AREG/CMakeLists.txt
+++ b/AREG/CMakeLists.txt
@@ -11,7 +11,7 @@ set(MODULE_PYTHON_SCRIPTS
   AREG_Method/IOSCBCT.py
   AREG_Method/Method.py
   AREG_Method/Progress.py
-  AREG_Method/install_pytorch.py
+  AREG_Method/Review.py
 )
 
 set(MODULE_PYTHON_RESOURCES

--- a/AREG_CBCT/AREG_CBCT_utils/utils.py
+++ b/AREG_CBCT/AREG_CBCT_utils/utils.py
@@ -65,6 +65,29 @@ def GetListFiles(folder_path, file_extension):
     return file_list
 
 
+# TIMEPOINT-SUFFIX (not implemented on purpose - read before touching)
+#
+# The patient id is whatever is left once a fixed list of markers is cut off
+# the file name, and the only timepoints in that list are _T1 and _T2. That id
+# is what pairs a scan with its follow-up, so an input named P001_T3.nii.gz
+# keeps the id "P001_T3" and never matches the P001_T4.nii.gz sitting in the
+# T2 folder: the pair is silently dropped instead of raising. _T0 breaks the
+# same way.
+#
+# The timepoint itself does NOT come from the name - it is the time_point
+# argument, i.e. the folder the file was found in. Only the id extraction is
+# in the way.
+#
+# Accepting any _T<digit> means replacing the split chain with
+# re.sub(r"_[Tt]\d+$", "", ...) here AND in every other copy of it: grep for
+# TIMEPOINT-SUFFIX to get the 10 sites, spread over AREG, AREG_CBCT, AREG_IOS,
+# AREG_IOSCBCT, ASO, MRI2CBCT and VFACE. Watch the order of the splits while
+# doing it - several chains rely on a longer marker being cut before a shorter
+# one that would otherwise match inside it.
+#
+# Left as is deliberately: the supported answer today is to rename the inputs
+# to _T1/_T2, and a rewrite touches two modules (ASO, MRI2CBCT) that nothing
+# in the current test set covers.
 def GetPatients(folder_path, time_point="T1", segmentationType=None, mask_folder=None):
     """Return a dictionary with patient id as key"""
     file_extension = [".nii.gz", ".nii", ".nrrd", ".nrrd.gz", ".gipl", ".gipl.gz"]
@@ -113,6 +136,9 @@ def GetPatients(folder_path, time_point="T1", segmentationType=None, mask_folder
         search_folder = mask_folder if mask_folder else folder_path
         mask_files = GetListFiles(search_folder, file_extension)
 
+        # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+        # patient pairing. See the full note above GetPatients in
+        # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
         for file in mask_files:
             basename = os.path.basename(file)
             patient = (

--- a/AREG_IOS/AREG_IOS.py
+++ b/AREG_IOS/AREG_IOS.py
@@ -315,6 +315,9 @@ def main(args):
                 if args.areg_mode == "Auto_IOS":
                     try:
                         logger.debug(f"Processing transformation files for Auto_IOS mode")
+                        # TIMEPOINT-SUFFIX: this assumes the T2 scan is named _T2; a _T4 input keeps
+                        # the suffix in patient_id and stops matching its T1. See the full note above
+                        # GetPatients in AREG_CBCT/AREG_CBCT_utils/utils.py.
                         patient_id = name_t2.split("_T2")[0]
                         patient_id_short = patient_id.split("_")[0] if "_" in patient_id else patient_id
                         

--- a/AREG_IOSCBCT/AREG_IOSCBCT.py
+++ b/AREG_IOSCBCT/AREG_IOSCBCT.py
@@ -369,6 +369,10 @@ def getPatients(ios_folder, cbct_folder, ios_lm_folder, cbct_lm_folder):
     
     def extract_patient_id(filename):
         """Extract patient ID from filename (letter + digits before timepoint)"""
+        # TIMEPOINT-SUFFIX: [Tt][0-2] accepts T0..T2 only, so a _T3 file matches
+        # nothing at all and this returns None - the patient is skipped rather than
+        # mispaired. Accepting more timepoints means \d+ here. See the full note
+        # above GetPatients in AREG_CBCT/AREG_CBCT_utils/utils.py.
         match = re.search(r'([A-Za-z]+)[_]?([0-9]+)[_]?[Tt][0-2]', filename)
         if match:
             return match.group(1) + match.group(2)  # Combine letter and digits

--- a/ASO/ASO_Method/CBCT.py
+++ b/ASO/ASO_Method/CBCT.py
@@ -39,6 +39,9 @@ class CBCT(Method):
         for extension, files in dic.items():
             for file in files:
                 file_name = os.path.basename(file).split(".")[0]
+                # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+                # patient pairing. See the full note above GetPatients in
+                # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
                 patient = (
                     file_name.split("_scan")[0]
                     .split("_Scanreg")[0]

--- a/ASO_CBCT/PRE_ASO_CBCT/PRE_ASO_CBCT.py
+++ b/ASO_CBCT/PRE_ASO_CBCT/PRE_ASO_CBCT.py
@@ -21,7 +21,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: registering the CLI through a symlink (a flat dev
+# folder of links into the source tree) leaves __file__ on the link, whose
+# parent holds no ASO_CBCT_utils. Resolving first lands in ASO_CBCT
+# either way. In a built install the package is already on sys.path.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from ASO_CBCT_utils import (

--- a/ASO_CBCT/SEMI_ASO_CBCT/SEMI_ASO_CBCT.py
+++ b/ASO_CBCT/SEMI_ASO_CBCT/SEMI_ASO_CBCT.py
@@ -23,7 +23,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: registering the CLI through a symlink (a flat dev
+# folder of links into the source tree) leaves __file__ on the link, whose
+# parent holds no ASO_CBCT_utils. Resolving first lands in ASO_CBCT
+# either way. In a built install the package is already on sys.path.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from ASO_CBCT_utils import (

--- a/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
+++ b/ASO_IOS/PRE_ASO_IOS/PRE_ASO_IOS.py
@@ -28,7 +28,11 @@ from tqdm import tqdm
 from itertools import chain
 
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no ASO_IOS_utils. Resolving first lands in
+# ASO_IOS either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 def check_platform():

--- a/ASO_IOS/SEMI_ASO_IOS/SEMI_ASO_IOS.py
+++ b/ASO_IOS/SEMI_ASO_IOS/SEMI_ASO_IOS.py
@@ -26,7 +26,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no ASO_IOS_utils. Resolving first lands in
+# ASO_IOS either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from ASO_IOS_utils import (

--- a/MRI2CBCT/MRI2CBCT_utils/utils_CBCT.py
+++ b/MRI2CBCT/MRI2CBCT_utils/utils_CBCT.py
@@ -38,6 +38,9 @@ def GetPatients(folder_path, time_point="T1", segmentationType=None):
 
     patients = {}
 
+    # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+    # patient pairing. See the full note above GetPatients in
+    # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
     for file in file_list:
         basename = os.path.basename(file)
         patient = (

--- a/MRI2CBCT_CLI/MRI2CBCT_APPROX/MRI2CBCT_APPROX.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_APPROX/MRI2CBCT_APPROX.py
@@ -21,7 +21,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no MRI2CBCT_CLI_utils. Resolving first lands in
+# MRI2CBCT_CLI either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 from MRI2CBCT_CLI_utils import approximation, get_transformation, crop_volume
 

--- a/MRI2CBCT_CLI/MRI2CBCT_CLI_utils/TMJ_crop.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_CLI_utils/TMJ_crop.py
@@ -18,6 +18,9 @@ logger.addHandler(console_handler)
 def GetListFiles(folder_path, extensions):
     return [str(p) for ext in extensions for p in Path(folder_path).rglob(f"*{ext}")]
 
+# TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+# patient pairing. See the full note above GetPatients in
+# AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
 def extract_patient_id(filename: str) -> str:
     # Remove suffixes like _Scan, _CB, _T1, _seg, _mask, etc.
     return (

--- a/MRI2CBCT_CLI/MRI2CBCT_LR_CROP/MRI2CBCT_LR_CROP.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_LR_CROP/MRI2CBCT_LR_CROP.py
@@ -20,7 +20,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no MRI2CBCT_CLI_utils. Resolving first lands in
+# MRI2CBCT_CLI either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from MRI2CBCT_CLI_utils import crop_mri, crop_cbct

--- a/MRI2CBCT_CLI/MRI2CBCT_REG/MRI2CBCT_REG.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_REG/MRI2CBCT_REG.py
@@ -20,7 +20,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no MRI2CBCT_CLI_utils. Resolving first lands in
+# MRI2CBCT_CLI either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 from MRI2CBCT_CLI_utils import invert_mri_intensity, normalize, apply_mask_f, registration
 

--- a/MRI2CBCT_CLI/MRI2CBCT_RESAMPLE_CBCT_MRI/MRI2CBCT_RESAMPLE_CBCT_MRI.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_RESAMPLE_CBCT_MRI/MRI2CBCT_RESAMPLE_CBCT_MRI.py
@@ -18,7 +18,11 @@ console_handler.setLevel(logging.INFO)
 formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno)d) - %(message)s')
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: registering the CLI through a symlink (a flat dev
+# folder of links into the source tree) leaves __file__ on the link, whose
+# parent holds no MRI2CBCT_CLI_utils. Resolving first lands in MRI2CBCT_CLI
+# either way. In a built install the package is already on sys.path.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from MRI2CBCT_CLI_utils import create_csv, resample_images

--- a/MRI2CBCT_CLI/MRI2CBCT_TMJ_CROP/MRI2CBCT_TMJ_CROP.py
+++ b/MRI2CBCT_CLI/MRI2CBCT_TMJ_CROP/MRI2CBCT_TMJ_CROP.py
@@ -23,7 +23,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no MRI2CBCT_CLI_utils. Resolving first lands in
+# MRI2CBCT_CLI either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from MRI2CBCT_CLI_utils import GetPatients

--- a/MedX_CLI/MedX_Dashboard/MedX_Dashboard.py
+++ b/MedX_CLI/MedX_Dashboard/MedX_Dashboard.py
@@ -17,7 +17,11 @@ formatter = logging.Formatter('%(name)s - %(levelname)s - (%(filename)s:%(lineno
 console_handler.setFormatter(formatter)
 logger.addHandler(console_handler)
 
-fpath = os.path.join(os.path.dirname(__file__), "..")
+# realpath, not __file__: this CLI sits in a sub-folder, so it is registered
+# through a flat folder of symlinks into the source tree. __file__ then names
+# the link, whose parent holds no MedX_CLI_utils. Resolving first lands in
+# MedX_CLI either way; a built install has the package on sys.path already.
+fpath = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 sys.path.append(fpath)
 
 from MedX_CLI_utils import show_dashboard

--- a/VFACE/CMakeLists.txt
+++ b/VFACE/CMakeLists.txt
@@ -13,6 +13,7 @@ set(MODULE_PYTHON_SCRIPTS
   VFACE_utils/Measure.py
   VFACE_utils/Point.py
   VFACE_utils/Progress.py
+  VFACE_utils/review_steps.py
   VFACE_utils/segmentation_logic.py
   )
 

--- a/VFACE/Resources/UI/VFACE.ui
+++ b/VFACE/Resources/UI/VFACE.ui
@@ -164,14 +164,34 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="ctkPathLineEdit" name="PathLineEdit">
-        <property name="filters">
-         <set>ctkPathLineEdit::Dirs</set>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string/>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_T1">
+        <item>
+         <widget class="ctkPathLineEdit" name="PathLineEdit">
+          <property name="filters">
+           <set>ctkPathLineEdit::Dirs</set>
+          </property>
+          <property name="SlicerParameterName" stdset="0">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="TestFilesButton">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="maximumWidth">
+           <number>80</number>
+          </property>
+          <property name="toolTip">
+           <string>Download a sample CBCT scan and use it as the T1 input, along with the default measurement lists (about 280 MB the first time)</string>
+          </property>
+          <property name="text">
+           <string>Test Files</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="5" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -262,21 +282,68 @@
        </widget>
       </item>
 
-      <item row="9" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>Intermediate Output Check</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QCheckBox" name="checkBox_2">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
 
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="ctkCollapsibleButton" name="reviewCollapsibleButton">
+     <property name="text">
+      <string>Review and manual adjustment</string>
+     </property>
+     <property name="collapsed">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_Review">
+      <property name="spacing"><number>6</number></property>
+      <item>
+       <widget class="QCheckBox" name="checkBox_2">
+        <property name="toolTip">
+         <string>Stop after the steps ticked below so you can look at the result, and correct it where the run allows it</string>
+        </property>
+        <property name="text">
+         <string>Pause during the run to check the results</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="reviewHelpLabel">
+        <property name="wordWrap"><bool>true</bool></property>
+        <property name="text">
+         <string>Tick the steps you want to stop at. The run waits for you there, and continues when you say so.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_Review">
+        <item>
+         <widget class="QPushButton" name="reviewSelectAllButton">
+          <property name="text"><string>Select all</string></property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="reviewSelectNoneButton">
+          <property name="text"><string>Select none</string></property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QScrollArea" name="reviewScrollArea">
+        <property name="widgetResizable"><bool>true</bool></property>
+        <property name="minimumSize">
+         <size><width>0</width><height>140</height></size>
+        </property>
+        <property name="maximumSize">
+         <size><width>16777215</width><height>260</height></size>
+        </property>
+        <widget class="QWidget" name="reviewScrollContents">
+         <layout class="QVBoxLayout" name="reviewStepsLayout">
+          <property name="spacing"><number>4</number></property>
+         </layout>
+        </widget>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -300,6 +367,22 @@
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Module lance</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="reviewLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
@@ -338,9 +421,84 @@
    </item>
 
   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_ReviewNav">
+     <item>
+      <widget class="QPushButton" name="reviewPrevPatientButton">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Go back to the patient before this one, to look again or change something</string>
+       </property>
+       <property name="text">
+        <string>&#9664; Previous patient</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="reviewPatientLabel">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="reviewNextPatientButton">
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Move on to the next patient of this step</string>
+       </property>
+       <property name="text">
+        <string>Next patient &#9654;</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+
+  <item>
+    <widget class="QPushButton" name="reviewFlagButton">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>Mark this patient as one to redo: going back will replay the steps for it alone</string>
+     </property>
+     <property name="text">
+      <string>Go back and edit this patient</string>
+     </property>
+    </widget>
+   </item>
+
+  <item>
     <widget class="QPushButton" name="continueButton">
      <property name="text">
-      <string>Continue on next step</string>
+      <string>Next step</string>
+     </property>
+    </widget>
+   </item>
+
+  <item>
+    <widget class="QPushButton" name="reviewGoBackButton">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>Go back to the last step you can correct, fix it there, and replay everything since</string>
+     </property>
+     <property name="text">
+      <string>Go back and fix</string>
      </property>
     </widget>
    </item>

--- a/VFACE/Resources/UI/VFACE.ui
+++ b/VFACE/Resources/UI/VFACE.ui
@@ -326,6 +326,14 @@
           <property name="text"><string>Select none</string></property>
          </widget>
         </item>
+          <item>
+           <widget class="QPushButton" name="reviewSelectRecommendedButton">
+            <property name="toolTip">
+             <string>The steps worth a look on most runs: the landmarks you can correct, each registration, and the final surfaces</string>
+            </property>
+            <property name="text"><string>Select recommended</string></property>
+           </widget>
+          </item>
        </layout>
       </item>
       <item>

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2119,10 +2119,13 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if loaded and item.get("adjustable") and moving is not None:
             self.setUpAdjustment(item, reference, moving)
 
-        # Only where points are being placed: on a registration the user judges
-        # two scans against each other on the slices, and a rendered block on top
-        # of that hides the very overlap they are looking at.
-        if loaded and item.get("editable") and reference is not None:
+        # On the reference only, and on every kind of pause. Rendering both scans
+        # of a registration would put two opaque blocks inside each other and
+        # show nothing - but rendering one costs nothing, because the rendering
+        # lives in the 3D view while the overlap is judged on the slices. An
+        # earlier version skipped registrations entirely, on the mistaken idea
+        # that a rendering would cover that overlap; it cannot.
+        if loaded and reference is not None:
             self.showVolumeRendering(reference)
 
         if loaded:

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1,5 +1,7 @@
+import contextlib
 import logging
 import os
+import tempfile
 from typing import Annotated
 import urllib.request
 import shutil
@@ -26,12 +28,16 @@ try:
     
     from VFACE_utils import createlistprocess
     importlib.reload(createlistprocess)
-    from VFACE_utils.createlistprocess import CreateListProcess, NumberScan
+    from VFACE_utils.createlistprocess import CreateListProcess, NumberScan, patientIdFromFileName
+
+    from VFACE_utils import review_steps
+    importlib.reload(review_steps)
 
 except Exception as e:
     logger.error(f"Error loading VFACE utilities: {e}")
     from VFACE_utils.Progress import DisplayALICBCT,DisplayAMASSS,DisplayASOCBCT,Display
-    from VFACE_utils.createlistprocess import CreateListProcess, NumberScan
+    from VFACE_utils.createlistprocess import CreateListProcess, NumberScan, patientIdFromFileName
+    from VFACE_utils import review_steps
 
 import vtk
 
@@ -183,7 +189,10 @@ class PopUpWindow(qt.QDialog):
             type: Dialog type - 'radio' for single selection, 'checkbox' for multiple
             tocheck: Items to pre-check (for checkbox mode)
         """
-        qt.QWidget.__init__(self)
+        # Without a parent the window manager attaches the dialog to a 1x1
+        # dummy window and never maps it. A modal one then takes every click
+        # with nothing on screen to dismiss - the run looks frozen at the end.
+        qt.QWidget.__init__(self, slicer.util.mainWindow())
         self.setWindowTitle(title)
         layout = qt.QGridLayout()
         self.setLayout(layout)
@@ -305,8 +314,25 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.cliNode = None
         self.list_process = []
         self.paused_for_visualization = False
-        self.current_output_to_load = None
         self.current_process_info = None
+        # One review item per patient for the step being reviewed, plus the
+        # nodes it put in the scene and the landmark positions as loaded, so
+        # Continue can tell an edited file from an untouched one.
+        self.pause_queue = []
+        self.pause_index = 0
+        self.pause_nodes = []
+        self.pause_markups_nodes = []
+        self.pause_markups_start = {}
+        self.pause_transform = None
+        self.pause_transform_item = None
+        self.pause_pending = False
+        # Batch review: the patients marked for rework, the steps already run
+        # so a rollback knows what lies behind, the patients a rollback is
+        # replaying, and the temporary folders a narrowed replay leaves behind.
+        self.review_flagged = set()
+        self.executed_steps = []
+        self.review_flagged_carry = []
+        self.review_temp_folders = []
         # onCliUpdated only assigns this when progress is 0, so a first event
         # carrying a non-zero progress would read it before it exists.
         self.updateProgessBar = False
@@ -339,6 +365,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Load widget from .ui file (created by Qt Designer).
         # Additional widgets can be instantiated manually and added to self.layout.
         uiWidget = slicer.util.loadUI(self.resourcePath("UI/VFACE.ui"))
+        self.uiWidget = uiWidget
         self.layout.addWidget(uiWidget)
         self.ui = slicer.util.childWidgetVariables(uiWidget)
 
@@ -350,6 +377,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Also apply label-specific stylesheet
         self._applyLabelStyleSheets(isDarkMode)
         self._applyButtonStyleSheets(isDarkMode)
+        self._applyCheckboxStyleSheets(isDarkMode)
 
         # Set scene in MRML widgets. Make sure that in Qt designer the top-level qMRMLWidget's
         # "mrmlSceneChanged(vtkMRMLScene*)" signal in is connected to each MRML widget's.
@@ -383,9 +411,14 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.CheckDependencyButton.connect("clicked(bool)", self.CheckDependency)
         self.ui.cancelButton.connect("clicked(bool)", self.onCancelButton)
         self.ui.DefaultListButton.connect("clicked(bool)", self.onDefaultButton)
+        self.ui.TestFilesButton.connect("clicked(bool)", self.onTestFilesButton)
 
         self.ui.continueButton.setVisible(False)
         self.ui.continueButton.connect("clicked(bool)", self.onContinueButton)
+        self.ui.reviewPrevPatientButton.connect("clicked(bool)", self.onReviewPreviousPatient)
+        self.ui.reviewNextPatientButton.connect("clicked(bool)", self.onReviewNextPatient)
+        self.ui.reviewFlagButton.connect("clicked(bool)", self.onReviewToggleFlag)
+        self.ui.reviewGoBackButton.connect("clicked(bool)", self.onReviewGoBack)
 
         documentsLocation = qt.QStandardPaths.DocumentsLocation
         self.documents = qt.QStandardPaths.writableLocation(documentsLocation)
@@ -398,7 +431,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Make sure parameter node is initialized (needed for module reload)
         self.initializeParameterNode()
+        self.setupReviewUi()
         self.ui.label_3.setVisible(False)
+        self.ui.reviewLabel.setVisible(False)
         self.ui.progressBar.setVisible(False)
 
     def _isDarkMode(self) -> bool:
@@ -546,13 +581,133 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         # List of labels to style
         labels = [
-            'label_5', 'label_4', 'label_2', 'label_6', 'label_7', 'label_3', 'label', 'modeLabel', 't2label', 'excellabel'
+            'label_5', 'label_4', 'label_2', 'label_6', 'label_3', 'label', 'modeLabel', 't2label', 'excellabel'
         ]
         
         for labelName in labels:
             if hasattr(self.ui, labelName):
                 label = getattr(self.ui, labelName)
                 label.setStyleSheet(labelStyle)
+
+        if hasattr(self.ui, "reviewLabel"):
+            if isDarkMode:
+                reviewStyle = (
+                    "color: #e8e8e8; background-color: #2f3b47;"
+                    " border: 1px solid #4ba3ff; border-radius: 4px; padding: 8px;"
+                )
+            else:
+                reviewStyle = (
+                    "color: #1f2d3a; background-color: #eaf3fb;"
+                    " border: 1px solid #3498db; border-radius: 4px; padding: 8px;"
+                )
+            self.ui.reviewLabel.setStyleSheet(reviewStyle)
+
+    def _applyCheckboxStyleSheets(self, isDarkMode: bool) -> None:
+        """
+        Style every checkbox of the module, the review list included.
+
+        Slicer's default indicator all but disappears against a dark panel, so
+        it is redrawn - the same treatment AREG gives its own. In light mode
+        the default is already right, and the style is cleared rather than
+        left behind when the theme changes back.
+
+        Args:
+            isDarkMode: Whether the application is in dark mode
+        """
+        if isDarkMode:
+            stylesheet = """
+            QCheckBox {
+              color: #ffffff;
+              font-weight: 500;
+              spacing: 6px;
+            }
+            QCheckBox::indicator {
+              width: 18px;
+              height: 18px;
+              border: 1px solid #555555;
+              border-radius: 3px;
+              background-color: #3c3c3c;
+            }
+            QCheckBox::indicator:hover {
+              border: 1px solid #5dade2;
+            }
+            QCheckBox::indicator:checked {
+              width: 18px;
+              height: 18px;
+              border: 1px solid #5dade2;
+              border-radius: 3px;
+              background-color: #5dade2;
+              image: url(:/Icons/SmallCheckMark.png);
+            }
+            QCheckBox::indicator:checked:hover {
+              border: 1px solid #7bbcef;
+              background-color: #7bbcef;
+            }
+            """
+        else:
+            # Same shape, light palette. AREG only redraws its checkboxes in
+            # dark mode, which left this module's own look inconsistent: its
+            # buttons are styled in both themes, so its boxes have to be too.
+            stylesheet = """
+            QCheckBox {
+              color: #34495e;
+              font-weight: 500;
+              spacing: 6px;
+            }
+            QCheckBox::indicator {
+              width: 18px;
+              height: 18px;
+              border: 1px solid #b0bec5;
+              border-radius: 3px;
+              background-color: #ffffff;
+            }
+            QCheckBox::indicator:hover {
+              border: 1px solid #3498db;
+            }
+            QCheckBox::indicator:checked {
+              width: 18px;
+              height: 18px;
+              border: 1px solid #3498db;
+              border-radius: 3px;
+              background-color: #3498db;
+              image: url(:/Icons/SmallCheckMark.png);
+            }
+            QCheckBox::indicator:checked:hover {
+              border: 1px solid #5cb3ff;
+              background-color: #5cb3ff;
+            }
+            QCheckBox:disabled {
+              color: #9aa5ab;
+            }
+            QCheckBox::indicator:disabled {
+              border: 1px solid #d5dbdd;
+              background-color: #eceff1;
+            }
+            """
+
+        self._styleAllCheckboxes(getattr(self, "uiWidget", None), stylesheet)
+
+    def _styleAllCheckboxes(self, parent, stylesheet: str) -> None:
+        """
+        Walk the widget tree and style every checkbox it holds.
+
+        The review steps are built after setup and rebuilt on every change of
+        mode, so they cannot be styled by name from a fixed list.
+
+        Args:
+            parent: Widget to start from
+            stylesheet: Style to apply, empty to restore the default
+        """
+        if parent is None:
+            return
+        if isinstance(parent, qt.QCheckBox):
+            try:
+                parent.setStyleSheet(stylesheet)
+            except Exception as e:
+                logger.warning(f"Could not style a checkbox: {e}")
+        if hasattr(parent, "children"):
+            for child in parent.children():
+                self._styleAllCheckboxes(child, stylesheet)
 
     def _applyButtonStyleSheets(self, isDarkMode: bool) -> None:
         """Apply button-specific stylesheets."""
@@ -652,7 +807,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             """
         
         # Apply standard style to most buttons
-        for buttonName in ['applyButton', 'CheckDependencyButton', 'continueButton','DefaultListButton']:
+        for buttonName in ['applyButton', 'CheckDependencyButton', 'continueButton',
+                           'DefaultListButton', 'TestFilesButton',
+                           'reviewSelectAllButton', 'reviewSelectNoneButton']:
             if hasattr(self.ui, buttonName):
                 button = getattr(self.ui, buttonName)
                 button.setStyleSheet(standardButtonStyle)
@@ -952,6 +1109,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onComboBoxChanged(self, text):
         """Called when the main comboBox value changes"""
         logger.info(f"ComboBox changed to: {text}")
+        self.rebuildReviewSteps()
 
     def onComboBox2Changed(self, text):
         
@@ -964,6 +1122,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.PathLineEdit_3.setVisible(True)
             self.ui.DefaultListButton.setVisible(True)
 
+        self.rebuildReviewSteps()
         self._checkCanApply()
 
     def onComboBox3Changed(self, text):
@@ -984,6 +1143,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.ui.modeLabel.setText("Oriented T1 Folder")
         else:
             self.ui.modeLabel.setText("T1 Folder")
+        self.rebuildReviewSteps()
         self._checkCanApply()
 
     def onComboBox4Changed(self, text):
@@ -999,6 +1159,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if self.ui.comboBox3.currentText == "File already Registered":
                 self.ui.t2label.setText("Registered T2 Folder")
             
+        self.rebuildReviewSteps()
         self._checkCanApply()
 
     def onApplyButton(self) -> None:
@@ -1028,6 +1189,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                                 mode2 = self.ui.comboBox4.currentText,
                                 model_vface = os.path.join(self.SlicerDownloadPath,"V_FACE"))
 
+        if self.list_process:
+            self.applyReviewSelection()
+
         if not self.list_process:
             PopUpWindow(
                 title="Nothing to run",
@@ -1040,9 +1204,15 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.CheckDependencyButton.enabled = False
         self.ui.cancelButton.setVisible(True)
         self.ui.label_3.setVisible(True)
+        self.ui.reviewLabel.setVisible(False)
         self.ui.progressBar.setVisible(True)
 
         self.NumberProcess = len(self.list_process)
+        # A second run in the same session must not see the first one's steps.
+        self.executed_steps = []
+        self.review_flagged = set()
+        self.review_flagged_carry = []
+        self.clearReviewTempFolders()
         self.executeProcess(self.list_process[0])
         del self.list_process[0]
 
@@ -1080,10 +1250,22 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         Called after user has reviewed visualization and is ready to proceed with next steps.
         """
+        # Moving between patients is what the navigation buttons are for, so
+        # this one does the single thing its label promises: it ends the pause.
+        # What the user changed on the patient in front of them is saved first,
+        # and the patients they never opened keep the results they already have.
+        if self.pause_queue:
+            self.savePauseEdits()
+            seen = self.pause_index + 1
+            total = len(self.pause_queue)
+            if seen < total:
+                logger.info(f"{total - seen} patient(s) accepted without being opened")
+
+        self.resetPauseState()
+
         logger.info("Continuing process after visualization...")
         self.ui.continueButton.setVisible(False)
         self.ui.cancelButton.setVisible(True)
-        self.paused_for_visualization = False
         self.ui.label_3.setVisible(True)
         self.ui.progressBar.setVisible(True)
         
@@ -1094,6 +1276,90 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         else:
             self.OnEndProcess()
     
+    # VFACE has no test archive of its own, and its T1 input is a plain CBCT:
+    # AREG's orientation set holds exactly that, unoriented, which is what the
+    # full pipeline expects. Replace with a VFACE release asset if one is ever
+    # published.
+    TEST_FILES_NAME = "Oriented-Automated"
+    TEST_FILES_URL = (
+        "https://github.com/lucanchling/Areg_CBCT/releases/download/TestFiles/"
+        "Or_FullyAuto.zip"
+    )
+
+    def onTestFilesButton(self) -> None:
+        """
+        Download a sample CBCT and point the T1 input at it.
+
+        The archive carries a T1 and a T2; only the T1 is of any use here, so
+        that is the folder the input is set to.
+        """
+        if not os.path.exists(self.SlicerDownloadPath):
+            os.makedirs(self.SlicerDownloadPath)
+
+        # Under V_FACE, next to DefaultList: the archive is borrowed from AREG
+        # but the copy belongs to this module, and uninstalling one must not
+        # take the other's sample away.
+        folder_name = os.path.join("V_FACE", "Test_Files", self.TEST_FILES_NAME)
+        try:
+            self.DownloadUnzip(
+                url=self.TEST_FILES_URL,
+                directory=self.SlicerDownloadPath,
+                folder_name=folder_name,
+                check_file="T1",
+            )
+        except Exception as e:
+            logger.error(f"Could not download the test files: {e}")
+            PopUpWindow(
+                title="Download failed",
+                text=f"The sample scan could not be downloaded:\n\n{e}",
+            ).exec_()
+            return
+
+        # The archive is AREG's, so it carries a second timepoint. VFACE makes
+        # its own T2 by mirroring the T1 and never reads one from disk, so that
+        # half is dropped rather than left to take up room for nothing.
+        t2_folder = os.path.join(self.SlicerDownloadPath, folder_name, "T2")
+        if os.path.isdir(t2_folder):
+            try:
+                shutil.rmtree(t2_folder)
+                logger.info("Test files: dropped the T2 this module has no use for")
+            except OSError as e:
+                logger.warning(f"Could not remove the unused T2 folder: {e}")
+
+        t1_folder = os.path.join(self.SlicerDownloadPath, folder_name, "T1")
+        if not os.path.isdir(t1_folder):
+            logger.error(f"No T1 folder in the test files: {t1_folder}")
+            PopUpWindow(
+                title="Test files incomplete",
+                text=f"The archive holds no T1 folder:\n\n{t1_folder}",
+            ).exec_()
+            return
+
+        nb_scan = NumberScan(t1_folder)
+        if nb_scan == 0:
+            logger.error(f"No scan found in the test files: {t1_folder}")
+            PopUpWindow(
+                title="No scan found",
+                text=f"No readable scan in the downloaded folder:\n\n{t1_folder}",
+            ).exec_()
+            return
+
+        self.ui.PathLineEdit.setCurrentPath(t1_folder)
+        logger.info(f"Test files ready: {nb_scan} patient(s) in {t1_folder}")
+
+        # Somewhere to write, beside the scans it will read, so the sample runs
+        # on a single click. A folder the user already chose is left alone.
+        if not self._parameterNode.OutputFolder:
+            output = os.path.join(self.SlicerDownloadPath, folder_name, "Output")
+            self.ui.PathLineEdit_2.setCurrentPath(output)
+            logger.info(f"Test files: output set to {output}")
+
+        # The sample is only runnable with the measurement lists beside it, so
+        # fetch those too rather than leaving the user one unexplained click
+        # short. A folder they already chose is left alone.
+        if not self.ui.PathLineEdit_3.currentPath:
+            self.onDefaultButton()
+
     def onDefaultButton(self):
         if not os.path.exists(self.SlicerDownloadPath):
             os.makedirs(self.SlicerDownloadPath)
@@ -1223,8 +1489,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.applyButton.enabled = True
         self.ui.CheckDependencyButton.enabled = True
 
-        self.paused_for_visualization = False
-        self.current_output_to_load = None
+        self.resetPauseState()
         self.current_process_info = None
         self.cliNode = None
         self.ActualProcess = 1
@@ -1232,84 +1497,913 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         
         logger.info("Interface reset after cancellation")
 
-    def loadOutputInSlicer(self, output_path: str) -> bool:
-        """
-        Load processed output into Slicer viewer for visualization.
-        
-        Supports volume formats (.nrrd, .nii, .nii.gz) and model format (.vtk).
-        Automatically configures appropriate layout and view settings.
-        
-        Args:
-            output_path: Path to the output file to load
-            
-        Returns:
-            bool: True if loading was successful, False otherwise
-        """
-        try:
-            if not output_path or not os.path.exists(output_path):
-                logger.warning(f"Output path does not exist: {output_path}")
-                return False
+    # ===== Manual review pauses =====
+    #
+    # A step marked "pause_for_visualization" stops the run once it finishes, so
+    # the user can look at what it produced and, for landmarks, correct it before
+    # the rest of the pipeline consumes it. The step itself says where its output
+    # went ("ReviewFolder"), which is what keeps this in step with the folders
+    # createlistprocess actually writes to.
 
-            if output_path.endswith(('.nrrd', '.nii', '.nii.gz')):
-                # Load volume file
-                volume_node = slicer.util.loadVolume(output_path)
-                if volume_node:
-                    slicer.util.setSliceViewerLayers(background=volume_node)
-                    slicer.app.layoutManager().setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
-                    slicer.util.resetSliceViews()
-                    logger.info(f"Volume loaded: {output_path}")
-                    return True
-                    
-            elif output_path.endswith('.vtk'):
-                # Load model file
-                model_node = slicer.util.loadModel(output_path)
-                if model_node:
-                    slicer.app.layoutManager().setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
-                    threeDView = slicer.app.layoutManager().threeDWidget(0).threeDView()
-                    threeDView.resetFocalPoint()
-                    logger.info(f"Model loaded: {output_path}")
-                    return True
-                    
-        except Exception as e:
-            logger.error(f"Error loading output file {output_path}: {e}")
-        
-        return False
+    VOLUME_EXT = (".nrrd", ".nii.gz", ".nii", ".nrrd.gz", ".gipl.gz", ".gipl")
+    MODEL_EXT = (".vtk", ".vtp", ".stl")
+    CONTINUE_BUTTON_TEXT = "Next step"
+
+    # ------------------------------------------------------- choosing the pauses
+
+    REVIEW_SETTINGS_KEY = "VFACE/ReviewSteps"
+
+    def setupReviewUi(self) -> None:
+        """Wire the review section up. Called once, from setup()."""
+        self.ui.checkBox_2.connect("toggled(bool)", self.onReviewEnableToggled)
+        self.ui.reviewSelectAllButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(True))
+        self.ui.reviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
+        self.onReviewEnableToggled(self.ui.checkBox_2.isChecked())
+        self.rebuildReviewSteps()
+
+    def onReviewEnableToggled(self, enabled: bool) -> None:
+        """Grey the list out when pausing is off, rather than hiding it."""
+        for widget in (self.ui.reviewScrollArea, self.ui.reviewSelectAllButton,
+                       self.ui.reviewSelectNoneButton, self.ui.reviewHelpLabel):
+            widget.setEnabled(enabled)
+
+    def rebuildReviewSteps(self) -> None:
+        """Rebuild the checkboxes for the settings now chosen.
+
+        A run that skips a step must not offer it: ticking a pause the run
+        never reaches reads as a broken feature the first time it goes
+        straight past. What the user ticked before is restored wherever the
+        same step still exists.
+        """
+        contents = getattr(self.ui, "reviewScrollContents", None)
+        layout = contents.layout() if contents is not None else None
+        if layout is None:
+            logger.warning("Review step list not found in the UI, no pause offered")
+            return
+
+        while layout.count():
+            item = layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.setParent(None)
+        self.review_checkboxes = {}
+
+        steps = review_steps.availableSteps(
+            mode=self.ui.comboBox3.currentText,
+            mode2=self.ui.comboBox4.currentText,
+            reg_type=self.ui.comboBox.currentText,
+            visualization="Visualization" in self.ui.comboBox2.currentText,
+            quantification="Quantitative" in self.ui.comboBox2.currentText,
+        )
+
+        remembered = self.loadReviewSelection()
+        group = None
+        for step in steps:
+            if step["group"] != group:
+                group = step["group"]
+                layout.addWidget(qt.QLabel(f"<b>{group}</b>"))
+
+            label = step["label"]
+            if step["kind"] != review_steps.VIEW:
+                label += "  (editable)"
+            box = qt.QCheckBox(label)
+            box.setToolTip(
+                "You can correct this one." if step["kind"] != review_steps.VIEW
+                else "Look only."
+            )
+            box.setChecked(step["id"] in remembered)
+            box.connect("toggled(bool)", lambda _checked: self.saveReviewSelection())
+            layout.addWidget(box)
+            self.review_checkboxes[step["id"]] = box
+
+        layout.addStretch(1)
+        # These boxes did not exist when the theme was applied.
+        self._applyCheckboxStyleSheets(self._isDarkMode())
+
+    def setAllReviewSteps(self, checked: bool) -> None:
+        """Tick or untick every step currently offered."""
+        for box in self.review_checkboxes.values():
+            box.setChecked(checked)
+
+    def selectedReviewIds(self) -> set:
+        """Ids the user ticked, empty when pausing is switched off."""
+        if not self.ui.checkBox_2.isChecked():
+            return set()
+        return {i for i, box in self.review_checkboxes.items() if box.isChecked()}
+
+    def saveReviewSelection(self) -> None:
+        """Keep the ticked steps between sessions."""
+        chosen = [i for i, box in self.review_checkboxes.items() if box.isChecked()]
+        qt.QSettings().setValue(self.REVIEW_SETTINGS_KEY, ",".join(sorted(chosen)))
+
+    def loadReviewSelection(self) -> set:
+        """Steps ticked the last time, as a set of ids."""
+        stored = qt.QSettings().value(self.REVIEW_SETTINGS_KEY, "")
+        if not stored:
+            return set()
+        if isinstance(stored, (list, tuple)):
+            return set(stored)
+        return {i for i in str(stored).split(",") if i}
+
+    def applyReviewSelection(self) -> int:
+        """Drop the pause from the steps the user did not ask to stop at.
+
+        The pipeline marks every step it could pause on; this is what turns
+        that into the handful the user actually wants.
+        """
+        chosen = self.selectedReviewIds()
+        kept = 0
+        for step in self.list_process:
+            if not step.get("pause_for_visualization"):
+                continue
+            if step.get("ReviewId") in chosen:
+                kept += 1
+            else:
+                step["pause_for_visualization"] = False
+        logger.info(f"{kept} step(s) will pause for review")
+        return kept
 
     def shouldPauseAfterProcess(self, process_info: dict) -> bool:
         """
         Determine if process execution should pause for visualization review.
-        
+
         Args:
             process_info: Process information dictionary
-            
+
         Returns:
             bool: True if pause is requested, False otherwise
         """
         return process_info.get("pause_for_visualization", False)
 
-    def getOutputPathForModule(self, module_name: str) -> str:
-        output_paths = {
-            "Orient T1 (CB)": os.path.join(self._parameterNode.OutputFolder, "Oriented Scans", "Oriented relative CB"),
-            "Orient T1 (MAX)": os.path.join(self._parameterNode.OutputFolder, "Oriented Scans", "Oriented relative MAX"),
-            "Masks Generation for T1 (MAX)": os.path.join(self._parameterNode.OutputFolder, "Masks"),
-            "Mirroring Masks": os.path.join(self._parameterNode.OutputFolder, "Mirrored_Masks"),
-            "Mirroring MAX Oriented Scan": os.path.join(self._parameterNode.OutputFolder, "Mirrored_Scan", "CB"),
-            "AREG - Registering Scan (MAND)": os.path.join(self._parameterNode.OutputFolder, "Registered Scan", "Mandible"),
-            "BDS - Segmentation T2 MAX": os.path.join(self._parameterNode.OutputFolder, "VTK Files","T2 MAX"),
-        }
-        
-        base_path = output_paths.get(module_name)
-        if base_path and os.path.exists(base_path):
-            for ext in ['.nrrd', '.nii.gz', '.nii', '.vtk']:
-                for file in os.listdir(base_path):
-                    if file.endswith(ext):
-                        return os.path.join(base_path, file)
-            
-            for root, dirs, files in os.walk(base_path):
-                for file in files:
-                    if file.endswith(('.nrrd', '.nii.gz', '.nii', '.vtk')):
-                        return os.path.join(root, file)
-        return None
+    def runPatientIds(self) -> set:
+        """The patients this run is about, read from the folder it was given.
+
+        The scans on the input side are what defines a run. An output folder may
+        hold months of earlier work, and a step that skips a patient it has
+        already done leaves that patient's file untouched and old - so the file
+        date says nothing useful about who is being processed. Only the input
+        list does.
+
+        Returns:
+            set: Patient ids, empty if the folder cannot be read
+        """
+        node = getattr(self, "_parameterNode", None)
+        folder = getattr(node, "InputFolder", None) if node is not None else None
+        if not folder or not os.path.isdir(folder):
+            return set()
+
+        wanted = self.VOLUME_EXT + self.MODEL_EXT + (".json",)
+        ids = set()
+        for root, _, files in os.walk(folder):
+            for name in files:
+                if name.endswith(wanted):
+                    ids.add(patientIdFromFileName(name))
+        return ids
+
+    @staticmethod
+    def belongsToRun(patient: str, wanted_ids: set) -> bool:
+        """Whether a produced file's id names one of the run's patients.
+
+        Usually the ids match outright. Some steps append a marker that
+        patientIdFromFileName does not know how to strip - the heatmaps come out
+        as "C_0001_Mandible_ModelDistance" - which leaves a longer id built on
+        the patient's own. Those still belong to the run, so accept an id that
+        extends an expected one at a separator. "C_0001" must not swallow
+        "C_00011", hence the boundary rather than a bare startswith.
+        """
+        if patient in wanted_ids:
+            return True
+        return any(patient.startswith(w + "_") for w in wanted_ids)
+
+    def buildPauseQueue(self, process_info: dict) -> list:
+        """
+        Build one review item per patient for the step that just finished.
+
+        Args:
+            process_info: Process information dictionary of the finished step
+
+        Returns:
+            list: Review items, each holding a patient's files and its scan
+        """
+        review_folder = process_info.get("ReviewFolder")
+        if not review_folder or not os.path.isdir(review_folder):
+            logger.warning(f"Nothing to review: {review_folder} not found")
+            return []
+
+        editable = process_info.get("ReviewEditable", False)
+        adjustable = process_info.get("ReviewAdjustable", False)
+        if editable:
+            wanted = (".json",)
+        elif adjustable:
+            wanted = self.VOLUME_EXT
+        else:
+            wanted = self.VOLUME_EXT + self.MODEL_EXT
+
+        # Output folders get reused between runs. Without this the review walks
+        # patients this run never processed - "patient 1 of 5" on a batch of
+        # three - and asks the user to check results that are not theirs.
+        # Only what the step just produced is filtered: the scans and matrices
+        # it is judged against are often copied in from earlier, and dropping
+        # those would leave the landmarks with nothing underneath.
+        #
+        # Identity, not file date: a step that skips a patient whose output is
+        # already there leaves that file weeks old, and dating it drops a
+        # patient the run really is processing.
+        # After a rollback only the marked patients were replayed, so they are
+        # the only ones this step is about - the others still hold the results
+        # they were accepted with.
+        expected = self.review_flagged_carry or self.runPatientIds()
+        self.review_flagged_carry = []
+        wanted_ids = set(expected) or None
+
+        # Some steps write several files per scan - BDS writes one surface per
+        # anatomical structure plus a merged one holding them all - and loading
+        # every one buries the view. A step can name what is worth looking at.
+        keep = process_info.get("ReviewNameContains")
+
+        by_patient = {}
+        held_back = {}
+        skipped = set()
+        for root, _, files in os.walk(review_folder):
+            for name in sorted(files):
+                if not name.endswith(wanted):
+                    continue
+                if keep and keep not in name:
+                    continue
+                patient = patientIdFromFileName(name)
+                path = os.path.join(root, name)
+                if wanted_ids is not None and not self.belongsToRun(patient, wanted_ids):
+                    skipped.add(patient)
+                    held_back.setdefault(patient, []).append(path)
+                    continue
+                by_patient.setdefault(patient, []).append(path)
+
+        # A filter that empties the review is worse than one that lets an extra
+        # patient through: the user would be told there is nothing to check and
+        # the run would carry on past a step they asked to inspect. If nothing
+        # survived but files were found, the ids simply do not line up with the
+        # input folder - show them all rather than nothing.
+        if not by_patient and held_back:
+            logger.warning(
+                "None of the files in this step matched the run's patients "
+                f"{sorted(wanted_ids)}; showing all {len(held_back)} found "
+                "instead of skipping the review"
+            )
+            by_patient = held_back
+        elif skipped:
+            logger.info(
+                f"{len(skipped)} patient(s) left out of the review, not part of "
+                f"this run: {sorted(skipped)}"
+            )
+
+        # Landmarks are only editable against the scan they were placed on, so
+        # pair each patient with its oriented volume when the step names one.
+        scans = {}
+        volume_folder = process_info.get("ReviewVolumeFolder")
+        if volume_folder and os.path.isdir(volume_folder):
+            for root, _, files in os.walk(volume_folder):
+                for name in sorted(files):
+                    if name.endswith(self.VOLUME_EXT):
+                        scans.setdefault(
+                            patientIdFromFileName(name), os.path.join(root, name)
+                        )
+
+        # An adjusted registration is only worth anything if its matrix can be
+        # updated too: the landmarks downstream follow the matrix, not the voxels.
+        matrices = {}
+        if adjustable:
+            for root, _, files in os.walk(review_folder):
+                for name in sorted(files):
+                    if name.endswith(".tfm"):
+                        matrices.setdefault(
+                            patientIdFromFileName(name), os.path.join(root, name)
+                        )
+
+        queue = []
+        for patient in sorted(by_patient):
+            if editable and patient not in scans:
+                logger.warning(
+                    f"No scan found for {patient}, its landmarks cannot be reviewed"
+                )
+            if adjustable and patient not in matrices:
+                logger.warning(
+                    f"No registration matrix found for {patient}, its registration "
+                    f"can be looked at but not adjusted"
+                )
+            queue.append(
+                {
+                    "patient": patient,
+                    "files": by_patient[patient],
+                    "volume": scans.get(patient),
+                    "editable": editable,
+                    "adjustable": adjustable and patient in matrices,
+                    "matrix": matrices.get(patient),
+                }
+            )
+
+        logger.info(f"{len(queue)} patient(s) to review after {self.module_name}")
+        return queue
+
+    def enterPauseForReview(self, process_info: dict) -> bool:
+        """
+        Decide whether to pause; the loading itself is left to the event loop.
+
+        Args:
+            process_info: Process information dictionary of the finished step
+
+        Returns:
+            bool: True if the run is now paused and must not advance
+        """
+        if not self.shouldPauseAfterProcess(process_info):
+            return False
+        if not self.ui.checkBox_2.isChecked():
+            return False
+
+        # Reading a volume makes Slicer write to the stdout pipe it only drains
+        # from the Qt event loop. This runs inside a VTK observer callback,
+        # where that loop cannot turn, so doing it here fills the pipe with no
+        # reader and hangs the main thread in write() - the same window that
+        # never comes back as the CLI output above. Hand the work to the event
+        # loop and return at once, exactly as that fix does.
+        self.pause_pending = True
+        qt.QTimer.singleShot(0, self.beginReview)
+        return True
+
+    def beginReview(self) -> None:
+        """Load the finished step's results, once the event loop is turning."""
+        if not self.pause_pending:
+            # cancelled between the callback returning and this firing
+            return
+        self.pause_pending = False
+
+        process_info = self.current_process_info or {}
+        self.pause_queue = self.buildPauseQueue(process_info)
+        self.pause_index = 0
+
+        if not self.pause_queue or not self.showPauseItem():
+            logger.warning(
+                f"Nothing could be loaded to review after {self.module_name}, continuing"
+            )
+            self.onContinueButton()
+            return
+
+        self.paused_for_visualization = True
+        self.ui.continueButton.setVisible(True)
+        self.ui.progressBar.setValue(0)
+        logger.info(f"Process on pause after {self.module_name}.")
+
+    def showPauseItem(self) -> bool:
+        """
+        Load the patient at the current queue position, skipping unloadable ones.
+
+        Returns:
+            bool: True if a patient is now on screen
+        """
+        while self.pause_index < len(self.pause_queue):
+            item = self.pause_queue[self.pause_index]
+            if self.loadPauseItem(item):
+                self.showReviewMessage(item)
+                self.updateReviewButtons()
+                return True
+            logger.warning(f"Nothing to load for {item['patient']}, skipping it")
+            self.pause_index += 1
+        return False
+
+    def showReviewMessage(self, item: dict) -> None:
+        """
+        Say where the run is and what the user may change, in the module panel.
+
+        The console log is not where a clinician looks, and the step counter must
+        stay readable: the pause used to overwrite it with its own text, leaving
+        no sign of how far along the run was.
+
+        Args:
+            item: Review item currently on screen
+        """
+        info = self.current_process_info or {}
+        title = info.get("ReviewTitle") or self.module_name
+        hint = info.get("ReviewHint", "")
+
+        self.ui.label_3.setText(
+            f"Paused at step {self.ActualProcess}/{self.NumberProcess} "
+            f"- {self.module_name}"
+        )
+
+        patient = item["patient"]
+        position = ""
+        if len(self.pause_queue) > 1:
+            position = f" - patient {self.pause_index + 1} of {len(self.pause_queue)}"
+
+        # A registration is adjustable, not editable: testing only the one flag
+        # labelled a step "Review only" while its own hint told the user to drag
+        # it, and the checkbox that armed it said it could be changed.
+        if item.get("editable"):
+            action = "You can move the points"
+        elif item.get("adjustable"):
+            action = "You can drag it into place"
+        else:
+            action = "Review only"
+        self.ui.reviewLabel.setText(
+            f"<b>{title}</b><br/>"
+            f"{patient}{position} &nbsp;·&nbsp; <i>{action}</i><br/>{hint}"
+        )
+        self.ui.reviewLabel.setVisible(True)
+
+        # Moving between patients is what the navigation buttons are for, so
+        # this one says the single thing it does: it ends the pause.
+        self.ui.continueButton.setText(self.CONTINUE_BUTTON_TEXT)
+
+        logger.info(f"Review - {title} - {patient}{position}")
+
+    def loadPauseItem(self, item: dict) -> bool:
+        """
+        Load one patient's result into the scene for review.
+
+        Args:
+            item: Review item built by buildPauseQueue
+
+        Returns:
+            bool: True if anything could be loaded
+        """
+        self.clearPauseNodes()
+        loaded = False
+        reference = None
+
+        if item.get("volume"):
+            reference = self.loadPauseFile(item["volume"])
+            if reference:
+                slicer.util.setSliceViewerLayers(background=reference)
+                loaded = True
+
+        moving = None
+        for path in item["files"]:
+            node = self.loadPauseFile(path)
+            if node:
+                moving = node
+                if not item.get("volume") and path.endswith(self.VOLUME_EXT):
+                    slicer.util.setSliceViewerLayers(background=node)
+                loaded = True
+
+        if loaded and item.get("adjustable") and moving is not None:
+            self.setUpAdjustment(item, reference, moving)
+
+        if loaded:
+            self.applyPauseLayout(item)
+        return loaded
+
+    def setUpAdjustment(self, item: dict, reference, moving) -> None:
+        """
+        Show the registered scan over the original and let the user move it.
+
+        The user drags the scan into place; the matrix that displacement amounts
+        to is what the landmarks need, and it is read back on Continue. Nothing
+        is asked of the user beyond moving the image.
+
+        Args:
+            item: Review item currently on screen
+            reference: The T1 volume node the registration is judged against
+            moving: The registered volume node the user may move
+        """
+        transform = slicer.mrmlScene.AddNewNodeByClass(
+            "vtkMRMLLinearTransformNode", f"{item['patient']} manual adjustment"
+        )
+        moving.SetAndObserveTransformNodeID(transform.GetID())
+        self.pause_nodes.append(transform)
+        self.pause_transform = transform
+        self.pause_transform_item = item
+
+        # Half-opaque over the original is what makes a misalignment visible.
+        if reference is not None:
+            slicer.util.setSliceViewerLayers(
+                background=reference, foreground=moving, foregroundOpacity=0.5
+            )
+        try:
+            display = transform.GetDisplayNode()
+            if display is None:
+                transform.CreateDefaultDisplayNodes()
+                display = transform.GetDisplayNode()
+            if display is not None:
+                display.SetEditorVisibility(True)
+        except Exception as e:
+            logger.warning(f"Could not show the interaction handles: {e}")
+
+    def loadPauseFile(self, path: str):
+        """
+        Load a single review file, dispatching on its type.
+
+        Args:
+            path: File to load
+
+        Returns:
+            The loaded node, or None if it could not be loaded
+        """
+        try:
+            if path.endswith(".json"):
+                node = self.loadEditableMarkups(path)
+            elif path.endswith(self.MODEL_EXT):
+                node = slicer.util.loadModel(path)
+            else:
+                node = slicer.util.loadVolume(path)
+        except Exception as e:
+            logger.error(f"Could not load {path}: {e}")
+            return None
+
+        if node is None:
+            logger.warning(f"Nothing loaded from {path}")
+            return None
+
+        self.pause_nodes.append(node)
+        return node
+
+    def loadEditableMarkups(self, path: str):
+        """
+        Load a landmark file so its points can actually be moved.
+
+        ALI writes every control point with "locked": true and the display
+        hidden, so loading one as-is shows an empty view holding points that
+        cannot be dragged. Both are forced here, on the node only - the file
+        keeps its own flags unless the user edits a position.
+
+        Args:
+            path: Landmark .mrk.json file
+
+        Returns:
+            The loaded markups node, or None
+        """
+        node = slicer.util.loadMarkups(path)
+        if node is None:
+            return None
+
+        node.SetLocked(False)
+        for i in range(node.GetNumberOfControlPoints()):
+            node.SetNthControlPointLocked(i, False)
+
+        display = node.GetDisplayNode()
+        if display:
+            display.SetVisibility(True)
+            display.SetPointLabelsVisibility(True)
+
+        self.pause_markups_nodes.append(node)
+        self.pause_markups_start[node.GetID()] = self.markupsPositions(node)
+        return node
+
+    @staticmethod
+    def markupsPositions(node) -> list:
+        """Control point positions of a markups node, in order."""
+        positions = []
+        for i in range(node.GetNumberOfControlPoints()):
+            position = [0.0, 0.0, 0.0]
+            node.GetNthControlPointPosition(i, position)
+            positions.append(tuple(position))
+        return positions
+
+    def savePauseEdits(self) -> None:
+        """
+        Write back the landmark files whose points the user moved.
+
+        Files left untouched are not rewritten, so a run where the user only
+        looked leaves ALI's output exactly as it was.
+        """
+        for node in self.pause_markups_nodes:
+            storage = node.GetStorageNode()
+            path = storage.GetFileName() if storage else None
+            if not path:
+                logger.warning(f"No file to save {node.GetName()} back to")
+                continue
+
+            before = self.pause_markups_start.get(node.GetID())
+            after = self.markupsPositions(node)
+            if before == after:
+                logger.info(f"{os.path.basename(path)} unchanged, not rewritten")
+                continue
+
+            moved = sum(1 for a, b in zip(before, after) if a != b)
+            try:
+                if slicer.util.saveNode(node, path):
+                    logger.info(f"{moved} landmark(s) adjusted, saved to {path}")
+                else:
+                    logger.error(f"Could not save adjusted landmarks to {path}")
+            except Exception as e:
+                logger.error(f"Could not save adjusted landmarks to {path}: {e}")
+
+        self.saveAdjustedRegistration()
+
+    def saveAdjustedRegistration(self) -> None:
+        """
+        Fold the user's displacement into the registration it corrects.
+
+        AutoMatrix applies one matrix per patient and per structure downstream,
+        and it cannot chain two. Composing here keeps that contract: the file it
+        already reads now carries the registration and the correction together,
+        so nothing after this step has to know an adjustment happened.
+        """
+        transform = self.pause_transform
+        item = self.pause_transform_item
+        if transform is None or not item or not item.get("matrix"):
+            return
+
+        matrix = vtk.vtkMatrix4x4()
+        transform.GetMatrixTransformToParent(matrix)
+        if self.isIdentityMatrix(matrix):
+            logger.info(f"{item['patient']}: registration left as AREG produced it")
+            return
+
+        import numpy as np
+        import SimpleITK as sitk
+
+        path = item["matrix"]
+        try:
+            areg = sitk.ReadTransform(path)
+        except Exception as e:
+            logger.error(f"Could not read {os.path.basename(path)}: {e}")
+            return
+
+        ras = np.array([[matrix.GetElement(r, c) for c in range(4)] for r in range(4)])
+        # Slicer holds the displacement in RAS; a .tfm is LPS, and the two differ
+        # by a flip of the first two axes.
+        flip = np.diag([-1.0, -1.0, 1.0, 1.0])
+        lps = flip @ ras @ flip
+
+        nudge = sitk.AffineTransform(3)
+        nudge.SetMatrix(lps[:3, :3].flatten().tolist())
+        nudge.SetTranslation(lps[:3, 3].tolist())
+
+        # Verified against applying the two in sequence: AutoMatrix inverts the
+        # matrix before moving a point, and this is the order that survives it.
+        composed = sitk.CompositeTransform([areg, nudge.GetInverse()])
+
+        try:
+            sitk.WriteTransform(composed, path)
+            logger.info(f"{item['patient']}: adjustment folded into {os.path.basename(path)}")
+        except Exception as e:
+            logger.error(f"Could not write the adjusted matrix to {path}: {e}")
+            return
+
+        self.saveAdjustedVolume(item, transform)
+
+    def saveAdjustedVolume(self, item: dict, transform) -> None:
+        """
+        Write the moved scan back, so the surfaces and heatmaps match the matrix.
+
+        Args:
+            item: Review item currently on screen
+            transform: The transform node holding the user's displacement
+        """
+        for node in self.pause_nodes:
+            if not node.IsA("vtkMRMLScalarVolumeNode"):
+                continue
+            if node.GetTransformNodeID() != transform.GetID():
+                continue
+            storage = node.GetStorageNode()
+            path = storage.GetFileName() if storage else None
+            if not path:
+                continue
+            try:
+                node.HardenTransform()
+                if slicer.util.saveNode(node, path):
+                    logger.info(f"{item['patient']}: adjusted scan saved to {os.path.basename(path)}")
+                else:
+                    logger.error(f"Could not save the adjusted scan to {path}")
+            except Exception as e:
+                logger.error(f"Could not save the adjusted scan to {path}: {e}")
+            return
+
+    @staticmethod
+    def isIdentityMatrix(matrix, tolerance: float = 1e-9) -> bool:
+        """
+        Tell whether a 4x4 holds no displacement at all.
+
+        Args:
+            matrix: vtkMatrix4x4 to test
+            tolerance: Largest deviation still counted as identity
+
+        Returns:
+            bool: True if the matrix is the identity within tolerance
+        """
+        for row in range(4):
+            for col in range(4):
+                expected = 1.0 if row == col else 0.0
+                if abs(matrix.GetElement(row, col) - expected) > tolerance:
+                    return False
+        return True
+
+    def clearPauseNodes(self) -> None:
+        """Remove the nodes the previous review item put in the scene."""
+        for node in self.pause_nodes:
+            try:
+                slicer.mrmlScene.RemoveNode(node)
+            except Exception as e:
+                logger.warning(f"Could not remove a reviewed node from the scene: {e}")
+        self.pause_nodes = []
+        self.pause_markups_nodes = []
+        self.pause_markups_start = {}
+        self.pause_transform = None
+        self.pause_transform_item = None
+
+    def showDoneMessage(self) -> None:
+        """Say the run is over without taking the application hostage.
+
+        Nothing waits on this answer, so it is shown rather than executed: a
+        modal dialog that fails to appear leaves the user with no way to click
+        anything, and that is exactly what a finished run must not do.
+        """
+        self.done_popup = PopUpWindow(
+            title="Process Complete", text="Processing completed successfully!"
+        )
+        self.done_popup.setModal(False)
+        self.done_popup.show()
+        self.done_popup.raise_()
+
+    def previousCorrectableStep(self):
+        """The nearest step behind this one the user can actually change.
+
+        Looking at a bad orientation is useless without a way back to the
+        landmarks that caused it. Steps that can only ever be looked at are
+        skipped over, so the button lands where something can be done.
+
+        Returns:
+            tuple: (step, steps to replay after it), or (None, []) when there is
+                nothing correctable behind the current one
+        """
+        current = self.current_process_info
+        history = self.executed_steps
+        # By identity, not equality: two runs of the same step carry equal
+        # dictionaries, and the one meant here is the one on screen.
+        here = None
+        for i in range(len(history) - 1, -1, -1):
+            if history[i] is current:
+                here = i
+                break
+        if here is None:
+            return None, []
+
+        for i in range(here - 1, -1, -1):
+            kind = review_steps.describe(history[i].get("ReviewId", "")).get("kind")
+            if kind in (review_steps.LANDMARKS, review_steps.REGISTRATION):
+                return history[i], history[i + 1:here + 1]
+        return None, []
+
+    def flaggedPatients(self) -> list:
+        """The marked patients, in the order the queue shows them."""
+        return [i["patient"] for i in self.pause_queue
+                if i["patient"] in self.review_flagged]
+
+    def updateReviewButtons(self) -> None:
+        """Show the actions this patient, and this step, actually allow.
+
+        Each button does one thing and says so: moving between patients never
+        advances the run, and going back never hides behind a forward label.
+        """
+        total = len(self.pause_queue)
+        index = self.pause_index
+        patient = self.pause_queue[index]["patient"] if total else ""
+
+        self.ui.reviewPatientLabel.setVisible(bool(patient))
+        self.ui.reviewPatientLabel.setText(
+            f"<b>{patient}</b>"
+            + (f" &nbsp;({index + 1} / {total})" if total > 1 else "")
+        )
+
+        self.ui.reviewPrevPatientButton.setVisible(total > 1)
+        self.ui.reviewPrevPatientButton.setEnabled(index > 0)
+        self.ui.reviewNextPatientButton.setVisible(total > 1)
+        self.ui.reviewNextPatientButton.setEnabled(index < total - 1)
+
+        # Marking is only worth offering when there is somewhere to go back to.
+        target, _ = self.previousCorrectableStep()
+        self.ui.reviewFlagButton.setVisible(target is not None)
+        if patient in self.review_flagged:
+            self.ui.reviewFlagButton.setText("Cancel - this patient is fine")
+        else:
+            self.ui.reviewFlagButton.setText("Go back and edit this patient")
+
+        flagged = self.flaggedPatients()
+        self.ui.reviewGoBackButton.setVisible(bool(flagged) and target is not None)
+        if flagged and target is not None:
+            name = review_steps.describe(target.get("ReviewId", "")).get(
+                "label", "the previous step")
+            self.ui.reviewGoBackButton.setText(
+                f"Go back to {name} for {len(flagged)} patient(s)"
+            )
+
+    def onReviewPreviousPatient(self) -> None:
+        """Show the patient before this one, keeping any edit made here."""
+        if self.pause_index > 0:
+            self.savePauseEdits()
+            self.pause_index -= 1
+            self.showPauseItem()
+
+    def onReviewNextPatient(self) -> None:
+        """Show the next patient of this step, keeping any edit made here."""
+        if self.pause_index < len(self.pause_queue) - 1:
+            self.savePauseEdits()
+            self.pause_index += 1
+            self.showPauseItem()
+
+    def onReviewToggleFlag(self) -> None:
+        """Mark this patient for rework, or take the mark back."""
+        if not self.pause_queue:
+            return
+        patient = self.pause_queue[self.pause_index]["patient"]
+        if patient in self.review_flagged:
+            self.review_flagged.discard(patient)
+            logger.info(f"{patient}: mark removed")
+        else:
+            self.review_flagged.add(patient)
+            logger.info(f"{patient}: marked for rework")
+        self.updateReviewButtons()
+
+    def onReviewGoBack(self) -> None:
+        """Return to the last correctable step, for the patients marked there.
+
+        Correcting the landmarks changes nothing on its own - the orientation
+        was computed from the old ones. So the steps in between are queued to
+        run again, narrowed to the marked patients: the rest of the batch keeps
+        the results it already has, and a run of fifty does not start over
+        because one case was wrong.
+        """
+        target, replay = self.previousCorrectableStep()
+        if target is None:
+            logger.warning("Nothing correctable behind this step")
+            return
+
+        flagged = self.flaggedPatients()
+        if not flagged:
+            logger.warning("No patient marked for rework")
+            return
+
+        name = review_steps.describe(target.get("ReviewId", "")).get(
+            "label", target.get("Module"))
+        logger.info(
+            f"Going back to '{name}' for {flagged}; "
+            f"{len(replay)} step(s) will run again for them"
+        )
+
+        narrowed = []
+        for step in replay:
+            restricted, folders = review_steps.restrictStepToPatients(step, flagged)
+            self.review_temp_folders.extend(folders)
+            narrowed.append(restricted)
+
+        self.resetPauseState()
+
+        # The steps between the two run again, ahead of whatever was left, and
+        # the user lands back on the step they can actually fix.
+        self.list_process[0:0] = narrowed
+        self.NumberProcess += len(narrowed)
+        self.review_flagged_carry = list(flagged)
+        self.current_process_info = target
+        self.module_name = target.get("Module", self.module_name)
+        # beginReview guards against a pause cancelled between the callback and
+        # the event loop; this one comes from a button, so it is armed here.
+        self.pause_pending = True
+        self.beginReview()
+
+    def clearReviewTempFolders(self) -> None:
+        """Drop the temporary folders a narrowed replay left behind."""
+        for folder in self.review_temp_folders:
+            try:
+                shutil.rmtree(folder, ignore_errors=True)
+            except OSError as e:
+                logger.warning(f"Could not remove {folder}: {e}")
+        self.review_temp_folders = []
+
+    def resetPauseState(self) -> None:
+        """Drop everything held for the review in progress."""
+        self.pause_pending = False
+        self.clearPauseNodes()
+        self.ui.reviewLabel.setVisible(False)
+        self.ui.reviewLabel.setText("")
+        self.ui.continueButton.setText(self.CONTINUE_BUTTON_TEXT)
+        for name in ("reviewPatientLabel", "reviewPrevPatientButton",
+                     "reviewNextPatientButton", "reviewFlagButton",
+                     "reviewGoBackButton"):
+            getattr(self.ui, name).setVisible(False)
+        self.pause_queue = []
+        self.pause_index = 0
+        self.review_flagged = set()
+        self.paused_for_visualization = False
+
+    def applyPauseLayout(self, item: dict) -> None:
+        """
+        Set a layout suited to what is being reviewed.
+
+        Args:
+            item: Review item currently on screen
+        """
+        layoutManager = slicer.app.layoutManager()
+        surfaces_only = not item.get("volume") and all(
+            f.endswith(self.MODEL_EXT) for f in item["files"]
+        )
+
+        if surfaces_only:
+            layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
+            widget = layoutManager.threeDWidget(0)
+            if widget:
+                widget.threeDView().resetFocalPoint()
+        else:
+            layoutManager.setLayout(slicer.vtkMRMLLayoutNode.SlicerLayoutFourUpView)
+            slicer.util.resetSliceViews()
 
     def executeProcess(self, process_info):
         import time
@@ -1317,6 +2411,8 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.module_name = process_info["Module"]
         self.displayModule = process_info["Display"]
         self.current_process_info = process_info  # Stocker les infos du processus actuel
+        # Kept in order: going back means finding what ran before this step.
+        self.executed_steps.append(process_info)
         
         process = process_info["Process"]
         parameters = process_info["Parameter"]
@@ -1341,7 +2437,16 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             self.addObserver(self.cliNode, vtk.vtkCommand.ModifiedEvent, self.onCliUpdated)
         else:
             logger.info(f"{self.module_name} is executed.")
-            self.ui.label_3.setText(f"Process : {self.module_name} ({self.ActualProcess}/{self.NumberProcess})")
+            # A python step holds the event loop for its whole duration, so this
+            # is the last thing drawn until it returns and the window stops
+            # repainting meanwhile. Say so, or a segmentation that legitimately
+            # takes minutes is indistinguishable from a freeze.
+            self.ui.label_3.setText(
+                f"Process : {self.module_name} "
+                f"({self.ActualProcess}/{self.NumberProcess}) - running, "
+                f"the window stays still until it finishes"
+            )
+            slicer.app.processEvents()
 
             # No CLI is running during a Python step: forget the previous node so
             # a late event from it cannot advance the chain from under our feet.
@@ -1358,26 +2463,137 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
     def startPythonProcess(self):
         """Start a Python process"""
+        import time
+
+        started = time.time()
+        log_path = None
         try:
             if callable(self.python_process):
-                # Execute the process
-                result = self.python_process(**self.python_parameters)
-                logger.info(f"Result of {self.module_name}: {result}")
+                with self.outputToFile() as log_path:
+                    result = self.python_process(**self.python_parameters)
+                logger.info(
+                    f"Result of {self.module_name}: {result} "
+                    f"(in {self.readableDuration(time.time() - started)})"
+                )
                 self.python_process_completed = True
             else:
                 logger.error(f"Error: {self.python_process} is not a callable function")
                 self.python_process_error = "Process is not callable"
                 self.python_process_completed = True
-                
+
         except Exception as e:
             logger.error(f"Error during the execution of {self.module_name}: {e}")
             import traceback
             traceback.print_exc()
             self.python_process_error = str(e)
             self.python_process_completed = True
-        
+
+        finally:
+            # A step that raised still wrote to the file, and its last lines are
+            # exactly the ones worth seeing; reporting here also stops the
+            # temporary file leaking on that path.
+            if log_path:
+                self._reportStepOutput(log_path)
+
         import qt
         qt.QTimer.singleShot(100, self.checkPythonProcessStatus)
+
+    @contextlib.contextmanager
+    def outputToFile(self):
+        """
+        Send everything a step prints to a file instead of Slicer's own pipe.
+
+        Slicer captures its standard output into a pipe it drains from the Qt
+        event loop. A python step runs with that loop stopped, so nothing drains
+        the pipe while it prints: a talkative one - the segmentation prints per
+        epoch - fills it and the main thread blocks in write() for ever, with a
+        window that never comes back. Writing to a file cannot block, which is
+        why the heatmap workers already do this.
+
+        The redirection is at file-descriptor level on purpose: torch and the
+        segmentation write from C, straight to fd 1, where swapping sys.stdout
+        would not catch them.
+
+        Yields:
+            str: path of the file the step's output was written to
+        """
+        handle = tempfile.NamedTemporaryFile(
+            mode="w+", suffix=".log", prefix="vface_step_", delete=False
+        )
+        saved_out, saved_err = None, None
+        saved_sys_out, saved_sys_err = sys.stdout, sys.stderr
+        try:
+            for stream in (sys.stdout, sys.stderr):
+                try:
+                    stream.flush()
+                except Exception:
+                    pass
+            saved_out = os.dup(1)
+            saved_err = os.dup(2)
+            os.dup2(handle.fileno(), 1)
+            os.dup2(handle.fileno(), 2)
+            sys.stdout, sys.stderr = handle, handle
+            yield handle.name
+        finally:
+            sys.stdout, sys.stderr = saved_sys_out, saved_sys_err
+            try:
+                handle.flush()
+            except Exception:
+                pass
+            if saved_out is not None:
+                os.dup2(saved_out, 1)
+                os.close(saved_out)
+            if saved_err is not None:
+                os.dup2(saved_err, 2)
+                os.close(saved_err)
+            try:
+                handle.close()
+            except Exception:
+                pass
+
+    def _reportStepOutput(self, log_path: str, keep_lines: int = 12) -> None:
+        """
+        Put the tail of a step's own output back in the log, and drop the file.
+
+        Args:
+            log_path: File the step's output was redirected to
+            keep_lines: How many trailing lines to bring back
+        """
+        try:
+            with open(log_path, encoding="utf-8", errors="replace") as f:
+                lines = [line.rstrip() for line in f if line.strip()]
+        except OSError:
+            return
+        finally:
+            try:
+                os.remove(log_path)
+            except OSError:
+                pass
+
+        if not lines:
+            return
+        shown = lines[-keep_lines:]
+        skipped = len(lines) - len(shown)
+        prefix = f"[{skipped} earlier line(s) not shown]\n" if skipped else ""
+        logger.info(f"{self.module_name} said:\n{prefix}" + "\n".join(shown))
+
+    @staticmethod
+    def readableDuration(seconds: float) -> str:
+        """
+        Spell out a duration the way the CLI steps already report theirs.
+
+        Args:
+            seconds: Elapsed seconds
+
+        Returns:
+            str: Human readable duration
+        """
+        seconds = int(seconds)
+        if seconds < 60:
+            return f"{seconds}s"
+        if seconds < 3600:
+            return f"{seconds // 60}min and {seconds % 60}s"
+        return f"{seconds // 3600}h, {seconds % 3600 // 60}min and {seconds % 60}s"
 
     def checkPythonProcessStatus(self):
         """Check Python process status"""
@@ -1390,16 +2606,8 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
     def onProcessCompleted(self):
         logger.info("\n\n ========= PROCESSED ========= \n")
 
-        if self.shouldPauseAfterProcess(self.current_process_info) and self.ui.checkBox_2.isChecked():
-            output_path = self.getOutputPathForModule(self.module_name)
-            if output_path:
-                if self.loadOutputInSlicer(output_path):
-                    self.paused_for_visualization = True
-                    self.current_output_to_load = output_path
-                    self.ui.continueButton.setVisible(True)
-                    self.ui.label_3.setText(f"Result of {self.module_name} loaded - Click on Continue to start next steps")
-                    logger.info(f"Process on pause after {self.module_name}. Result loaded.")
-                    return
+        if self.enterPauseForReview(self.current_process_info):
+            return
 
         try:
             self.executeProcess(self.list_process[0])
@@ -1463,17 +2671,8 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 0, lambda: logger.info(f"\n\n ========= PROCESSED ========= \n{cli_output}")
             )
             
-            if self.shouldPauseAfterProcess(self.current_process_info) and self.ui.checkBox_2.isChecked():
-                output_path = self.getOutputPathForModule(self.module_name)
-                if output_path:
-                    if self.loadOutputInSlicer(output_path):
-                        self.paused_for_visualization = True
-                        self.current_output_to_load = output_path
-                        self.ui.continueButton.setVisible(True)
-                        self.ui.label_3.setText(f"Result of {self.module_name} loaded - Click on Continue to start next steps")
-                        logger.info(f"Process on pause after {self.module_name}. Result loaded.")
-                        self.ui.progressBar.setValue(0)
-                        return
+            if self.enterPauseForReview(self.current_process_info):
+                return
             
             try:
                 # Run next process
@@ -1528,17 +2727,20 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         logger.info(f"PROCESS COMPLETED in {timer}")
 
+        # The narrowed replays are only links into the real output; once the run
+        # is over they say nothing and would pile up run after run.
+        self.clearReviewTempFolders()
+
         self.ui.label_3.setVisible(False)
         self.ui.progressBar.setVisible(False)
         self.ui.continueButton.setVisible(False)
         self.ui.cancelButton.setVisible(False)
         self.ui.CheckDependencyButton.enabled = True
-        self.paused_for_visualization = False
+        self.resetPauseState()
         self.ActualProcess = 1
         self.NumberProcess = 0
         self.cliNode = None
         self.list_process = []
-        self.current_output_to_load = None
         self.current_process_info = None
 
         self._checkCanApply()
@@ -1571,12 +2773,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # nested event loop while the CLI node is still dispatching events, and
         # the modal grab can leave the whole desktop session unresponsive, not
         # just Slicer. Same fix as AREG: defer it so the callback returns first.
-        qt.QTimer.singleShot(
-            0,
-            lambda: PopUpWindow(
-                title="Process Complete", text="Processing completed successfully!"
-            ).exec_(),
-        )
+        qt.QTimer.singleShot(0, self.showDoneMessage)
             
             
             

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2464,9 +2464,13 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if shown:
             try:
+                # The 3D view, because a surface map is unreadable on slices -
+                # but the module panel stays on VFACE. Switching to Models here
+                # would move the clinician away at the exact moment the run ends,
+                # hiding the end-of-run message and the buttons. The message
+                # points at Models for anyone who wants to go further.
                 slicer.app.layoutManager().setLayout(
                     slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
-                slicer.util.selectModule("Models")
                 slicer.util.resetThreeDViews()
             except Exception as e:
                 logger.warning(f"Heatmaps loaded but the view could not be set: {e}")
@@ -2497,10 +2501,11 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             text = "Processing completed successfully!"
         if shown:
             text += (
-                f"\n\n{shown} distance map(s) are on screen, coloured from the "
-                "surface's own range. Use <b>Models</b> to change the colours or "
-                "hide one."
-            ).replace("<b>", "").replace("</b>", "")
+                f"\n\n{shown} distance map(s) are on screen in the 3D view, "
+                "coloured by signed distance around zero.\n"
+                "Open the Models module to look closer - colour scale, range, "
+                "or hiding a surface."
+            )
 
         self.done_popup = PopUpWindow(title="Process Complete", text=text)
         self.done_popup.setModal(False)

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2032,8 +2032,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             tools = ("Open <b>Markups</b> to pick a point from the list, and "
                      "<b>Volume Rendering</b> to change how the bone is shown.")
         elif item.get("adjustable"):
-            tools = ("Drag the scan in a slice view. <b>Volume Rendering</b> "
-                     "changes how the bone is shown.")
+            tools = ("Drag the scan in a slice view. <b>Transforms</b> shows the "
+                     "displacement you are applying, in numbers; "
+                     "<b>Volume Rendering</b> changes how the bone is shown.")
         else:
             tools = "<b>Models</b> and <b>Volume Rendering</b> change how this is shown."
 
@@ -2305,7 +2306,15 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         # Verified against applying the two in sequence: AutoMatrix inverts the
         # matrix before moving a point, and this is the order that survives it.
+        # CompositeTransform([A, B]) applies A(B(p)) - the last added acts first.
         composed = sitk.CompositeTransform([areg, nudge.GetInverse()])
+
+        # Written as one matrix whenever both are affine, which is the normal
+        # case. A composite .tfm is valid and AutoMatrix does read it, but it
+        # leaves two matrices in a file every other tool expects to hold one, and
+        # a second manual correction would stack a third. The product is exactly
+        # equivalent - checked point by point - so there is nothing to lose.
+        composed = self.flattenIfAffine(composed, areg, nudge.GetInverse())
 
         try:
             sitk.WriteTransform(composed, path)
@@ -2315,6 +2324,47 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             return
 
         self.saveAdjustedVolume(item, transform)
+
+    @staticmethod
+    def flattenIfAffine(composite, first, second):
+        """One matrix instead of two, when both parts are affine.
+
+        CompositeTransform([A, B]) moves a point as A(B(p)), which is the product
+        of their matrices. Collapsing keeps the file to a single transform, so
+        nothing downstream has to know an adjustment happened - which is what the
+        pipeline assumed all along.
+
+        Returns the composite untouched if either part is not affine: correctness
+        first, tidiness second.
+
+        Args:
+            composite: The composed transform, returned as-is on any doubt
+            first: Transform applied second to a point
+            second: Transform applied first to a point
+
+        Returns:
+            A single AffineTransform, or the composite unchanged
+        """
+        import numpy as np
+        import SimpleITK as sitk
+
+        def as_matrix(t):
+            affine = sitk.AffineTransform(t)      # raises unless truly affine
+            m = np.eye(4)
+            m[:3, :3] = np.array(affine.GetMatrix()).reshape(3, 3)
+            m[:3, 3] = affine.GetTranslation()
+            return m
+
+        try:
+            product = as_matrix(first) @ as_matrix(second)
+        except Exception as e:
+            logger.info(f"Keeping a composite transform, not both parts are affine: {e}")
+            return composite
+
+        flat = sitk.AffineTransform(3)
+        flat.SetMatrix(product[:3, :3].flatten().tolist())
+        flat.SetTranslation(product[:3, 3].tolist())
+        return flat
 
     def saveAdjustedVolume(self, item: dict, transform) -> None:
         """
@@ -2425,12 +2475,15 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         if not os.path.isdir(folder):
             return 0
 
-        files = sorted(glob.glob(os.path.join(folder, "*merged*ModelDistance.vtk")))
-        if not files:
-            files = sorted(glob.glob(os.path.join(folder, "*.vtk")))
+        files = sorted(glob.glob(os.path.join(folder, "*.vtk")))
         if not files:
             logger.info("No heatmap to show")
             return 0
+        # All of them are loaded and coloured, so a tick in Models is enough to
+        # see one. Only the merged map starts visible: the per-structure maps
+        # cover the same anatomy, and showing them at once would stack surfaces
+        # on top of each other until none is readable.
+        merged = [f for f in files if "merged" in os.path.basename(f).lower()]
 
         # Rainbow reads as a map; if this build ships the cold-to-hot variant,
         # its ends are clearer for signed data.
@@ -2440,7 +2493,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             if table is not None:
                 break
 
-        shown = 0
+        shown, loaded = 0, 0
         for path in files:
             try:
                 model = slicer.util.loadModel(path)
@@ -2458,8 +2511,12 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     if table is not None:
                         display.SetAndObserveColorNodeID(table.GetID())
                     display.SetScalarVisibility(True)
-                    self.addColorLegend(display)
-                shown += 1
+                    on = (not merged) or (path in merged)
+                    display.SetVisibility(on)
+                    if on:
+                        self.addColorLegend(display)
+                        shown += 1
+                loaded += 1
             except Exception as e:
                 logger.warning(f"Could not show {os.path.basename(path)}: {e}")
 
@@ -2483,9 +2540,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 f"<b>Distance maps</b><br/>"
                 f"{shown} map(s) in the 3D view, coloured by signed distance "
                 "around zero; the scale beside them is in millimetres."
-                "<br/><span style='color:#7f8c8d'>Open <b>Models</b> to change "
-                "the colours or the range, or to hide a surface. The maps VFACE "
-                "did not open are in the Heatmaps folder.</span>"
+                f"<br/><span style='color:#7f8c8d'>{loaded} map(s) loaded in all: "
+                "tick one in <b>Models</b> to show it, where you can also change "
+                "the colours or the range.</span>"
             )
             self.ui.reviewLabel.setVisible(True)
             logger.info(f"{shown} heatmap(s) on screen, coloured by signed distance")

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2760,7 +2760,18 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 files_to_keep.append("Classification")
 
             try:
-                output_path = Path(self._parameterNode.OutputFolder)
+                # Path("") is Path("."), and iterdir() would then walk whatever
+                # directory Slicer happens to be running from, deleting every
+                # sub-folder in it and leaving the files - which is how a run
+                # with no output folder set can empty a source tree. Nothing is
+                # cleaned unless the folder is an absolute path that exists.
+                output = (self._parameterNode.OutputFolder or "").strip()
+                if not output or not os.path.isabs(output) or not os.path.isdir(output):
+                    raise ValueError(
+                        f"output folder {output!r} is not an absolute existing "
+                        "directory; nothing cleaned"
+                    )
+                output_path = Path(output)
                 for item in output_path.iterdir():
                     if item.is_dir() and item.name not in files_to_keep:
                         shutil.rmtree(item)

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2495,7 +2495,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             if table is not None:
                 break
 
-        shown, loaded = 0, 0
+        shown, loaded, spans = 0, 0, []
         for path in files:
             try:
                 model = slicer.util.loadModel(path)
@@ -2520,6 +2520,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     # surface with no scale, and its range can be ten times
                     # smaller than the merged map's.
                     self.addColorLegend(display)
+                    spans.append((os.path.basename(path).replace("_ModelDistance.vtk", ""), edge))
                     if on:
                         shown += 1
                 loaded += 1
@@ -2542,17 +2543,45 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             # dismissed and leaves nothing behind, so a clinician looking at a
             # coloured skull a minute later has no clue what to do with it. The
             # explanatory box is where every other instruction has appeared.
+            # The same numbers in the panel, out of the 3D view: with several maps
+            # shown the bars compete for the same corner, and a written range is
+            # readable whatever is on screen.
+            ranges = "<br/>".join(
+                f"&nbsp;&nbsp;{name} &nbsp;<b>&plusmn;{edge:.1f} mm</b>"
+                for name, edge in sorted(spans)
+            )
             self.ui.reviewLabel.setText(
                 f"<b>Distance maps</b><br/>"
                 f"{shown} map(s) in the 3D view, coloured by signed distance "
                 "around zero; the scale beside them is in millimetres."
+                f"<br/>{ranges}"
                 f"<br/><span style='color:#7f8c8d'>{loaded} map(s) loaded in all: "
                 "tick one in <b>Models</b> to show it, where you can also change "
                 "the colours or the range.</span>"
             )
+            self.layoutLegends()
             self.ui.reviewLabel.setVisible(True)
             logger.info(f"{shown} heatmap(s) on screen, coloured by signed distance")
         return shown
+
+    def layoutLegends(self) -> None:
+        """Spread the visible scales across the view instead of stacking them.
+
+        Every colour legend is created at the same spot, (0.95, 0.5), so showing
+        three maps at once puts three bars exactly on top of each other. Each
+        visible one gets its own column, right to left, in the order the maps
+        were loaded.
+        """
+        visible = [legend for display, legend in self.legend_pairs
+                   if display.GetVisibility()]
+        for i, legend in enumerate(visible):
+            try:
+                legend.SetSize(0.13, 0.45)
+                # 0.16 apart for a bar 0.13 wide: they sit side by side without
+                # touching, and three still fit inside the view.
+                legend.SetPosition(max(0.05, 0.95 - 0.16 * i), 0.5)
+            except Exception as e:
+                logger.warning(f"Could not place a colour scale: {e}")
 
     def onHeatmapVisibilityChanged(self, caller, event) -> None:
         """Keep each scale with the surface it describes.
@@ -2564,6 +2593,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for display, legend in self.legend_pairs:
             if display is caller:
                 legend.SetVisibility(bool(display.GetVisibility()))
+                self.layoutLegends()
                 return
 
     def addColorLegend(self, display) -> None:

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -809,7 +809,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Apply standard style to most buttons
         for buttonName in ['applyButton', 'CheckDependencyButton', 'continueButton',
                            'DefaultListButton', 'TestFilesButton',
-                           'reviewSelectAllButton', 'reviewSelectNoneButton']:
+                           'reviewSelectAllButton', 'reviewSelectNoneButton',
+                           'reviewPrevPatientButton', 'reviewNextPatientButton',
+                           'reviewFlagButton', 'reviewGoBackButton']:
             if hasattr(self.ui, buttonName):
                 button = getattr(self.ui, buttonName)
                 button.setStyleSheet(standardButtonStyle)

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -2458,6 +2458,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     if table is not None:
                         display.SetAndObserveColorNodeID(table.GetID())
                     display.SetScalarVisibility(True)
+                    self.addColorLegend(display)
                 shown += 1
             except Exception as e:
                 logger.warning(f"Could not show {os.path.basename(path)}: {e}")
@@ -2474,8 +2475,42 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 slicer.util.resetThreeDViews()
             except Exception as e:
                 logger.warning(f"Heatmaps loaded but the view could not be set: {e}")
+            # In the panel, not only in the end-of-run dialog: that dialog is
+            # dismissed and leaves nothing behind, so a clinician looking at a
+            # coloured skull a minute later has no clue what to do with it. The
+            # explanatory box is where every other instruction has appeared.
+            self.ui.reviewLabel.setText(
+                f"<b>Distance maps</b><br/>"
+                f"{shown} map(s) in the 3D view, coloured by signed distance "
+                "around zero; the scale beside them is in millimetres."
+                "<br/><span style='color:#7f8c8d'>Open <b>Models</b> to change "
+                "the colours or the range, or to hide a surface. The maps VFACE "
+                "did not open are in the Heatmaps folder.</span>"
+            )
+            self.ui.reviewLabel.setVisible(True)
             logger.info(f"{shown} heatmap(s) on screen, coloured by signed distance")
         return shown
+
+    @staticmethod
+    def addColorLegend(display) -> None:
+        """Put a scale next to the map, so the colours mean a distance.
+
+        Without it a gradient says nothing: the merged map of a case runs to
+        +/-32 mm while its mandible alone stays under +/-3 mm, and the two look
+        identical. Best effort - an older Slicer without colour legends still
+        shows the map, just without its scale.
+
+        Args:
+            display: The model display node whose scalars are already visible
+        """
+        try:
+            logic = slicer.modules.colors.logic()
+            legend = logic.AddDefaultColorLegendDisplayNode(display)
+            if legend is not None:
+                legend.SetTitleText("Distance (mm)")
+                legend.SetVisibility(True)
+        except Exception as e:
+            logger.warning(f"No colour legend on this build: {e}")
 
     def showDoneMessage(self) -> None:
         """Say the run is over without taking the application hostage.

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -336,6 +336,8 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # {landmark: [scans it was missed on, scans tried]}, filled from the
         # summary ALI prints when a run ends.
         self.missing_landmarks = {}
+        # (display node, its colour legend) so one follows the other's visibility
+        self.legend_pairs = []
         self.executed_steps = []
         self.review_flagged_carry = []
         self.review_temp_folders = []
@@ -2513,8 +2515,12 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     display.SetScalarVisibility(True)
                     on = (not merged) or (path in merged)
                     display.SetVisibility(on)
+                    # A legend on every map, not only the visible one: ticking a
+                    # hidden map in Models would otherwise show a coloured
+                    # surface with no scale, and its range can be ten times
+                    # smaller than the merged map's.
+                    self.addColorLegend(display)
                     if on:
-                        self.addColorLegend(display)
                         shown += 1
                 loaded += 1
             except Exception as e:
@@ -2548,8 +2554,19 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             logger.info(f"{shown} heatmap(s) on screen, coloured by signed distance")
         return shown
 
-    @staticmethod
-    def addColorLegend(display) -> None:
+    def onHeatmapVisibilityChanged(self, caller, event) -> None:
+        """Keep each scale with the surface it describes.
+
+        Args:
+            caller: The model display node that changed
+            event: Unused, required by the observer signature
+        """
+        for display, legend in self.legend_pairs:
+            if display is caller:
+                legend.SetVisibility(bool(display.GetVisibility()))
+                return
+
+    def addColorLegend(self, display) -> None:
         """Put a scale next to the map, so the colours mean a distance.
 
         Without it a gradient says nothing: the merged map of a case runs to
@@ -2563,9 +2580,16 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         try:
             logic = slicer.modules.colors.logic()
             legend = logic.AddDefaultColorLegendDisplayNode(display)
-            if legend is not None:
-                legend.SetTitleText("Distance (mm)")
-                legend.SetVisibility(True)
+            if legend is None:
+                return
+            legend.SetTitleText("Distance (mm)")
+            legend.SetVisibility(bool(display.GetVisibility()))
+            # A legend does not follow its surface on its own - measured: hiding
+            # the model leaves its scale on screen. Without this, loading three
+            # maps would stack three bars over each other for good.
+            self.legend_pairs.append((display, legend))
+            self.addObserver(display, vtk.vtkCommand.ModifiedEvent,
+                             self.onHeatmapVisibilityChanged)
         except Exception as e:
             logger.warning(f"No colour legend on this build: {e}")
 

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import glob
 import os
 import re
 import stat
@@ -866,6 +867,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         for buttonName in ['applyButton', 'CheckDependencyButton', 'continueButton',
                            'DefaultListButton', 'TestFilesButton',
                            'reviewSelectAllButton', 'reviewSelectNoneButton',
+                           'reviewSelectRecommendedButton',
                            'reviewPrevPatientButton', 'reviewNextPatientButton',
                            'reviewFlagButton', 'reviewGoBackButton']:
             if hasattr(self.ui, buttonName):
@@ -1611,6 +1613,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.checkBox_2.connect("toggled(bool)", self.onReviewEnableToggled)
         self.ui.reviewSelectAllButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(True))
         self.ui.reviewSelectNoneButton.connect("clicked(bool)", lambda: self.setAllReviewSteps(False))
+        self.ui.reviewSelectRecommendedButton.connect("clicked(bool)", self.setRecommendedReviewSteps)
         self.onReviewEnableToggled(self.ui.checkBox_2.isChecked())
         self.rebuildReviewSteps()
 
@@ -1672,6 +1675,32 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         layout.addStretch(1)
         # These boxes did not exist when the theme was applied.
         self._applyCheckboxStyleSheets(self._isDarkMode())
+
+    # What a clinician checks on a normal run: the landmarks they can actually
+    # correct, each of the three registrations, and the surfaces the measurements
+    # rest on. Everything else is worth a look while debugging, not routinely.
+    RECOMMENDED_REVIEW_IDS = (
+        "t1_landmarks",
+        "registration_cb",
+        "registration_max",
+        "registration_mand",
+        "bone_surfaces",
+    )
+
+    def setRecommendedReviewSteps(self) -> None:
+        """Tick the steps worth pausing on for a routine run.
+
+        Only among the steps this mode actually offers: ticking an id the run
+        will never reach reads as a broken feature the first time it goes
+        straight past it.
+        """
+        wanted = set(self.RECOMMENDED_REVIEW_IDS)
+        for review_id, box in self.review_checkboxes.items():
+            box.setChecked(review_id in wanted)
+        offered = wanted & set(self.review_checkboxes)
+        logger.info(f"{len(offered)} recommended step(s) ticked: {sorted(offered)}")
+        if not offered:
+            logger.warning("None of the recommended steps exist in this mode")
 
     def setAllReviewSteps(self, checked: bool) -> None:
         """Tick or untick every step currently offered."""
@@ -1996,9 +2025,22 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             action = "You can drag it into place"
         else:
             action = "Review only"
+        # Name the modules: a clinician who does not already know Slicer has no
+        # way to guess that the points are editable in Markups, or that the 3D
+        # view they are looking at is driven by Volume Rendering.
+        if item.get("editable"):
+            tools = ("Open <b>Markups</b> to pick a point from the list, and "
+                     "<b>Volume Rendering</b> to change how the bone is shown.")
+        elif item.get("adjustable"):
+            tools = ("Drag the scan in a slice view. <b>Volume Rendering</b> "
+                     "changes how the bone is shown.")
+        else:
+            tools = "<b>Models</b> and <b>Volume Rendering</b> change how this is shown."
+
         self.ui.reviewLabel.setText(
             f"<b>{title}</b><br/>"
             f"{patient}{position} &nbsp;·&nbsp; <i>{action}</i><br/>{hint}"
+            f"<br/><span style='color:#7f8c8d'>{tools}</span>"
         )
         self.ui.reviewLabel.setVisible(True)
 
@@ -2007,6 +2049,40 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.continueButton.setText(self.CONTINUE_BUTTON_TEXT)
 
         logger.info(f"Review - {title} - {patient}{position}")
+
+    def showVolumeRendering(self, volume) -> None:
+        """Turn on volume rendering for the scan a landmark review sits on.
+
+        Points are placed on anatomy, and anatomy reads far better in 3D than on
+        three grey slices. Slicer can do this in one call but nobody thinks to
+        ask for it mid-run, so the pause sets it up and the clinician only has to
+        look.
+
+        Best effort throughout: a machine without the Volume Rendering module, or
+        one that refuses the GPU, still gets a perfectly usable review on the
+        slices. Failing the pause over a convenience would be the wrong trade.
+
+        Args:
+            volume: The loaded scalar volume node
+        """
+        if volume is None or not hasattr(slicer.modules, "volumerendering"):
+            return
+        try:
+            vr = slicer.modules.volumerendering.logic()
+            display = vr.CreateDefaultVolumeRenderingNodes(volume)
+            if display is None:
+                return
+            # CT-Bone reads the skeleton, which is what every landmark here sits
+            # on. If this build does not ship it, the default transfer function
+            # still shows something rather than nothing.
+            preset = vr.GetPresetByName("CT-Bone") or vr.GetPresetByName("CT-AAA")
+            if preset is not None and display.GetVolumePropertyNode():
+                display.GetVolumePropertyNode().Copy(preset)
+            display.SetVisibility(True)
+            self.pause_nodes.append(display)
+            logger.info(f"Volume rendering on for {volume.GetName()}")
+        except Exception as e:
+            logger.warning(f"Could not turn on volume rendering: {e}")
 
     def loadPauseItem(self, item: dict) -> bool:
         """
@@ -2039,6 +2115,12 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
 
         if loaded and item.get("adjustable") and moving is not None:
             self.setUpAdjustment(item, reference, moving)
+
+        # Only where points are being placed: on a registration the user judges
+        # two scans against each other on the slices, and a rendered block on top
+        # of that hides the very overlap they are looking at.
+        if loaded and item.get("editable") and reference is not None:
+            self.showVolumeRendering(reference)
 
         if loaded:
             self.applyPauseLayout(item)
@@ -2319,6 +2401,78 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         ]
         return "\n".join(lines)
 
+    def showHeatmaps(self) -> int:
+        """Put the distance maps on screen once the run is over.
+
+        The heatmaps are the point of a visualization run, and they were being
+        left as files nobody opened. A model carrying a "Distance" array shows
+        nothing until that array is made active with a colour range, so this does
+        the three things that turn a grey surface into a readable map.
+
+        The range is made symmetric around zero on purpose: the distances are
+        signed, and a range like [-2.7, 2.4] would paint zero slightly off the
+        middle colour, so untouched anatomy would read as a small displacement.
+
+        Only the merged map per patient is loaded. The per-structure files say
+        the same thing over a smaller area, and one of these surfaces runs to
+        120 MB - loading all of them would cost a gigabyte to show the same
+        thing three times. They stay in the folder for anyone who wants them.
+
+        Returns:
+            int: how many maps were put on screen
+        """
+        folder = os.path.join(self._parameterNode.OutputFolder or "", "Heatmaps")
+        if not os.path.isdir(folder):
+            return 0
+
+        files = sorted(glob.glob(os.path.join(folder, "*merged*ModelDistance.vtk")))
+        if not files:
+            files = sorted(glob.glob(os.path.join(folder, "*.vtk")))
+        if not files:
+            logger.info("No heatmap to show")
+            return 0
+
+        # Rainbow reads as a map; if this build ships the cold-to-hot variant,
+        # its ends are clearer for signed data.
+        table = None
+        for name in ("ColdToHotRainbow", "Rainbow"):
+            table = slicer.mrmlScene.GetFirstNodeByName(name)
+            if table is not None:
+                break
+
+        shown = 0
+        for path in files:
+            try:
+                model = slicer.util.loadModel(path)
+                if model is None:
+                    continue
+                data = model.GetPolyData()
+                array = data.GetPointData().GetArray("Distance") if data else None
+                display = model.GetDisplayNode()
+                if array is not None and display is not None:
+                    low, high = array.GetRange()
+                    edge = max(abs(low), abs(high)) or 1.0
+                    display.SetActiveScalarName("Distance")
+                    display.SetScalarRangeFlag(display.UseManualScalarRange)
+                    display.SetScalarRange(-edge, edge)
+                    if table is not None:
+                        display.SetAndObserveColorNodeID(table.GetID())
+                    display.SetScalarVisibility(True)
+                shown += 1
+            except Exception as e:
+                logger.warning(f"Could not show {os.path.basename(path)}: {e}")
+
+        if shown:
+            try:
+                slicer.app.layoutManager().setLayout(
+                    slicer.vtkMRMLLayoutNode.SlicerLayoutOneUp3DView)
+                slicer.util.selectModule("Models")
+                slicer.util.resetThreeDViews()
+            except Exception as e:
+                logger.warning(f"Heatmaps loaded but the view could not be set: {e}")
+            logger.info(f"{shown} heatmap(s) on screen, coloured by signed distance")
+        return shown
+
     def showDoneMessage(self) -> None:
         """Say the run is over without taking the application hostage.
 
@@ -2329,6 +2483,7 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # A measurement is only as good as the points it rests on: a run that
         # finished with landmarks missing produced empty columns, and saying so
         # here is the difference between a known gap and a silent one.
+        shown = self.showHeatmaps()
         report = self.missingLandmarkReport()
         if report:
             logger.warning(f"Landmarks never placed during this run:\n{report}")
@@ -2340,6 +2495,12 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             )
         else:
             text = "Processing completed successfully!"
+        if shown:
+            text += (
+                f"\n\n{shown} distance map(s) are on screen, coloured from the "
+                "surface's own range. Use <b>Models</b> to change the colours or "
+                "hide one."
+            ).replace("<b>", "").replace("</b>", "")
 
         self.done_popup = PopUpWindow(title="Process Complete", text=text)
         self.done_popup.setModal(False)

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import os
+import stat
 import tempfile
 from typing import Annotated
 import urllib.request
@@ -356,9 +357,60 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         except Exception as e:
             logger.error(f"Error reloading custom modules: {e}")
 
+    @staticmethod
+    def widenCapturedPipes() -> None:
+        """Give Slicer's captured output more room than the default 64 KB.
+
+        Precaution, not a proven cure. What is established: long VFACE runs have
+        frozen several times with the main thread in `pipe_write` on the pipe
+        Slicer captures its own stdout into, zero CPU, never recovering. What is
+        not established: what fills it. Writing 200 KB from inside a VTK observer
+        callback - the shape the freeze was blamed on - does NOT deadlock, with
+        or without a main window, so that explanation is wrong or incomplete.
+
+        Widening suppresses no output and changes no behaviour; it only raises
+        the ceiling from 64 KB to whatever the kernel allows, typically 1 MB,
+        against a whole run's console output of roughly 100 KB. If the freeze
+        really is an accumulation, this removes it; if it is something else, this
+        costs nothing. Do not read it as the fix until a run confirms it.
+
+        Fails quietly wherever it does not apply - Windows, output redirected to
+        a file rather than a pipe, a kernel that refuses - because a smaller pipe
+        is not worth failing over.
+        """
+        try:
+            import fcntl
+        except ImportError:
+            return  # not a POSIX platform; nothing to widen
+        F_SETPIPE_SZ, F_GETPIPE_SZ = 1031, 1032
+        try:
+            with open("/proc/sys/fs/pipe-max-size") as fh:
+                target = int(fh.read().strip())
+        except (OSError, ValueError):
+            target = 1024 * 1024
+        for fd in (1, 2):
+            try:
+                if not stat.S_ISFIFO(os.fstat(fd).st_mode):
+                    continue
+                before = fcntl.fcntl(fd, F_GETPIPE_SZ)
+                if before >= target:
+                    continue
+                fcntl.fcntl(fd, F_SETPIPE_SZ, target)
+                logger.info(
+                    f"Captured output fd{fd} widened {before} -> "
+                    f"{fcntl.fcntl(fd, F_GETPIPE_SZ)} bytes"
+                )
+            except (OSError, ValueError) as e:
+                logger.warning(f"Could not widen fd{fd}, leaving it as it is: {e}")
+
     def setup(self) -> None:
         """Called when the user opens the module the first time and the widget is initialized."""
         ScriptedLoadableModuleWidget.setup(self)
+
+        # Before anything else writes: the deadlock this avoids takes the whole
+        # application down, and an undersized pipe is only a problem once it is
+        # already full.
+        self.widenCapturedPipes()
 
         self.reloadCustomModules()
 
@@ -1498,6 +1550,39 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.NumberProcess = 0
         
         logger.info("Interface reset after cancellation")
+
+    def abortOnCliError(self, module_name: str, error_text: str) -> None:
+        """
+        Stop the run where a CLI failed.
+
+        Every later step reads what the previous one wrote, so carrying on past a
+        failure only produces a chain of steps finding nothing and a run that
+        claims to have completed. Stop here and say which step broke.
+
+        Args:
+            module_name: Step whose CLI reported errors
+            error_text: Tail of that CLI's stderr, already trimmed
+        """
+        self.list_process = []
+        self.resetUIAfterCancel()
+
+        details = error_text.strip() if error_text else ""
+        if not details:
+            details = "The step produced no error output; see the Python console."
+
+        # Deferred for the same reason as the completion dialog: this is reached
+        # from inside a VTK observer callback, and an application-modal dialog
+        # opened there runs a nested event loop while the CLI node is still
+        # dispatching events.
+        qt.QTimer.singleShot(
+            0,
+            lambda: PopUpWindow(
+                title="Process failed",
+                text=(
+                    f"'{module_name}' failed, so the run was stopped.\n\n{details}"
+                ),
+            ).exec_(),
+        )
 
     # ===== Manual review pauses =====
     #
@@ -2669,6 +2754,22 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             # is what lets the pipe fill until the main thread blocks in write()
             # with no reader left - the black window that never comes back.
             cli_output = self._briefCliOutput(caller.GetOutputText())
+
+            # CompletedWithErrors is Completed | ErrorsMask, so the test above is
+            # also true of a CLI that died. Without this branch the failure was
+            # invisible - a Python traceback goes to stderr, which GetOutputText()
+            # does not carry - and the chain went on running every later step on
+            # the empty folders the dead one never filled, reporting success.
+            if status & slicer.vtkMRMLCommandLineModuleNode.ErrorsMask:
+                failed_module = self.module_name
+                cli_error = self._briefCliOutput(caller.GetErrorText())
+                qt.QTimer.singleShot(0, lambda: logger.error(
+                    f"\n\n ========= {failed_module} FAILED ========= \n{cli_output}"
+                    f"\n ========= ERROR DETAILS ========= \n{cli_error}"
+                ))
+                self.abortOnCliError(failed_module, cli_error)
+                return
+
             qt.QTimer.singleShot(
                 0, lambda: logger.info(f"\n\n ========= PROCESSED ========= \n{cli_output}")
             )

--- a/VFACE/VFACE.py
+++ b/VFACE/VFACE.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import os
+import re
 import stat
 import tempfile
 from typing import Annotated
@@ -331,6 +332,9 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # so a rollback knows what lies behind, the patients a rollback is
         # replaying, and the temporary folders a narrowed replay leaves behind.
         self.review_flagged = set()
+        # {landmark: [scans it was missed on, scans tried]}, filled from the
+        # summary ALI prints when a run ends.
+        self.missing_landmarks = {}
         self.executed_steps = []
         self.review_flagged_carry = []
         self.review_temp_folders = []
@@ -1262,8 +1266,10 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.progressBar.setVisible(True)
 
         self.NumberProcess = len(self.list_process)
-        # A second run in the same session must not see the first one's steps.
+        # A second run in the same session must not see the first one's steps,
+        # nor report the landmarks the previous one missed.
         self.executed_steps = []
+        self.missing_landmarks = {}
         self.review_flagged = set()
         self.review_flagged_carry = []
         self.clearReviewTempFolders()
@@ -2287,6 +2293,32 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.pause_transform = None
         self.pause_transform_item = None
 
+    # ALI says which landmarks its agents could not place, then moves on. Those
+    # lines used to scroll past in the console: the first sign of trouble was an
+    # empty column in the measurements, or a KeyError three steps later.
+    MISSING_LANDMARK_RE = re.compile(r"Landmark '([^']+)': (\d+)/(\d+) failures")
+
+    def collectMissingLandmarks(self, output_text: str) -> None:
+        """Note the landmarks a finished ALI run reported it could not find.
+
+        Args:
+            output_text: The CLI's standard output, untrimmed
+        """
+        for name, failed, total in self.MISSING_LANDMARK_RE.findall(output_text or ""):
+            entry = self.missing_landmarks.setdefault(name, [0, 0])
+            entry[0] += int(failed)
+            entry[1] += int(total)
+
+    def missingLandmarkReport(self) -> str:
+        """One line per landmark the run never placed, or an empty string."""
+        if not self.missing_landmarks:
+            return ""
+        lines = [
+            f"- {name}: not found on {failed} of {total} scan(s)"
+            for name, (failed, total) in sorted(self.missing_landmarks.items())
+        ]
+        return "\n".join(lines)
+
     def showDoneMessage(self) -> None:
         """Say the run is over without taking the application hostage.
 
@@ -2294,9 +2326,22 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         modal dialog that fails to appear leaves the user with no way to click
         anything, and that is exactly what a finished run must not do.
         """
-        self.done_popup = PopUpWindow(
-            title="Process Complete", text="Processing completed successfully!"
-        )
+        # A measurement is only as good as the points it rests on: a run that
+        # finished with landmarks missing produced empty columns, and saying so
+        # here is the difference between a known gap and a silent one.
+        report = self.missingLandmarkReport()
+        if report:
+            logger.warning(f"Landmarks never placed during this run:\n{report}")
+            text = (
+                "Processing completed, but some landmarks were never found:\n\n"
+                f"{report}\n\n"
+                "Measurements that rest on them are empty. A landmark is usually "
+                "missed because it falls outside the scan's field of view."
+            )
+        else:
+            text = "Processing completed successfully!"
+
+        self.done_popup = PopUpWindow(title="Process Complete", text=text)
         self.done_popup.setModal(False)
         self.done_popup.show()
         self.done_popup.raise_()
@@ -2753,7 +2798,12 @@ class VFACEWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             # a VTK observer callback where that loop cannot run. Writing here
             # is what lets the pipe fill until the main thread blocks in write()
             # with no reader left - the black window that never comes back.
-            cli_output = self._briefCliOutput(caller.GetOutputText())
+            full_output = caller.GetOutputText() or ""
+            # From the untrimmed text: the summary sits at the very end of ALI's
+            # output, but _briefCliOutput keeps only a tail and a longer run
+            # could push it out.
+            self.collectMissingLandmarks(full_output)
+            cli_output = self._briefCliOutput(full_output)
 
             # CompletedWithErrors is Completed | ErrorsMask, so the test above is
             # also true of a CLI that died. Without this branch the failure was

--- a/VFACE/VFACE_utils/createlistprocess.py
+++ b/VFACE/VFACE_utils/createlistprocess.py
@@ -2529,6 +2529,34 @@ def _landmark_label(dic_features, composant, i):
     return (first+" / "+second).replace("_","-")
 
 
+def _measurement(by_landmark, dic_features, composant, i, feature, patient):
+    """One measurement for a feature column, or None if the run never made it.
+
+    A column can name a landmark the pipeline does not produce - the reference
+    sheet asks for "Me", which ALI's mandible model does not predict - and
+    indexing that blind ends the whole post-processing on a KeyError. The Excel
+    is then never written, and every later step fails looking for it: that is how
+    one missing landmark turned into a failed classification.
+
+    A column left empty is visible and recoverable; a run stopped halfway is not.
+    """
+    label = _landmark_label(dic_features, composant, i)
+    row = by_landmark.get(label)
+    if row is None:
+        logger.warning(
+            f"{patient}: no '{label}' measurement, leaving '{feature}' empty"
+        )
+        return None
+    try:
+        return float(row[composant])
+    except (KeyError, TypeError, ValueError):
+        logger.warning(
+            f"{patient}: '{label}' carries no usable {composant}, "
+            f"leaving '{feature}' empty"
+        )
+        return None
+
+
 def _index_measurements(df):
     """{patient: {landmark: row}}, keeping the first row of a repeated landmark."""
     index = {}
@@ -2622,12 +2650,23 @@ def postprocess (cb_path,mand_path,max_path,exemple_path,outputfolder):
 
             composant = dic_features.get("Composant")
             if dic_features.get("Average") == "No":
-                record[feature] = float(by_landmark[_landmark_label(dic_features, composant, 0)][composant])
+                value = _measurement(by_landmark, dic_features, composant, 0, feature, val)
+                if value is None:
+                    continue
+                record[feature] = value
             else:
                 nbr = dic_features.get("Nbr_Landmarks")//2
                 average = 0
                 for i in range(nbr):
-                    average += float(by_landmark[_landmark_label(dic_features, composant, i)][composant])
+                    value = _measurement(by_landmark, dic_features, composant, i, feature, val)
+                    if value is None:
+                        # Averaging what is left would quietly report a different
+                        # measurement than the column claims to be.
+                        average = None
+                        break
+                    average += value
+                if average is None:
+                    continue
                 record[feature] = average / nbr
 
         records.append(record)

--- a/VFACE/VFACE_utils/createlistprocess.py
+++ b/VFACE/VFACE_utils/createlistprocess.py
@@ -13,6 +13,7 @@ from .functionaq3dc import AQ3DCLogic, AQ3DCWidget, patientIdFromFileName
 import qt
 import re
 import shutil
+import tempfile
 from pathlib import Path
 import pandas as pd
 import traceback
@@ -236,7 +237,7 @@ def CreateListProcess(**kwargs):
             "output_folder": preaso_MAX_folder_path,
             "model_folder": False,
             "SmallFOV": False,
-            "temp_folder": slicer.util.tempDirectory(),
+            "temp_folder": _unique_temp_dir("work"),
             "DCMInput": False,
         }
         list_process.append(
@@ -255,7 +256,7 @@ def CreateListProcess(**kwargs):
             "dir_models": kwargs["model_folder_ali"],
             "lm_type": "'ANS','IF','PNS','UL6O','UR1O','UR6O'",
             "output_dir": preaso_MAX_folder_path,
-            "temp_fold": slicer.util.tempDirectory(),
+            "temp_fold": _unique_temp_dir("work"),
             "DCMInput": False,
             "spacing": "[1,0.3]",
             "speed_per_scale": "[1,1]",
@@ -316,7 +317,7 @@ def CreateListProcess(**kwargs):
             "output_folder": preaso_CB_folder_path,
             "model_folder": False,
             "SmallFOV": False,
-            "temp_folder": slicer.util.tempDirectory(),
+            "temp_folder": _unique_temp_dir("work"),
             "DCMInput": False,
         }
 
@@ -336,7 +337,7 @@ def CreateListProcess(**kwargs):
             "dir_models": kwargs["model_folder_ali"],
             "lm_type": "'Ba', 'LPo', 'N', 'RPo', 'S', 'LOr', 'ROr'",
             "output_dir": preaso_CB_folder_path,
-            "temp_fold": slicer.util.tempDirectory(),
+            "temp_fold": _unique_temp_dir("work"),
             "DCMInput": False,
             "spacing": "[1,0.3]",
             "speed_per_scale": "[1,1]",
@@ -434,7 +435,7 @@ def CreateListProcess(**kwargs):
                 "output_folder": t2_centered_folder_path,
                 "model_folder": False,
                 "SmallFOV": False,
-                "temp_folder": slicer.util.tempDirectory(),
+                "temp_folder": _unique_temp_dir("work"),
                 "DCMInput": False,
             }
 
@@ -526,7 +527,7 @@ def CreateListProcess(**kwargs):
                     "matrix_name": False,
                     "fromAreg": False,
                     "output_folder": t2mask_folder_path,
-                    "log_path": slicer.util.tempDirectory(),
+                    "log_path": _unique_temp_dir("log"),
                     "is_seg": True
                 }
                 list_process.append(
@@ -556,7 +557,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": t2_cb_folder,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
             }
 
@@ -579,7 +580,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": t2_max_folder,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
             }
 
@@ -620,7 +621,7 @@ def CreateListProcess(**kwargs):
             "add_name": "_Reg",
             "DCMInput": False,
             "SegmentationLabel": "0",
-            "temp_folder": slicer.util.tempDirectory(),
+            "temp_folder": _unique_temp_dir("work"),
             "ApproxReg": False,
             "mask_folder_t1": mask_folder_path,
         }
@@ -656,7 +657,7 @@ def CreateListProcess(**kwargs):
             "add_name": "_Reg",
             "DCMInput": False,
             "SegmentationLabel": "0",
-            "temp_folder": slicer.util.tempDirectory(),
+            "temp_folder": _unique_temp_dir("work"),
             "ApproxReg": False,
             "mask_folder_t1": mask_folder_path,
         }
@@ -692,7 +693,7 @@ def CreateListProcess(**kwargs):
             "add_name": "_Reg",
             "DCMInput": False,
             "SegmentationLabel": "0",
-            "temp_folder": slicer.util.tempDirectory(),
+            "temp_folder": _unique_temp_dir("work"),
             "ApproxReg": False,
             "mask_folder_t1": mask_folder_path,
         }
@@ -758,7 +759,13 @@ def CreateListProcess(**kwargs):
         # step outside the unpadded image, so a landmark at the edge is out of
         # reach. Hand it a roomier copy: the scans on disk are untouched and
         # every later step still reads the originals.
-        padded_scans_path = slicer.util.tempDirectory()
+        # tempfile.mkdtemp, not slicer.util.tempDirectory: the latter names its
+        # folder to the millisecond, and the calls that build this list run
+        # microseconds apart, so it handed the padded scans and ALI's own
+        # temp_fold the same directory. ALI then found the leftovers of an
+        # earlier step there - elastix's fixed_image_masked - and landmarked
+        # that instead of the patients.
+        padded_scans_path = _unique_temp_dir("padded")
 
         list_process.append(
             {
@@ -780,7 +787,7 @@ def CreateListProcess(**kwargs):
                 "dir_models": kwargs["model_folder_ali"],
                 "lm_type": ",".join([f"'{e}'" for e in list_landmark]),
                 "output_dir": landmarks_cb_folder_path,
-                "temp_fold": slicer.util.tempDirectory(),
+                "temp_fold": _unique_temp_dir("ali"),
                 "DCMInput": False,
                 "spacing": "[1,0.3]",
                 "speed_per_scale": "[1,1]",
@@ -855,7 +862,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": mirrored_landmarks_cb_folder_path,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
                 }
 
@@ -878,7 +885,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": mirrored_landmarks_max_folder_path,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
                 }
 
@@ -919,7 +926,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": mirrored_registered_cb_landmarks_folder_path,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
                 }
 
@@ -942,7 +949,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": mirrored_registered_mand_landmarks_folder_path,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
                 }
 
@@ -965,7 +972,7 @@ def CreateListProcess(**kwargs):
                 "matrix_name": False,
                 "fromAreg": False,
                 "output_folder": mirrored_registered_max_landmarks_folder_path,
-                "log_path": slicer.util.tempDirectory(),
+                "log_path": _unique_temp_dir("log"),
                 "is_seg": False
                 }
 
@@ -997,7 +1004,7 @@ def CreateListProcess(**kwargs):
                     "dir_models": kwargs["model_folder_ali"],
                     "lm_type": ",".join([f"'{e}'" for e in list_landmark]),
                     "output_dir": t2_landmarks_cb_folder_path,
-                    "temp_fold": slicer.util.tempDirectory(),
+                    "temp_fold": _unique_temp_dir("ali"),
                     "DCMInput": False,
                     "spacing": "[1,0.3]",
                     "speed_per_scale": "[1,1]",
@@ -1021,7 +1028,7 @@ def CreateListProcess(**kwargs):
                     "dir_models": kwargs["model_folder_ali"],
                     "lm_type": ",".join([f"'{e}'" for e in list_landmark_max]),
                     "output_dir": t2_landmarks_max_folder_path,
-                    "temp_fold": slicer.util.tempDirectory(),
+                    "temp_fold": _unique_temp_dir("ali"),
                     "DCMInput": False,
                     "spacing": "[1,0.3]",
                     "speed_per_scale": "[1,1]",
@@ -1045,7 +1052,7 @@ def CreateListProcess(**kwargs):
                     "dir_models": kwargs["model_folder_ali"],
                     "lm_type": ",".join([f"'{e}'" for e in list_landmark_max]),
                     "output_dir": t2_landmarks_mand_folder_path,
-                    "temp_fold": slicer.util.tempDirectory(),
+                    "temp_fold": _unique_temp_dir("ali"),
                     "DCMInput": False,
                     "spacing": "[1,0.3]",
                     "speed_per_scale": "[1,1]",
@@ -2071,6 +2078,29 @@ def create_list_measure(df_path):
         else:
             logger.error("There is an issue in the xlsx file")
     return list_measure
+
+def _unique_temp_dir(what):
+    """A directory no other step can be handed.
+
+    slicer.util.tempDirectory() names its folder from the clock to the
+    millisecond, and the steps of a pipeline are built microseconds apart, so two
+    of them are regularly given the *same* directory. That is not theoretical:
+    the padded scans and ALI's own temp_fold collided, ALI found elastix's
+    leftover fixed_image_masked there and landmarked it instead of the patients.
+
+    Kept under Slicer's temporary root so its own cleanup still applies.
+
+    Args:
+        what: short tag that ends up in the folder name, to make a stray one
+            traceable back to the step that made it
+
+    Returns:
+        str: path of a fresh, empty directory
+    """
+    root = getattr(slicer.app, "temporaryPath", None) or tempfile.gettempdir()
+    os.makedirs(root, exist_ok=True)
+    return tempfile.mkdtemp(prefix=f"VFACE_{what}_", dir=root)
+
 
 def pad_scans_for_landmarks(input_folder, output_folder, margin_mm=30):
     """Copy each scan with empty space around it so ALI can work at the edges.

--- a/VFACE/VFACE_utils/createlistprocess.py
+++ b/VFACE/VFACE_utils/createlistprocess.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
 if current_dir not in sys.path:
@@ -8,7 +9,7 @@ if current_dir not in sys.path:
 from .Progress import DisplayASOCBCT,DisplayAMASSS,DisplayAREGCBCT,DisplayALICBCT
 from glob import iglob
 import slicer
-from .functionaq3dc import AQ3DCLogic, AQ3DCWidget
+from .functionaq3dc import AQ3DCLogic, AQ3DCWidget, patientIdFromFileName
 import qt
 import re
 import shutil
@@ -270,6 +271,15 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayALICBCT(6,
                     nb_scan
                 ),
+                "ReviewTitle": "Maxilla orientation landmarks",
+                "ReviewHint": (
+                    "These points decide how the scan is oriented, and every step after it inherits that orientation. Drag any that sits off its anatomy. Your changes are saved when you click Continue - you do not need to save in Slicer."
+                ),
+                "ReviewFolder": preaso_MAX_folder_path,
+                "ReviewVolumeFolder": preaso_MAX_folder_path,
+                "ReviewEditable": True,
+                "ReviewId": "t1_landmarks_orientation_max",
+                "pause_for_visualization": True,
             }
         )
         
@@ -289,6 +299,14 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayASOCBCT(
                     nb_scan
                 ),
+                "ReviewTitle": "Maxilla orientation of the original scan",
+                "ReviewHint": (
+                    "Check the scan is oriented on the occlusal and mid-sagittal "
+                    "planes. Nothing to edit here - look at the result, then click "
+                    "Continue."
+                ),
+                "ReviewFolder": orientation_max_folder_path,
+                "ReviewId": "t1_oriented_max",
                 "pause_for_visualization": True,
             }
         )
@@ -334,6 +352,15 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayALICBCT(6,
                     nb_scan
                 ),
+                "ReviewTitle": "Cranial base orientation landmarks",
+                "ReviewHint": (
+                    "These points decide how the scan is oriented, and every step after it inherits that orientation. Drag any that sits off its anatomy. Your changes are saved when you click Continue - you do not need to save in Slicer."
+                ),
+                "ReviewFolder": preaso_CB_folder_path,
+                "ReviewVolumeFolder": preaso_CB_folder_path,
+                "ReviewEditable": True,
+                "ReviewId": "t1_landmarks_orientation_cb",
+                "pause_for_visualization": True,
             }
         )
 
@@ -353,6 +380,14 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayASOCBCT(
                     nb_scan
                 ),
+                "ReviewTitle": "Cranial base orientation of the original scan",
+                "ReviewHint": (
+                    "Check the scan is oriented on the Frankfort horizontal and "
+                    "mid-sagittal planes. Nothing to edit here - look at the "
+                    "result, then click Continue."
+                ),
+                "ReviewFolder": orientation_cb_folder_path,
+                "ReviewId": "t1_oriented_cb",
                 "pause_for_visualization": True,
             }
         )
@@ -467,6 +502,14 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayAMASSS(
                     nb_scan, len(full_reg_struct)
                 ),
+                "ReviewTitle": "Bone segmentation of the original scan",
+                "ReviewHint": (
+                    "Check the cranial base, mandible and maxilla masks follow the "
+                    "bone - they guide the registration that comes next. Nothing to "
+                    "edit here - look at the result, then click Continue."
+                ),
+                "ReviewFolder": mask_folder_path,
+                "ReviewId": "t1_masks",
                 "pause_for_visualization": True,
             },
         )
@@ -494,6 +537,13 @@ def CreateListProcess(**kwargs):
                         "Display": DisplayAMASSS(
                             nb_scan, len(full_reg_struct)
                         ),
+                        "ReviewTitle": "Mirrored bone segmentation",
+                        "ReviewHint": (
+                            "Check the mirrored masks. Nothing to edit here - look at the "
+                            "result, then click Continue."
+                        ),
+                        "ReviewFolder": t2mask_folder_path,
+                        "ReviewId": "mirror_masks",
                         "pause_for_visualization": True,
                     },
                 )
@@ -541,6 +591,20 @@ def CreateListProcess(**kwargs):
                     "Display": DisplayAMASSS(
                         nb_scan, len(full_reg_struct)
                     ),
+                    "ReviewTitle": "Mirrored scan, the side being compared against",
+                    "ReviewHint": (
+                        "Check the mirror of the patient's own scan. Nothing to edit "
+                        "here - look at the result, then click Continue."
+                    ),
+                    # Both mirrored scans, not just the maxilla this step
+                    # happened to write last. In a longitudinal run the two
+                    # already share one folder.
+                    "ReviewFolder": (
+                        t2scan_folder_path
+                        if kwargs["mode2"] != "Longitudinal studies"
+                        else t2_max_folder
+                    ),
+                    "ReviewId": "mirror_scans",
                     "pause_for_visualization": True,
                 },
             )
@@ -569,6 +633,18 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayAREGCBCT(
                     nb_scan
                 ),
+                "ReviewTitle": "Mirrored scan registered on the cranial base",
+                "ReviewHint": (
+                    "Check how closely the mirrored scan (shown half-transparent "
+                    "over the original) matches it. If it is off, drag it into "
+                    "place - the correction is applied to the landmarks too, "
+                    "automatically, when you click Continue."
+                ),
+                "ReviewFolder": os.path.join(registeredscan_folder_path, "Cranial Base"),
+                "ReviewVolumeFolder": orientation_cb_folder_path,
+                "ReviewAdjustable": True,
+                "ReviewId": "registration_cb",
+                "pause_for_visualization": True,
             },
         )
 
@@ -593,6 +669,18 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayAREGCBCT(
                     nb_scan
                 ),
+                "ReviewTitle": "Mirrored scan registered on the maxilla",
+                "ReviewHint": (
+                    "Check how closely the mirrored scan (shown half-transparent "
+                    "over the original) matches it. If it is off, drag it into "
+                    "place - the correction is applied to the landmarks too, "
+                    "automatically, when you click Continue."
+                ),
+                "ReviewFolder": os.path.join(registeredscan_folder_path, "Maxilla"),
+                "ReviewVolumeFolder": orientation_max_folder_path,
+                "ReviewAdjustable": True,
+                "ReviewId": "registration_max",
+                "pause_for_visualization": True,
             },
         )
 
@@ -617,6 +705,17 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayAREGCBCT(
                     nb_scan
                 ),
+                "ReviewTitle": "Mirrored scan registered on the mandible",
+                "ReviewHint": (
+                    "Check how closely the mirrored scan (shown half-transparent "
+                    "over the original) matches it. If it is off, drag it into "
+                    "place - the correction is applied to the landmarks too, "
+                    "automatically, when you click Continue."
+                ),
+                "ReviewFolder": os.path.join(registeredscan_folder_path, "Mandible"),
+                "ReviewVolumeFolder": orientation_cb_folder_path,
+                "ReviewAdjustable": True,
+                "ReviewId": "registration_mand",
                 "pause_for_visualization": True,
             },
         )
@@ -639,179 +738,11 @@ def CreateListProcess(**kwargs):
             logger.error("Issue, it seems to miss some cbct or transform files in the T2 folder")
             return
         
-    if kwargs["bool_visualization"]:
-
-        vtk_folder_path = os.path.join(kwargs["OutputFolder"],"VTK Files")
-        os.makedirs(vtk_folder_path, exist_ok=True)
-
-        BDSProcess = run_bds
-            
-        t1_cb_vtk_folder_path = os.path.join(vtk_folder_path,"T1 CB")
-        os.makedirs(t1_cb_vtk_folder_path, exist_ok=True)
-
-        t1_max_vtk_folder_path = os.path.join(vtk_folder_path,"T1 MAX")
-        os.makedirs(t1_max_vtk_folder_path, exist_ok=True)
-
-        t2_cb_vtk_folder_path = os.path.join(vtk_folder_path,"T2 CB")
-        os.makedirs(t2_cb_vtk_folder_path, exist_ok=True)
-
-        t2_mand_vtk_folder_path = os.path.join(vtk_folder_path,"T2 MAND")
-        os.makedirs(t2_mand_vtk_folder_path, exist_ok=True)
-
-        t2_max_vtk_folder_path = os.path.join(vtk_folder_path,"T2 MAX")
-        os.makedirs(t2_max_vtk_folder_path, exist_ok=True)
-
-        parameter_bds_t1_cb = {
-            "input_path":orientation_cb_folder_path,
-            "output_path":t1_cb_vtk_folder_path,
-            }
-
-        list_process.append(
-            {
-                "Process": BDSProcess,
-                "Parameter": parameter_bds_t1_cb,
-                "Module": "BDS - Segmentation T1 CB",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_bds_t1_max = {
-            "input_path":orientation_max_folder_path,
-            "output_path":t1_max_vtk_folder_path,
-            }
-
-        list_process.append(
-            {
-                "Process": BDSProcess,
-                "Parameter": parameter_bds_t1_max,
-                "Module": "BDS - Segmentation T1 MAX",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_bds_t2_cb = {
-            "input_path":os.path.join(registeredscan_folder_path,"Cranial Base"),
-            "output_path":t2_cb_vtk_folder_path,
-            }
-        
-        if kwargs["mode"] == "File already Registered":
-            parameter_bds_t2_cb["input_path"] = os.path.join(registeredscan_folder_path,"Cranial Base")
-
-        list_process.append(
-            {
-                "Process": BDSProcess,
-                "Parameter": parameter_bds_t2_cb,
-                "Module": "BDS - Segmentation T2 CB",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_bds_t2_mand = {
-            "input_path":os.path.join(registeredscan_folder_path,"Mandible"),
-            "output_path":t2_mand_vtk_folder_path,
-            }
-        
-        if kwargs["mode"] == "File already Registered":
-            parameter_bds_t2_mand["input_path"] = os.path.join(registeredscan_folder_path,"Mandible")
-
-        list_process.append(
-            {
-                "Process": BDSProcess,
-                "Parameter": parameter_bds_t2_mand,
-                "Module": "BDS - Segmentation T2 MAND",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_bds_t2_max = {
-            "input_path":os.path.join(registeredscan_folder_path,"Maxilla"),
-            "output_path":t2_max_vtk_folder_path,
-            }
-        
-        if kwargs["mode"] == "File already Registered":
-            parameter_bds_t2_max["input_path"] = os.path.join(registeredscan_folder_path,"Maxilla")
-
-        list_process.append(
-            {
-                "Process": BDSProcess,
-                "Parameter": parameter_bds_t2_max,
-                "Module": "BDS - Segmentation T2 MAX",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-                "pause_for_visualization": True,
-            },
-        )
-
-        heatmap_folder_path = os.path.join(kwargs["OutputFolder"],"Heatmaps")
-        os.makedirs(heatmap_folder_path, exist_ok=True)
-        HeatmapProcess = batch_process
-
-        parameter_heatmap_cb = {
-            "t1_dir":t1_cb_vtk_folder_path,
-            "t2_dir":t2_cb_vtk_folder_path,
-            "patient_list":patients.keys(),
-            "output_dir":heatmap_folder_path,
-            "zone_type":"merged"
-            }
-
-        list_process.append(
-            {
-                "Process": HeatmapProcess,
-                "Parameter": parameter_heatmap_cb,
-                "Module": "ModelToModel Distance CB",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_heatmap_mand = {
-            "t1_dir":t1_cb_vtk_folder_path,
-            "t2_dir":t2_mand_vtk_folder_path,
-            "patient_list":patients.keys(),
-            "output_dir":heatmap_folder_path,
-            "zone_type":"Mandible"
-            }
-
-        list_process.append(
-            {
-                "Process": HeatmapProcess,
-                "Parameter": parameter_heatmap_mand,
-                "Module": "ModelToModel Distance MAND",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-
-        parameter_heatmap_max = {
-            "t1_dir":t1_max_vtk_folder_path,
-            "t2_dir":t2_max_vtk_folder_path,
-            "patient_list":patients.keys(),
-            "output_dir":heatmap_folder_path,
-            "zone_type":"Upper_Skull"
-            }
-
-        list_process.append(
-            {
-                "Process": HeatmapProcess,
-                "Parameter": parameter_heatmap_max,
-                "Module": "ModelToModel Distance MAX",
-                "Display": DisplayAREGCBCT(
-                    nb_scan
-                ),
-            },
-        )
-    
+    # Quantification runs before visualization: nothing here depends on the
+    # surfaces or the heatmaps, and the landmark review is the only step the
+    # user can act on. Behind the visualization block it meant waiting through
+    # five segmentations and three distance runs before being able to correct
+    # a single point.
     if kwargs["bool_quantification"]:
 
         landmarks_folder_path = os.path.join(kwargs["OutputFolder"],"T1 Landmarks")
@@ -844,30 +775,45 @@ def CreateListProcess(**kwargs):
                 "Display": DisplayALICBCT(30,
                     nb_scan
                 ),
+                "ReviewTitle": "All T1 landmarks",
+                "ReviewHint": (
+                    "Every landmark the measurements use is here, maxilla "
+                    "included - the maxilla set is derived from these, so this is "
+                    "the only review. Drag any misplaced point onto the correct "
+                    "anatomy. Your changes are saved automatically when you click "
+                    "Continue - you do not need to save in Slicer."
+                ),
+                "ReviewFolder": landmarks_cb_folder_path,
+                "ReviewVolumeFolder": orientation_cb_folder_path,
+                "ReviewEditable": True,
+                "ReviewId": "t1_landmarks",
+                "pause_for_visualization": True,
             },
         )
 
-        parameter_ali_max = {
-                "input": orientation_max_folder_path,
-                "dir_models": kwargs["model_folder_ali"],
-                "lm_type": ",".join([f"'{e}'" for e in list_landmark_max]),
-                "output_dir": landmarks_max_folder_path,
-                "temp_fold": slicer.util.tempDirectory(),
-                "DCMInput": False,
-                "spacing": "[1,0.3]",
-                "speed_per_scale": "[1,1]",
-                "agent_FOV": "[64,64,64]",
-                "spawn_radius": "10"
-                }
+        # The maxilla landmarks are the same anatomical points the cranial base
+        # run already found, wanted in the other oriented frame. Both frames come
+        # from the same centred scan, so a rigid transform places them exactly,
+        # in seconds instead of minutes - and it keeps one point from landing in
+        # two slightly different places depending on which run found it. It also
+        # means the review above is the only one: a correction there flows here.
+        parameter_derive_max = {
+            "source_folder": landmarks_cb_folder_path,
+            "source_tfm_folder": orientation_cb_folder_path,
+            "target_tfm_folder": orientation_max_folder_path,
+            "target_scan_folder": orientation_max_folder_path,
+            "keep_landmarks": list_landmark_max,
+            "output_folder": landmarks_max_folder_path,
+        }
 
         list_process.append(
             {
-                "Process": ALIProcess,
-                "Parameter": parameter_ali_max,
-                "Module": "ALI - Identifying T1 Landmarks (MAX)",
-                "Display": DisplayALICBCT(30,
+                "Process": derive_landmarks,
+                "Parameter": parameter_derive_max,
+                "Module": "Deriving T1 Landmarks (MAX)",
+                "Display": DisplayAREGCBCT(
                     nb_scan
-                )
+                ),
             },
         )
         if kwargs["mode2"] == "Asymmetry Assesment":
@@ -1209,6 +1155,195 @@ def CreateListProcess(**kwargs):
                 },
             )
 
+    if kwargs["bool_visualization"]:
+
+        vtk_folder_path = os.path.join(kwargs["OutputFolder"],"VTK Files")
+        os.makedirs(vtk_folder_path, exist_ok=True)
+
+        BDSProcess = run_bds
+            
+        t1_cb_vtk_folder_path = os.path.join(vtk_folder_path,"T1 CB")
+        os.makedirs(t1_cb_vtk_folder_path, exist_ok=True)
+
+        t1_max_vtk_folder_path = os.path.join(vtk_folder_path,"T1 MAX")
+        os.makedirs(t1_max_vtk_folder_path, exist_ok=True)
+
+        t2_cb_vtk_folder_path = os.path.join(vtk_folder_path,"T2 CB")
+        os.makedirs(t2_cb_vtk_folder_path, exist_ok=True)
+
+        t2_mand_vtk_folder_path = os.path.join(vtk_folder_path,"T2 MAND")
+        os.makedirs(t2_mand_vtk_folder_path, exist_ok=True)
+
+        t2_max_vtk_folder_path = os.path.join(vtk_folder_path,"T2 MAX")
+        os.makedirs(t2_max_vtk_folder_path, exist_ok=True)
+
+        parameter_bds_t1_cb = {
+            "input_path":orientation_cb_folder_path,
+            "output_path":t1_cb_vtk_folder_path,
+            }
+
+        list_process.append(
+            {
+                "Process": BDSProcess,
+                "Parameter": parameter_bds_t1_cb,
+                "Module": "BDS - Segmentation T1 CB",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_bds_t1_max = {
+            "input_path":orientation_max_folder_path,
+            "output_path":t1_max_vtk_folder_path,
+            }
+
+        list_process.append(
+            {
+                "Process": BDSProcess,
+                "Parameter": parameter_bds_t1_max,
+                "Module": "BDS - Segmentation T1 MAX",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_bds_t2_cb = {
+            "input_path":os.path.join(registeredscan_folder_path,"Cranial Base"),
+            "output_path":t2_cb_vtk_folder_path,
+            }
+        
+        if kwargs["mode"] == "File already Registered":
+            parameter_bds_t2_cb["input_path"] = os.path.join(registeredscan_folder_path,"Cranial Base")
+
+        list_process.append(
+            {
+                "Process": BDSProcess,
+                "Parameter": parameter_bds_t2_cb,
+                "Module": "BDS - Segmentation T2 CB",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_bds_t2_mand = {
+            "input_path":os.path.join(registeredscan_folder_path,"Mandible"),
+            "output_path":t2_mand_vtk_folder_path,
+            }
+        
+        if kwargs["mode"] == "File already Registered":
+            parameter_bds_t2_mand["input_path"] = os.path.join(registeredscan_folder_path,"Mandible")
+
+        list_process.append(
+            {
+                "Process": BDSProcess,
+                "Parameter": parameter_bds_t2_mand,
+                "Module": "BDS - Segmentation T2 MAND",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_bds_t2_max = {
+            "input_path":os.path.join(registeredscan_folder_path,"Maxilla"),
+            "output_path":t2_max_vtk_folder_path,
+            }
+        
+        if kwargs["mode"] == "File already Registered":
+            parameter_bds_t2_max["input_path"] = os.path.join(registeredscan_folder_path,"Maxilla")
+
+        list_process.append(
+            {
+                "Process": BDSProcess,
+                "Parameter": parameter_bds_t2_max,
+                "Module": "BDS - Segmentation T2 MAX",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+                "ReviewTitle": "Bone surfaces used for the heatmaps",
+                "ReviewHint": (
+                    "Check the surfaces before the distance maps are computed. "
+                    "Nothing to edit here - look at the result, then click "
+                    "Continue."
+                ),
+                # The whole VTK folder, not just the last one written: the
+                # heatmaps compare T1 against T2, and reviewing one side alone
+                # cannot tell whether they are worth comparing. It also keeps
+                # the pause from showing nothing when that folder is empty.
+                "ReviewFolder": vtk_folder_path,
+                # One surface per scan rather than the six BDS writes: the
+                # merged one already holds every structure, and eighteen skulls
+                # at once is a blob nobody can judge.
+                "ReviewNameContains": "_merged",
+                "ReviewId": "bone_surfaces",
+                "pause_for_visualization": True,
+            },
+        )
+
+        heatmap_folder_path = os.path.join(kwargs["OutputFolder"],"Heatmaps")
+        os.makedirs(heatmap_folder_path, exist_ok=True)
+        HeatmapProcess = batch_process
+
+        parameter_heatmap_cb = {
+            "t1_dir":t1_cb_vtk_folder_path,
+            "t2_dir":t2_cb_vtk_folder_path,
+            "patient_list":patients.keys(),
+            "output_dir":heatmap_folder_path,
+            "zone_type":"merged"
+            }
+
+        list_process.append(
+            {
+                "Process": HeatmapProcess,
+                "Parameter": parameter_heatmap_cb,
+                "Module": "ModelToModel Distance CB",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_heatmap_mand = {
+            "t1_dir":t1_cb_vtk_folder_path,
+            "t2_dir":t2_mand_vtk_folder_path,
+            "patient_list":patients.keys(),
+            "output_dir":heatmap_folder_path,
+            "zone_type":"Mandible"
+            }
+
+        list_process.append(
+            {
+                "Process": HeatmapProcess,
+                "Parameter": parameter_heatmap_mand,
+                "Module": "ModelToModel Distance MAND",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
+        parameter_heatmap_max = {
+            "t1_dir":t1_max_vtk_folder_path,
+            "t2_dir":t2_max_vtk_folder_path,
+            "patient_list":patients.keys(),
+            "output_dir":heatmap_folder_path,
+            "zone_type":"Upper_Skull"
+            }
+
+        list_process.append(
+            {
+                "Process": HeatmapProcess,
+                "Parameter": parameter_heatmap_max,
+                "Module": "ModelToModel Distance MAX",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+    
     return list_process
 
 def run_aq3dc(t1_path, t2_path, list_measure, output_path, filename):
@@ -1233,6 +1368,186 @@ def run_aq3dc(t1_path, t2_path, list_measure, output_path, filename):
         
     logic.writeMeasurementExcel(compute,output_path,filename)
 
+
+
+def _ali_group_labels():
+    """ALI's landmark-to-group map, read from its source without importing torch."""
+    import ast
+
+    constants = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "ALI_CBCT", "ALI_CBCT_utils", "constants.py",
+    )
+    try:
+        tree = ast.parse(open(constants).read())
+        for node in tree.body:
+            if isinstance(node, ast.Assign) and any(
+                isinstance(t, ast.Name) and t.id == "GROUP_LABELS" for t in node.targets
+            ):
+                groups = ast.literal_eval(node.value)
+                return {lm: g for g, lms in groups.items() for lm in lms}
+    except Exception as e:
+        logger.warning(f"Could not read ALI landmark groups ({e}), writing one group")
+    return {}
+
+
+def _read_landmarks(folder):
+    """{patient: {label: position}} for every .mrk.json under folder."""
+    patients = {}
+    for path in sorted(GetListFiles(folder, [".mrk.json"])):
+        patient = patientIdFromFileName(os.path.basename(path))
+        try:
+            data = json.load(open(path))
+        except Exception as e:
+            logger.warning(f"Could not read {os.path.basename(path)}: {e}")
+            continue
+        for markup in data.get("markups", []):
+            for point in markup.get("controlPoints", []):
+                patients.setdefault(patient, {})[point["label"]] = list(point["position"])
+    return patients
+
+
+def _transforms_by_patient(folder):
+    """{patient: path} for the ASO .tfm files written next to the oriented scans."""
+    found = {}
+    for path in sorted(GetListFiles(folder, [".tfm"])):
+        found[patientIdFromFileName(os.path.basename(path))] = path
+    return found
+
+
+def _scan_stems_by_patient(folder):
+    """{patient: scan basename without extension}, to name outputs as ALI does."""
+    stems = {}
+    for ext in [".nii.gz", ".nii", ".nrrd", ".nrrd.gz", ".gipl.gz", ".gipl"]:
+        for path in sorted(GetListFiles(folder, [ext])):
+            name = os.path.basename(path)
+            stems.setdefault(patientIdFromFileName(name), name[: -len(ext)])
+    return stems
+
+
+def derive_landmarks(source_folder, source_tfm_folder, target_tfm_folder,
+                     target_scan_folder, keep_landmarks, output_folder):
+    """
+    Express landmarks found in one oriented frame in another oriented frame.
+
+    Both orientations come from the same centred scan, so a landmark's position
+    in the target frame is inv(target_transform) . source_transform applied to
+    its position in the source frame. Running the landmark search a second time
+    on the other orientation costs minutes per patient and makes the same
+    anatomical point land in two slightly different places; a rigid transform
+    is exact and instant.
+
+    Args:
+        source_folder: folder holding the landmarks already found
+        source_tfm_folder: folder holding the source orientation's ASO transform
+        target_tfm_folder: folder holding the target orientation's ASO transform
+        target_scan_folder: oriented scans of the target frame, used for naming
+        keep_landmarks: labels to write out
+        output_folder: where the derived landmark files go
+
+    Returns:
+        bool: True if every patient with landmarks produced an output
+    """
+    import SimpleITK as sitk
+
+    source = _read_landmarks(source_folder)
+    source_tfm = _transforms_by_patient(source_tfm_folder)
+    target_tfm = _transforms_by_patient(target_tfm_folder)
+    stems = _scan_stems_by_patient(target_scan_folder)
+    group_of = _ali_group_labels()
+
+    if not source:
+        logger.error(f"No landmarks to derive from in {source_folder}")
+        return False
+
+    wanted = list(keep_landmarks)
+    os.makedirs(output_folder, exist_ok=True)
+    ok = True
+
+    for patient, points in sorted(source.items()):
+        if patient not in source_tfm or patient not in target_tfm:
+            logger.error(
+                f"{patient}: missing an orientation transform, cannot derive its "
+                f"landmarks (source={patient in source_tfm}, target={patient in target_tfm})"
+            )
+            ok = False
+            continue
+
+        try:
+            to_centred = sitk.ReadTransform(source_tfm[patient])
+            from_centred = sitk.ReadTransform(target_tfm[patient]).GetInverse()
+        except Exception as e:
+            logger.error(f"{patient}: could not read an orientation transform: {e}")
+            ok = False
+            continue
+
+        missing = [lm for lm in wanted if lm not in points]
+        if missing:
+            logger.warning(f"{patient}: not found in the source landmarks: {missing}")
+
+        by_group = {}
+        for label in wanted:
+            if label not in points:
+                continue
+            moved = from_centred.TransformPoint(to_centred.TransformPoint(points[label]))
+            by_group.setdefault(group_of.get(label, "U"), []).append((label, moved))
+
+        if not by_group:
+            logger.error(f"{patient}: none of the requested landmarks were available")
+            ok = False
+            continue
+
+        stem = stems.get(patient, f"{patient}_derived")
+        for group, entries in by_group.items():
+            control_points = [
+                {
+                    "id": str(i + 1),
+                    "label": label,
+                    "description": "",
+                    "associatedNodeID": "",
+                    "position": [float(c) for c in position],
+                    "orientation": [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0],
+                    "selected": True,
+                    "locked": True,
+                    "visibility": True,
+                    "positionStatus": "defined",
+                }
+                for i, (label, position) in enumerate(entries)
+            ]
+            out_path = os.path.join(output_folder, f"{stem}_lm_Pred_{group}.mrk.json")
+            with open(out_path, "w") as f:
+                json.dump(
+                    {
+                        "@schema": "https://raw.githubusercontent.com/slicer/slicer/"
+                                   "master/Modules/Loadable/Markups/Resources/Schema/"
+                                   "markups-schema-v1.0.0.json#",
+                        "markups": [
+                            {
+                                "type": "Fiducial",
+                                "coordinateSystem": "LPS",
+                                "locked": False,
+                                "labelFormat": "%N-%d",
+                                "controlPoints": control_points,
+                                "measurements": [],
+                                "display": {
+                                    "visibility": False,
+                                    "opacity": 1.0,
+                                    "color": [0.4, 1.0, 0.0],
+                                    "selectedColor": [1.0, 0.5, 0.5],
+                                    "activeColor": [0.4, 1.0, 0.0],
+                                    "propertiesLabelVisibility": False,
+                                    "pointLabelsVisibility": True,
+                                    "textScale": 3.0,
+                                },
+                            }
+                        ],
+                    },
+                    f,
+                    indent=2,
+                )
+            logger.info(f"{patient}: {len(entries)} landmark(s) derived -> {os.path.basename(out_path)}")
+
+    return ok
 
 
 def run_bds(input_path, output_path, model_name="DentalSegmentator", device="cuda"):
@@ -1781,6 +2096,9 @@ def GetPatients(folder_path, time_point="T1", segmentationType=None, folder_mask
     
     patients = {}
 
+    # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+    # patient pairing. See the full note above GetPatients in
+    # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
     for file in all_files:
         basename = os.path.basename(file)
         patient = (
@@ -1966,6 +2284,9 @@ def batch_process(t1_dir, t2_dir, patient_list, output_dir, signed=True, output_
                     return True
         return False
 
+    # TIMEPOINT-SUFFIX: only _T1/_T2 are stripped here, so _T3/_T4 inputs break
+    # patient pairing. See the full note above GetPatients in
+    # AREG_CBCT/AREG_CBCT_utils/utils.py before changing this.
     def clean_patient_id(patient_id):
         return (
             patient_id.split("_Scan")[0]

--- a/VFACE/VFACE_utils/createlistprocess.py
+++ b/VFACE/VFACE_utils/createlistprocess.py
@@ -754,8 +754,29 @@ def CreateListProcess(**kwargs):
         landmarks_max_folder_path = os.path.join(landmarks_folder_path,"MAX")
         os.makedirs(landmarks_max_folder_path, exist_ok=True)
 
+        # ALI's agent may sample inside the border ALI adds, but it refuses to
+        # step outside the unpadded image, so a landmark at the edge is out of
+        # reach. Hand it a roomier copy: the scans on disk are untouched and
+        # every later step still reads the originals.
+        padded_scans_path = slicer.util.tempDirectory()
+
+        list_process.append(
+            {
+                "Process": pad_scans_for_landmarks,
+                "Parameter": {
+                    "input_folder": orientation_cb_folder_path,
+                    "output_folder": padded_scans_path,
+                    "margin_mm": 30,
+                },
+                "Module": "Making room for the landmark search",
+                "Display": DisplayAREGCBCT(
+                    nb_scan
+                ),
+            },
+        )
+
         parameter_ali = {
-                "input": orientation_cb_folder_path,
+                "input": padded_scans_path,
                 "dir_models": kwargs["model_folder_ali"],
                 "lm_type": ",".join([f"'{e}'" for e in list_landmark]),
                 "output_dir": landmarks_cb_folder_path,
@@ -2050,6 +2071,58 @@ def create_list_measure(df_path):
         else:
             logger.error("There is an issue in the xlsx file")
     return list_measure
+
+def pad_scans_for_landmarks(input_folder, output_folder, margin_mm=30):
+    """Copy each scan with empty space around it so ALI can work at the edges.
+
+    ALI border-pads the image it samples (agent_fov/2 + 1 voxels), but Agent.Move
+    refuses any position outside the *unpadded* size. A landmark sitting a voxel
+    or two from the border therefore sends the agent into a bounds bounce: random
+    restart, attempt counter up, and after three tries it gives up. Me is 1.2 mm
+    above the floor of these CBCTs, and the very same model finds it at once when
+    there is room around it.
+
+    Fixing that mismatch belongs in ALI and would serve every module that calls
+    it. This is the safe half of the answer: give the scan room, touch nothing
+    that AREG and ASO also depend on.
+
+    Physical coordinates are preserved - the origin moves with the padding - so
+    the landmarks come back in the original scan's space. Measured against an
+    unpadded run: points away from the border moved by at most one voxel.
+
+    Args:
+        input_folder: Folder of scans to copy
+        output_folder: Where the padded copies go
+        margin_mm: Room to add on every side, in millimetres
+
+    Returns:
+        str: output_folder, so the caller can feed it straight to ALI
+    """
+    import SimpleITK as sitk
+
+    os.makedirs(output_folder, exist_ok=True)
+    scans = GetListFiles(input_folder, [".nii", ".nii.gz", ".nrrd", ".gipl", ".gipl.gz"])
+    if not scans:
+        logger.warning(f"No scan to pad in {input_folder}; landmarks will run on it as it is")
+        return input_folder
+
+    for path in scans:
+        target = os.path.join(output_folder, os.path.basename(path))
+        try:
+            image = sitk.ReadImage(path)
+            pad = [max(1, int(round(margin_mm / sp))) for sp in image.GetSpacing()]
+            # The scan's own minimum, not zero: an air value that already exists
+            # in the volume keeps the intensity rescaling ALI applies unchanged.
+            background = float(sitk.GetArrayViewFromImage(image).min())
+            sitk.WriteImage(sitk.ConstantPad(image, pad, pad, background), target)
+        except Exception as e:
+            # A scan that cannot be padded is still worth landmarking as it is.
+            logger.warning(f"Could not pad {os.path.basename(path)}, using it unpadded: {e}")
+            shutil.copy(path, target)
+
+    logger.info(f"{len(scans)} scan(s) given {margin_mm} mm of room for the landmark search")
+    return output_folder
+
 
 def create_list_landmark(df_path):
 

--- a/VFACE/VFACE_utils/review_steps.py
+++ b/VFACE/VFACE_utils/review_steps.py
@@ -212,6 +212,13 @@ def restrictStepToPatients(step, patients, tempdir_factory=None, id_of=None):
                 relative = os.path.relpath(source, folder)
                 target = os.path.join(linked, relative)
                 os.makedirs(os.path.dirname(target), exist_ok=True)
+                # slicer.util.tempDirectory() names its folder to the millisecond,
+                # so two narrowings close together can be handed the same one. The
+                # file is then already linked, and copying onto a link that points
+                # at its own source raises SameFileError.
+                if os.path.lexists(target):
+                    kept += 1
+                    continue
                 try:
                     os.symlink(source, target)
                     kept += 1

--- a/VFACE/VFACE_utils/review_steps.py
+++ b/VFACE/VFACE_utils/review_steps.py
@@ -1,0 +1,242 @@
+"""Which steps of a VFACE run can be paused on, and what the user may do there.
+
+Kept apart from the pipeline itself: the module panel needs this list as soon
+as a mode is picked, long before CreateListProcess runs and starts making
+folders. Ids are what the panel stores and what a step carries, so they outlive
+any change of wording.
+"""
+
+import logging
+import os
+import shutil
+
+logger = logging.getLogger("VFACE")
+
+VIEW = "view"                   # look only
+LANDMARKS = "landmarks"         # drag the points, saved back to their file
+REGISTRATION = "registration"   # drag the scan, folded into its matrix
+
+PREPARATION = "Preparation"
+MIRROR = "Mirroring"
+REGISTRATION_GROUP = "Registration"
+MEASUREMENT = "Measurements"
+VISUALIZATION = "Visualization"
+
+LOOK = "Nothing to edit here - look at the result, then click Continue."
+
+CATALOGUE = {
+    "t1_landmarks_orientation_max": {
+        "label": "Maxilla orientation landmarks",
+        "group": PREPARATION,
+        "kind": LANDMARKS,
+    },
+    "t1_landmarks_orientation_cb": {
+        "label": "Cranial base orientation landmarks",
+        "group": PREPARATION,
+        "kind": LANDMARKS,
+    },
+    "t1_oriented_max": {
+        "label": "Maxilla orientation",
+        "group": PREPARATION,
+        "kind": VIEW,
+    },
+    "t1_oriented_cb": {
+        "label": "Cranial base orientation",
+        "group": PREPARATION,
+        "kind": VIEW,
+    },
+    "t1_masks": {
+        "label": "Bone segmentation",
+        "group": PREPARATION,
+        "kind": VIEW,
+    },
+    "mirror_masks": {
+        "label": "Mirrored segmentation",
+        "group": MIRROR,
+        "kind": VIEW,
+    },
+    "mirror_scans": {
+        "label": "Mirrored scans",
+        "group": MIRROR,
+        "kind": VIEW,
+    },
+    "registration_cb": {
+        "label": "Registered on the cranial base",
+        "group": REGISTRATION_GROUP,
+        "kind": REGISTRATION,
+    },
+    "registration_max": {
+        "label": "Registered on the maxilla",
+        "group": REGISTRATION_GROUP,
+        "kind": REGISTRATION,
+    },
+    "registration_mand": {
+        "label": "Registered on the mandible",
+        "group": REGISTRATION_GROUP,
+        "kind": REGISTRATION,
+    },
+    "t1_landmarks": {
+        "label": "T1 landmarks",
+        "group": MEASUREMENT,
+        "kind": LANDMARKS,
+    },
+    "bone_surfaces": {
+        "label": "Bone surfaces",
+        "group": VISUALIZATION,
+        "kind": VIEW,
+    },
+}
+
+# The order the run reaches them, which is the order the panel lists them in.
+ORDER = [
+    "t1_landmarks_orientation_max",
+    "t1_oriented_max",
+    "t1_landmarks_orientation_cb",
+    "t1_oriented_cb",
+    "t1_masks",
+    "mirror_masks",
+    "mirror_scans",
+    "registration_cb",
+    "registration_max",
+    "registration_mand",
+    "t1_landmarks",
+    "bone_surfaces",
+]
+
+
+def describe(review_id):
+    """Catalogue entry of a pause, or an empty dict if the id is unknown."""
+    return CATALOGUE.get(review_id, {})
+
+
+def availableSteps(mode, mode2, reg_type, visualization, quantification):
+    """The pauses a run with these settings will actually reach.
+
+    A mode that skips a step must not offer it: ticking a pause that never
+    happens reads as a broken feature the first time the run goes straight past
+    it.
+
+    Args:
+        mode: "Full pipeline", "File already Oriented" or "File already Registered"
+        mode2: "Asymmetry Assesment" or "Longitudinal studies"
+        reg_type: "AREG" or "CMFReg"
+        visualization: whether the heatmap branch runs
+        quantification: whether the measurement branch runs
+
+    Returns:
+        list: catalogue entries, each carrying its id, in run order
+    """
+    full_pipeline = mode == "Full pipeline"
+    registered = mode == "File already Registered"
+    asymmetry = mode2 == "Asymmetry Assesment"
+
+    available = {
+        # These points decide the orientation everything downstream inherits:
+        # a bad one throws ASO off, which throws the masks and the registration
+        # off in turn. They are only placed when the run does its own
+        # orientation.
+        "t1_landmarks_orientation_max": full_pipeline,
+        "t1_landmarks_orientation_cb": full_pipeline,
+        "t1_oriented_max": full_pipeline,
+        "t1_oriented_cb": full_pipeline,
+        "t1_masks": not registered,
+        "mirror_masks": not registered and asymmetry and reg_type == "CMFReg",
+        "mirror_scans": not registered and asymmetry,
+        "registration_cb": not registered,
+        "registration_max": not registered,
+        "registration_mand": not registered,
+        "t1_landmarks": bool(quantification),
+        "bone_surfaces": bool(visualization),
+    }
+
+    steps = []
+    for review_id in ORDER:
+        if available.get(review_id):
+            steps.append(dict(CATALOGUE[review_id], id=review_id))
+    return steps
+
+
+# Parameters that name a folder of patient files. A replay narrowed to a few
+# patients has to point these somewhere smaller; everything else in a step -
+# models, spacings, output paths - is left alone.
+INPUT_KEYS = ("input", "input_patient", "input_matrix")
+
+
+def restrictStepToPatients(step, patients, tempdir_factory=None, id_of=None):
+    """A copy of this step that only reads the patients given.
+
+    Args:
+        step: the step dictionary to narrow
+        patients: patient ids to keep
+        tempdir_factory: callable returning a fresh empty directory, so a
+            caller can control where the links go
+        id_of: callable turning a file name into a patient id
+
+    Returns:
+        tuple: (narrowed step, folders created). The step is returned unchanged
+            when nothing can be narrowed, which is the safe outcome: replaying
+            every patient wastes time, replaying none loses work.
+    """
+    wanted = set(patients or ())
+    if not wanted:
+        return step, []
+
+    if tempdir_factory is None:
+        import slicer
+        tempdir_factory = slicer.util.tempDirectory
+    if id_of is None:
+        from VFACE_utils.functionaq3dc import patientIdFromFileName as id_of
+
+    narrowed = dict(step)
+    parameters = dict(step.get("Parameter") or {})
+    created = []
+    changed = False
+
+    for key in INPUT_KEYS:
+        folder = parameters.get(key)
+        if not isinstance(folder, str) or not os.path.isdir(folder):
+            continue
+
+        linked = tempdir_factory()
+        kept = 0
+        # Walked, and the tree kept: VFACE writes per-structure results into
+        # sub-folders, and the modules it calls walk those to find their input.
+        # A flat listing would leave them with nothing.
+        for root, _, names in os.walk(folder):
+            for name in sorted(names):
+                source = os.path.join(root, name)
+                if not os.path.isfile(source):
+                    continue
+                if id_of(name) not in wanted:
+                    continue
+                relative = os.path.relpath(source, folder)
+                target = os.path.join(linked, relative)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                try:
+                    os.symlink(source, target)
+                    kept += 1
+                except OSError as e:
+                    # A filesystem without links is no reason to lose the replay.
+                    logger.warning(f"Could not link {relative}, copying instead: {e}")
+                    shutil.copy(source, target)
+                    kept += 1
+
+        # Shared inputs - the mirror matrix is one file for the whole run - match
+        # no patient and must be left exactly as they were, or the step loses
+        # what it needs to run at all.
+        if kept == 0:
+            logger.warning(
+                f"None of {sorted(wanted)} found in {folder}; leaving '{key}' as it was"
+            )
+            continue
+
+        parameters[key] = linked
+        created.append(linked)
+        changed = True
+        logger.info(f"'{key}' narrowed to {kept} file(s) for {sorted(wanted)}")
+
+    if not changed:
+        return step, []
+
+    narrowed["Parameter"] = parameters
+    return narrowed, created


### PR DESCRIPTION
## Why

VFACE runs for an hour and, until now, a clinician only saw the result at the
end. Worse, when something failed on the way the run said nothing: a Python step
that raised was logged and stepped over, and a CLI that died was counted as a
success. A run could report "Processing completed successfully!" having produced
no classification at all - which is exactly what it had been doing.

This brings VFACE the review mode AREG already has, and makes the pipeline say
when it did not work.

## Pausing for review

A collapsible section lists the steps that can pause, rebuilt from the mode
actually selected; each is a checkbox, with Select all / none / recommended.
"Recommended" ticks what a clinician checks on a normal run - the landmarks they
can correct, the three registrations, and the final surfaces.

Three kinds of pause, and the panel says which one is on screen:

- **Landmarks** - the `.json` is loaded unlocked; points are dragged in Slicer
  and saved back to the same file on Continue.
- **Registration** - the scan is loaded with a transform; dragging it into place
  is folded into the registration matrix itself.
- **Review only** - a visual check.

The scan is put in volume rendering, and the panel names the modules that do the
work: Markups for the points, Transforms to read a displacement in numbers,
Volume Rendering for the view. None of that is guessable for a clinician who
does not already know Slicer.

## Saying when it failed

- A CLI that reports errors now **stops the run** and names the step, instead of
  letting every later step run on the empty folders it never filled.
- A measurement whose landmark is missing leaves its column empty and says so,
  instead of ending the post-processing on a KeyError - one missing landmark used
  to cost the whole classification.
- Landmarks ALI could not place are collected and reported when the run ends.
  ALI had always printed them; nothing read it.

## Distance maps

Every map in the Heatmaps folder is loaded and coloured; the merged one starts
visible, the others are one tick away in Models. Each carries its own scale,
shown with its own surface and spread across the view rather than stacked - the
ranges differ by more than tenfold between maps, so a shared or missing scale
reads as a wrong displacement. The ranges are also written in the panel.

## Fixes found along the way

Several are pre-existing bugs that this work made reachable:

- `OnEndProcess` cleaned the output folder by walking `Path(OutputFolder)`.
  `Path("")` is `Path(".")`, so a run with no output folder set deleted every
  sub-folder of whatever directory Slicer was launched from, leaving the files.
  Present since the module was added; it emptied a working tree twice here.
- `slicer.util.tempDirectory()` names its folder from the clock to the
  millisecond, and steps built microseconds apart were handed **the same
  directory** - measured: 20 calls, 2 distinct folders. ALI found elastix's
  leftovers in its input and landmarked those instead of the patients. Every
  step now gets its own.
- ALI cannot reach a landmark within a voxel or two of the scan border: its
  agent may sample inside the padding ALI adds, but `Agent.Move` refuses to step
  outside the unpadded image. Me sits 1.2 mm above the floor of these CBCTs and
  was never found; the scans are now given 30 mm of room before the landmark
  search, which recovers it with other landmarks moving at most one voxel. The
  root fix belongs in ALI and would serve AREG and ASO too.
- A manual adjustment was written as a composite transform, leaving two matrices
  in a `.tfm` every other tool expects to hold one. Written as a single matrix
  now - verified point by point to be identical.
- CLI modules registered through a symlink could not find their utils, because
  `sys.path` was built from `__file__` rather than its resolved path.
- `review_steps.py` and `Review.py` were missing from the CMake script, so the
  built extension shipped without them.

## Testing

12 scripted suites run inside Slicer, kept in `DEBUG/vface-tests` with a runner.
They cover the pause and batch flow, the identity filter, the replay narrowing,
the padding, the temp-folder uniqueness, the missing-landmark report, and every
display behaviour described above - each against real output from a run, not
fixtures.

Exercised by hand end to end: a landmark pause, a registration pause with a
manual drag, and the end-of-run maps.

## Not in this PR

`AREG/AREG_Method/Review.py` gets a one-line guard here (a narrowed replay could
copy a file onto the symlink it had just made). It is an AREG bug already in
main, small enough to carry rather than leave broken.
